### PR TITLE
Add --tui global flag to Cli struct

### DIFF
--- a/src/integrations/cli.rs
+++ b/src/integrations/cli.rs
@@ -24,6 +24,9 @@ pub struct Cli {
     #[arg(long, global = true, help = "Return structured JSON output")]
     pub json: bool,
 
+    #[arg(long, global = true, help = "Force the TUI to open even when processing CLI requests")]
+    pub tui: bool,
+
     #[arg(help = "Add a torrent file path or magnet link without using a subcommand")]
     pub input: Option<String>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -304,10 +304,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             } else {
                 eprintln!("[Error] Application failed: {}", error);
             }
-            std::process::exit(1);
+            if !cli.tui {
+                std::process::exit(1);
+            }
         }
-        tracing::info!("Command processed, exiting temporary instance.");
-        return Ok(());
+        if !cli.tui {
+            tracing::info!("Command processed, exiting temporary instance.");
+            return Ok(());
+        }
+        tracing::info!("Command processed, continuing to TUI.");
     }
 
     let runtime_mode = if shared_mode {


### PR DESCRIPTION
- Add --tui global flag to Cli struct
- When --tui is used, process CLI request then continue to open TUI
- Enables protocol handler (magnet/torrent) to add and show UI in one step