### PR TITLE
Preserve processed .torrent last modified timestamp in some edge cases

### DIFF
--- a/src/watch_inbox.rs
+++ b/src/watch_inbox.rs
@@ -12,9 +12,7 @@ pub fn is_cross_device_link_error(error: &io::Error) -> bool {
 }
 
 pub fn open_for_timestamp_update(destination: &Path) -> io::Result<fs::File> {
-    fs::OpenOptions::new()
-        .write(true)
-        .open(destination)
+    fs::OpenOptions::new().write(true).open(destination)
 }
 
 pub fn move_file_with_fallback_impl<F>(

--- a/src/watch_inbox.rs
+++ b/src/watch_inbox.rs
@@ -11,6 +11,12 @@ pub fn is_cross_device_link_error(error: &io::Error) -> bool {
     matches!(error.raw_os_error(), Some(18) | Some(17))
 }
 
+pub fn open_for_timestamp_update(destination: &Path) -> io::Result<fs::File> {
+    fs::OpenOptions::new()
+        .write(true)
+        .open(destination)
+}
+
 pub fn move_file_with_fallback_impl<F>(
     source: &Path,
     destination: &Path,
@@ -27,15 +33,22 @@ where
         Ok(()) => Ok(()),
         Err(error) if is_cross_device_link_error(&error) => {
             let metadata = fs::metadata(source)?;
-            let mut timestamp = fs::FileTimes::new();
-            if let Ok(mtime) = metadata.modified() {
-                timestamp = timestamp.set_modified(mtime);
-            }
             fs::copy(source, destination)?;
-            fs::OpenOptions::new()
-                .write(true)
-                .open(destination)?
-                .set_times(timestamp)?;
+
+            if let Ok(mtime) = metadata.modified() {
+                let timestamp = fs::FileTimes::new().set_modified(mtime);
+                if let Err(error) = open_for_timestamp_update(destination)
+                    .and_then(|file| file.set_times(timestamp))
+                {
+                    tracing::warn!(
+                        ?source,
+                        ?destination,
+                        ?error,
+                        "failed to preserve copied file timestamp"
+                    );
+                }
+            }
+
             fs::remove_file(source)?;
             Ok(())
         }

--- a/src/watch_inbox.rs
+++ b/src/watch_inbox.rs
@@ -26,7 +26,16 @@ where
     match rename_op(source, destination) {
         Ok(()) => Ok(()),
         Err(error) if is_cross_device_link_error(&error) => {
+            let metadata = fs::metadata(source)?;
+            let mut timestamp = fs::FileTimes::new();
+            if let Ok(mtime) = metadata.modified() {
+                timestamp = timestamp.set_modified(mtime);
+            }
             fs::copy(source, destination)?;
+            fs::OpenOptions::new()
+                .write(true)
+                .open(destination)?
+                .set_times(timestamp)?;
             fs::remove_file(source)?;
             Ok(())
         }


### PR DESCRIPTION
https://github.com/Jagalite/superseedr/issues/243

This is the edit I made to fix the issue on my system.
I just used fs, don't know if filetime would be better.
It doesn't copy the last accessed time, since they should be changing a lot at this point anyway, but another if let can be added for the last accessed date/time, if it is required.

Also, due to this change, the processed .torrent file is currently being opened twice.
We could use io::copy to only open the file once if this is a requirement, but I don't think it's worth the added complexity.