### PR TITLE
Support live torrent storage moves

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -28,7 +28,7 @@ use crate::config::{
 };
 use crate::control_service::{
     control_event_details, online_control_success_message, plan_control_request,
-    ControlExecutionPlan,
+    prepare_offline_move_transaction, ControlExecutionPlan, OfflineMoveTransaction,
 };
 use crate::dht_service::{DhtService, DhtServiceConfig, DhtStatus, DhtWaveTelemetry};
 use crate::persistence::activity_history::{
@@ -901,6 +901,21 @@ pub enum AppCommand {
     },
     ReloadClusterState(PathBuf),
     SubmitControlRequest(ControlRequest),
+    StorageMoveStaged {
+        operation_id: u64,
+        info_hash: Vec<u8>,
+        download_path: PathBuf,
+        result: Result<(OfflineMoveTransaction, bool), String>,
+    },
+    StorageMoveCompleted {
+        operation_id: u64,
+        info_hash: Vec<u8>,
+        result: Result<String, String>,
+    },
+    StorageMoveSettingsPersisted {
+        operation_id: u64,
+        settings_saved: Option<bool>,
+    },
     SubmitManualAddRequest {
         request: ControlRequest,
         pending_ingest: Option<PendingManualIngest>,
@@ -2745,6 +2760,19 @@ pub struct App {
     persisted_torrent_metadata_cache: HashMap<Vec<u8>, TorrentMetadataEntry>,
     data_availability_fault_log_cooldowns: HashMap<Vec<u8>, LogCooldown>,
     probe_available_log_cooldowns: HashMap<Vec<u8>, LogCooldown>,
+    pending_storage_moves: HashMap<Vec<u8>, u64>,
+    pending_storage_move_transactions: HashMap<u64, PendingStorageMoveTransaction>,
+    storage_path_overrides: HashMap<Vec<u8>, PathBuf>,
+    next_storage_move_operation_id: u64,
+}
+
+#[derive(Debug)]
+struct PendingStorageMoveTransaction {
+    info_hash: Vec<u8>,
+    download_path: PathBuf,
+    previous_download_path: Option<PathBuf>,
+    was_already_paused: bool,
+    transaction: OfflineMoveTransaction,
 }
 
 #[derive(Clone)]
@@ -2762,6 +2790,7 @@ pub struct ActivityHistoryPersistRequest {
 #[derive(Clone)]
 pub struct PersistPayload {
     pub settings: Settings,
+    pub storage_move_request_ids: Vec<u64>,
     pub rss_state: RssPersistedState,
     pub network_history: Option<NetworkHistoryPersistRequest>,
     pub activity_history: Option<ActivityHistoryPersistRequest>,
@@ -2990,29 +3019,46 @@ fn spawn_persistence_writer(
                 .activity_history
                 .as_ref()
                 .map(|request| request.request_id);
+            let storage_move_request_ids = payload.storage_move_request_ids.clone();
             let write_result = tokio::task::spawn_blocking(move || {
-                save_settings(&payload.settings)
-                    .map_err(|e| format!("Failed to auto-save settings: {}", e))?;
-                save_rss_state(&payload.rss_state)
-                    .map_err(|e| format!("Failed to auto-save RSS state: {}", e))?;
-                if let Some(network_history) = payload.network_history {
-                    save_network_history_state(&network_history.state)
-                        .map_err(|e| format!("Failed to auto-save network history state: {}", e))?;
+                if let Err(error) = save_settings(&payload.settings) {
+                    return (
+                        false,
+                        Err(format!("Failed to auto-save settings: {}", error)),
+                    );
                 }
-                if let Some(activity_history) = payload.activity_history {
-                    save_activity_history_state(&activity_history.state).map_err(|e| {
-                        format!("Failed to auto-save activity history state: {}", e)
-                    })?;
-                }
-                save_event_journal_state(&payload.event_journal_state)
-                    .map_err(|e| format!("Failed to auto-save event journal state: {}", e))?;
-                Ok::<(), String>(())
+                let result = (|| {
+                    save_rss_state(&payload.rss_state)
+                        .map_err(|e| format!("Failed to auto-save RSS state: {}", e))?;
+                    if let Some(network_history) = payload.network_history {
+                        save_network_history_state(&network_history.state).map_err(|e| {
+                            format!("Failed to auto-save network history state: {}", e)
+                        })?;
+                    }
+                    if let Some(activity_history) = payload.activity_history {
+                        save_activity_history_state(&activity_history.state).map_err(|e| {
+                            format!("Failed to auto-save activity history state: {}", e)
+                        })?;
+                    }
+                    save_event_journal_state(&payload.event_journal_state)
+                        .map_err(|e| format!("Failed to auto-save event journal state: {}", e))?;
+                    Ok::<(), String>(())
+                })();
+                (true, result)
             })
             .await;
 
             match write_result {
-                Ok(Ok(())) => {
+                Ok((settings_saved, Ok(()))) => {
                     tracing_event!(Level::DEBUG, "Persistence payload auto-saved successfully.");
+                    for operation_id in storage_move_request_ids {
+                        let _ = persistence_app_command_tx
+                            .send(AppCommand::StorageMoveSettingsPersisted {
+                                operation_id,
+                                settings_saved: Some(settings_saved),
+                            })
+                            .await;
+                    }
                     if let Some(request_id) = network_history_request_id {
                         let _ = persistence_app_command_tx
                             .send(AppCommand::NetworkHistoryPersisted {
@@ -3030,13 +3076,21 @@ fn spawn_persistence_writer(
                             .await;
                     }
                 }
-                Ok(Err(e)) => {
+                Ok((settings_saved, Err(e))) => {
                     if persistence_error_log_cooldowns
                         .entry(e.clone())
                         .or_default()
                         .should_log(Instant::now(), REPEATED_HEALTH_LOG_INTERVAL)
                     {
                         tracing_event!(Level::ERROR, "{}", e);
+                    }
+                    for operation_id in storage_move_request_ids {
+                        let _ = persistence_app_command_tx
+                            .send(AppCommand::StorageMoveSettingsPersisted {
+                                operation_id,
+                                settings_saved: Some(settings_saved),
+                            })
+                            .await;
                     }
                     if let Some(request_id) = network_history_request_id {
                         let _ = persistence_app_command_tx
@@ -3057,6 +3111,14 @@ fn spawn_persistence_writer(
                 }
                 Err(e) => {
                     tracing_event!(Level::ERROR, "Persistence writer join failed: {}", e);
+                    for operation_id in storage_move_request_ids {
+                        let _ = persistence_app_command_tx
+                            .send(AppCommand::StorageMoveSettingsPersisted {
+                                operation_id,
+                                settings_saved: None,
+                            })
+                            .await;
+                    }
                     if let Some(request_id) = network_history_request_id {
                         let _ = persistence_app_command_tx
                             .send(AppCommand::NetworkHistoryPersisted {
@@ -3321,6 +3383,10 @@ impl App {
             persisted_torrent_metadata_cache,
             data_availability_fault_log_cooldowns: HashMap::new(),
             probe_available_log_cooldowns: HashMap::new(),
+            pending_storage_moves: HashMap::new(),
+            pending_storage_move_transactions: HashMap::new(),
+            storage_path_overrides: HashMap::new(),
+            next_storage_move_operation_id: 1,
         };
         app.sync_cluster_role_label();
         app.refresh_system_warning();
@@ -5649,8 +5715,12 @@ impl App {
             if previous.torrent_control_state != torrent.torrent_control_state {
                 if let Some(manager_tx) = self.torrent_manager_command_txs.get(info_hash) {
                     let command = match torrent.torrent_control_state {
-                        TorrentControlState::Paused => Some(ManagerCommand::Pause),
-                        TorrentControlState::Running => Some(ManagerCommand::Resume),
+                        TorrentControlState::Paused => {
+                            Some(ManagerCommand::Pause { response: None })
+                        }
+                        TorrentControlState::Running => {
+                            Some(ManagerCommand::Resume { response: None })
+                        }
                         TorrentControlState::Deleting => {
                             if torrent.delete_files {
                                 Some(ManagerCommand::DeleteFile)
@@ -5926,6 +5996,46 @@ impl App {
             }
             AppCommand::SubmitControlRequest(request) => {
                 self.handle_submit_control_request(request, None).await;
+            }
+            AppCommand::StorageMoveStaged {
+                operation_id,
+                info_hash,
+                download_path,
+                result,
+            } => {
+                self.handle_storage_move_staged(operation_id, info_hash, download_path, result)
+                    .await;
+            }
+            AppCommand::StorageMoveCompleted {
+                operation_id,
+                info_hash,
+                result,
+            } => {
+                if self.pending_storage_moves.get(&info_hash) == Some(&operation_id) {
+                    self.pending_storage_moves.remove(&info_hash);
+                    match result {
+                        Ok(message) => {
+                            tracing_event!(
+                                Level::INFO,
+                                info_hash = %hex::encode(&info_hash),
+                                "{}",
+                                message
+                            );
+                            self.dispatch_integrity_probe_batches();
+                            self.trigger_status_dump_after_successful_cluster_mutation();
+                        }
+                        Err(error) => {
+                            tracing_event!(
+                                Level::ERROR,
+                                info_hash = %hex::encode(&info_hash),
+                                "Storage move did not complete safely: {}",
+                                error
+                            );
+                            self.app_state.system_error = Some(error);
+                        }
+                    }
+                    self.app_state.ui.needs_redraw = true;
+                }
             }
             AppCommand::SubmitManualAddRequest {
                 request,
@@ -6240,6 +6350,13 @@ impl App {
                         );
                     }
                 }
+            }
+            AppCommand::StorageMoveSettingsPersisted {
+                operation_id,
+                settings_saved,
+            } => {
+                self.handle_storage_move_settings_persisted(operation_id, settings_saved)
+                    .await;
             }
             AppCommand::UpdateVersionAvailable(latest_version) => {
                 self.app_state.update_available = Some(latest_version);
@@ -7046,6 +7163,7 @@ impl App {
         let mut changed = false;
         let mut closed_info_hashes = Vec::new();
         let mut completion_events: Vec<(Vec<u8>, String)> = Vec::new();
+        let mut confirmed_storage_paths = Vec::new();
 
         for (info_hash, rx) in self.torrent_metric_watch_rxs.iter_mut() {
             match rx.has_changed() {
@@ -7057,7 +7175,14 @@ impl App {
                         .get(info_hash)
                         .map(|torrent| !torrent_is_effectively_incomplete(&torrent.latest_state))
                         .unwrap_or(false);
-                    let message = rx.borrow_and_update().clone();
+                    let mut message = rx.borrow_and_update().clone();
+                    if let Some(expected_path) = self.storage_path_overrides.get(info_hash) {
+                        if message.download_path.as_ref() == Some(expected_path) {
+                            confirmed_storage_paths.push(info_hash.clone());
+                        } else {
+                            message.download_path = Some(expected_path.clone());
+                        }
+                    }
                     UiTelemetry::on_metrics(&mut self.app_state, message);
                     let completion_record = self.app_state.torrents.get(info_hash).map(|torrent| {
                         (
@@ -7080,6 +7205,13 @@ impl App {
 
         for info_hash in closed_info_hashes {
             self.torrent_metric_watch_rxs.remove(&info_hash);
+        }
+
+        if !confirmed_storage_paths.is_empty() {
+            for info_hash in confirmed_storage_paths {
+                self.storage_path_overrides.remove(&info_hash);
+            }
+            self.save_state_to_disk();
         }
 
         if !completion_events.is_empty() {
@@ -7206,15 +7338,24 @@ impl App {
     }
 
     fn save_state_to_disk(&mut self) {
+        let _ = self.queue_state_to_disk();
+    }
+
+    fn queue_state_to_disk(&mut self) -> Result<(), ()> {
         if !self.cluster_capabilities().can_persist_local_runtime_state {
-            return;
+            return Err(());
         }
 
-        let payload = build_persist_payload(
+        let mut payload = build_persist_payload(
             &mut self.client_configs,
             &mut self.app_state,
             &self.startup_deferred_load_queue,
         );
+        payload.storage_move_request_ids = self
+            .pending_storage_move_transactions
+            .keys()
+            .copied()
+            .collect();
         let network_history_request_id = payload
             .network_history
             .as_ref()
@@ -7233,7 +7374,9 @@ impl App {
                 Level::ERROR,
                 "Failed to queue persistence payload: persistence task unavailable"
             );
+            return Err(());
         }
+        Ok(())
     }
 
     fn torrent_saved_location(metrics: &TorrentMetrics) -> Option<PathBuf> {
@@ -8394,6 +8537,350 @@ impl App {
         });
     }
 
+    async fn start_live_storage_move(
+        &mut self,
+        info_hash_hex: String,
+        download_path: PathBuf,
+    ) -> Result<String, String> {
+        let info_hash = hex::decode(&info_hash_hex)
+            .map_err(|error| format!("Invalid torrent info hash '{}': {}", info_hash_hex, error))?;
+        if self.pending_storage_moves.contains_key(&info_hash) {
+            return Err(format!(
+                "A storage move is already in progress for torrent '{}'",
+                info_hash_hex
+            ));
+        }
+        let manager_tx = self
+            .torrent_manager_command_txs
+            .get(&info_hash)
+            .cloned()
+            .ok_or_else(|| format!("Torrent '{}' does not have a live manager", info_hash_hex))?;
+
+        let operation_id = self.next_storage_move_operation_id;
+        self.next_storage_move_operation_id = self.next_storage_move_operation_id.saturating_add(1);
+        self.pending_storage_moves
+            .insert(info_hash.clone(), operation_id);
+
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+        if let Err(error) = manager_tx
+            .send(ManagerCommand::Pause {
+                response: Some(response_tx),
+            })
+            .await
+        {
+            self.pending_storage_moves.remove(&info_hash);
+            return Err(format!("Failed to prepare live storage move: {}", error));
+        }
+
+        let app_command_tx = self.app_command_tx.clone();
+        let settings = self.client_configs.clone();
+        let staged_info_hash = info_hash.clone();
+        let staged_download_path = download_path.clone();
+        let staged_info_hash_hex = info_hash_hex.clone();
+        tokio::spawn(async move {
+            let pause_result = match time::timeout(Duration::from_secs(30), response_rx).await {
+                Ok(Ok(result)) => result,
+                Ok(Err(_)) => Err("Torrent manager dropped the pause response".to_string()),
+                Err(_) => Err("Timed out waiting for paused torrent I/O to drain".to_string()),
+            };
+
+            let (was_already_paused, result) = match pause_result {
+                Ok(pause_result) => {
+                    let was_already_paused = pause_result.was_already_paused;
+                    let result = match pause_result.storage_relocation {
+                        Ok(()) => {
+                            let info_hash_hex = staged_info_hash_hex;
+                            let download_path = staged_download_path.clone();
+                            match tokio::task::spawn_blocking(move || {
+                                prepare_offline_move_transaction(
+                                    &settings,
+                                    &info_hash_hex,
+                                    &download_path,
+                                )
+                            })
+                            .await
+                            {
+                                Ok(result) => result,
+                                Err(error) => {
+                                    Err(format!("Storage move task failed to join: {}", error))
+                                }
+                            }
+                        }
+                        Err(error) => Err(error),
+                    };
+                    (
+                        Some(was_already_paused),
+                        result.map(|transaction| (transaction, was_already_paused)),
+                    )
+                }
+                Err(error) => (None, Err(error)),
+            };
+
+            if result.is_err() && was_already_paused == Some(false) {
+                let _ = manager_tx
+                    .send(ManagerCommand::Resume { response: None })
+                    .await;
+            }
+            let _ = app_command_tx
+                .send(AppCommand::StorageMoveStaged {
+                    operation_id,
+                    info_hash: staged_info_hash,
+                    download_path: staged_download_path,
+                    result,
+                })
+                .await;
+        });
+
+        Ok(format!(
+            "Queued live storage move for torrent '{}' to '{}'",
+            info_hash_hex,
+            download_path.display()
+        ))
+    }
+
+    async fn handle_storage_move_staged(
+        &mut self,
+        operation_id: u64,
+        info_hash: Vec<u8>,
+        download_path: PathBuf,
+        result: Result<(OfflineMoveTransaction, bool), String>,
+    ) {
+        if self.pending_storage_moves.get(&info_hash) != Some(&operation_id) {
+            if let Ok((transaction, _)) = result {
+                let _ = tokio::task::spawn_blocking(move || transaction.rollback()).await;
+            }
+            return;
+        }
+
+        let (transaction, was_already_paused) = match result {
+            Ok(result) => result,
+            Err(error) => {
+                self.pending_storage_moves.remove(&info_hash);
+                self.app_state.system_error = Some(format!("Storage move failed: {}", error));
+                self.app_state.ui.needs_redraw = true;
+                return;
+            }
+        };
+
+        let mut next_settings = self.client_configs.clone();
+        let Some(torrent_settings) = next_settings.torrents.iter_mut().find(|torrent| {
+            info_hash_from_torrent_source(&torrent.torrent_or_magnet).as_deref()
+                == Some(info_hash.as_slice())
+        }) else {
+            let _ = tokio::task::spawn_blocking(move || transaction.rollback()).await;
+            if !was_already_paused {
+                if let Some(manager_tx) = self.torrent_manager_command_txs.get(&info_hash) {
+                    let _ = manager_tx
+                        .send(ManagerCommand::Resume { response: None })
+                        .await;
+                }
+            }
+            self.pending_storage_moves.remove(&info_hash);
+            self.app_state.system_error = Some(
+                "Storage move could not update settings because the torrent disappeared"
+                    .to_string(),
+            );
+            self.app_state.ui.needs_redraw = true;
+            return;
+        };
+        torrent_settings.download_path = Some(download_path.clone());
+
+        let previous_download_path = self
+            .client_configs
+            .torrents
+            .iter()
+            .find(|torrent| {
+                info_hash_from_torrent_source(&torrent.torrent_or_magnet).as_deref()
+                    == Some(info_hash.as_slice())
+            })
+            .and_then(|torrent| torrent.download_path.clone());
+        self.client_configs = next_settings;
+        if let Some(display) = self.app_state.torrents.get_mut(&info_hash) {
+            display.latest_state.download_path = Some(download_path.clone());
+        }
+        self.storage_path_overrides
+            .insert(info_hash.clone(), download_path.clone());
+        self.pending_storage_move_transactions.insert(
+            operation_id,
+            PendingStorageMoveTransaction {
+                info_hash,
+                download_path,
+                previous_download_path,
+                was_already_paused,
+                transaction,
+            },
+        );
+
+        if self.queue_state_to_disk().is_err() {
+            self.handle_storage_move_settings_persisted(operation_id, Some(false))
+                .await;
+        }
+    }
+
+    async fn handle_storage_move_settings_persisted(
+        &mut self,
+        operation_id: u64,
+        settings_saved: Option<bool>,
+    ) {
+        let Some(pending) = self.pending_storage_move_transactions.remove(&operation_id) else {
+            return;
+        };
+        let PendingStorageMoveTransaction {
+            info_hash,
+            download_path,
+            previous_download_path,
+            was_already_paused,
+            transaction,
+        } = pending;
+        if self.pending_storage_moves.get(&info_hash) != Some(&operation_id) {
+            return;
+        }
+
+        if settings_saved != Some(true) {
+            if settings_saved == Some(false) {
+                self.storage_path_overrides.remove(&info_hash);
+                if let Some(torrent) = self.client_configs.torrents.iter_mut().find(|torrent| {
+                    info_hash_from_torrent_source(&torrent.torrent_or_magnet).as_deref()
+                        == Some(info_hash.as_slice())
+                }) {
+                    torrent.download_path = previous_download_path.clone();
+                }
+                if let Some(display) = self.app_state.torrents.get_mut(&info_hash) {
+                    display.latest_state.download_path = previous_download_path;
+                }
+                let rollback_error = tokio::task::spawn_blocking(move || transaction.rollback())
+                    .await
+                    .ok()
+                    .and_then(Result::err);
+                if !was_already_paused {
+                    if let Some(manager_tx) = self.torrent_manager_command_txs.get(&info_hash) {
+                        let _ = manager_tx
+                            .send(ManagerCommand::Resume { response: None })
+                            .await;
+                    }
+                }
+                self.pending_storage_moves.remove(&info_hash);
+                self.app_state.system_error = Some(match rollback_error {
+                    Some(error) => format!(
+                        "Failed to persist moved path. Staged destination rollback also failed: {}",
+                        error
+                    ),
+                    None => {
+                        "Failed to persist moved path; the staged move was rolled back".to_string()
+                    }
+                });
+            } else {
+                self.pending_storage_moves.remove(&info_hash);
+                self.app_state.system_error = Some(
+                    "Could not confirm whether the moved path was persisted. Both file locations were retained and the torrent remains paused."
+                        .to_string(),
+                );
+            }
+            self.app_state.ui.needs_redraw = true;
+            return;
+        }
+
+        self.integrity_scheduler.on_storage_moved(&info_hash);
+
+        let Some(manager_tx) = self.torrent_manager_command_txs.get(&info_hash).cloned() else {
+            self.pending_storage_moves.remove(&info_hash);
+            self.app_state.system_error = Some(
+                "Moved path was persisted, but the torrent manager is no longer available. Both file locations were retained."
+                    .to_string(),
+            );
+            self.app_state.ui.needs_redraw = true;
+            return;
+        };
+        let (apply_tx, apply_rx) = tokio::sync::oneshot::channel();
+        if manager_tx
+            .send(ManagerCommand::ApplyStoragePath {
+                torrent_data_path: download_path,
+                response: apply_tx,
+            })
+            .await
+            .is_err()
+        {
+            self.pending_storage_moves.remove(&info_hash);
+            self.app_state.system_error = Some(
+                "Moved path was persisted, but the torrent manager closed before applying it. Both file locations were retained."
+                    .to_string(),
+            );
+            self.app_state.ui.needs_redraw = true;
+            return;
+        }
+
+        let app_command_tx = self.app_command_tx.clone();
+        tokio::spawn(async move {
+            let apply_result = match time::timeout(Duration::from_secs(30), apply_rx).await {
+                Ok(Ok(result)) => result,
+                Ok(Err(_)) => Err("Torrent manager dropped the path update response".to_string()),
+                Err(_) => {
+                    Err("Timed out waiting for torrent state to apply the moved path".to_string())
+                }
+            };
+
+            let result = match apply_result {
+                Ok(()) => {
+                    let resume_result = if was_already_paused {
+                        Ok(())
+                    } else {
+                        let (resume_tx, resume_rx) = tokio::sync::oneshot::channel();
+                        match manager_tx
+                            .send(ManagerCommand::Resume {
+                                response: Some(resume_tx),
+                            })
+                            .await
+                        {
+                            Ok(()) => {
+                                match time::timeout(Duration::from_secs(30), resume_rx).await {
+                                    Ok(Ok(())) => Ok(()),
+                                    Ok(Err(_)) => Err(
+                                        "Torrent manager dropped the resume response".to_string(),
+                                    ),
+                                    Err(_) => Err(
+                                        "Timed out waiting for torrent manager to resume"
+                                            .to_string(),
+                                    ),
+                                }
+                            }
+                            Err(error) => {
+                                Err(format!("Failed to resume torrent after move: {}", error))
+                            }
+                        }
+                    };
+
+                    match resume_result {
+                        Ok(()) => {
+                            match tokio::task::spawn_blocking(move || transaction.commit()).await {
+                                Ok(message) => Ok(message),
+                                Err(error) => Err(format!(
+                                    "Source cleanup task failed to join: {}",
+                                    error
+                                )),
+                            }
+                        }
+                        Err(error) => Err(format!(
+                            "Moved path was applied, but resume was not confirmed: {}. Both file locations were retained.",
+                            error
+                        )),
+                    }
+                }
+                Err(error) => Err(format!(
+                    "Moved path was persisted but could not be applied live: {}. Both file locations were retained and the torrent remains paused.",
+                    error
+                )),
+            };
+
+            let _ = app_command_tx
+                .send(AppCommand::StorageMoveCompleted {
+                    operation_id,
+                    info_hash,
+                    result,
+                })
+                .await;
+        });
+    }
+
     async fn apply_control_request(&mut self, request: &ControlRequest) -> Result<String, String> {
         self.apply_control_request_with_ingest_result(request)
             .await
@@ -8434,6 +8921,13 @@ impl App {
                 self.trigger_status_dump_after_successful_cluster_mutation();
                 Ok((success_message, None))
             }
+            ControlExecutionPlan::MoveTorrent {
+                info_hash_hex,
+                download_path,
+            } => self
+                .start_live_storage_move(info_hash_hex, download_path)
+                .await
+                .map(|message| (message, None)),
             ControlExecutionPlan::AddTorrentFile {
                 source_path,
                 download_path,
@@ -9140,12 +9634,7 @@ fn compose_system_warning(
 }
 
 fn validate_runtime_control_request(request: &ControlRequest) -> Result<(), String> {
-    if matches!(request, ControlRequest::MoveTorrent { .. }) {
-        return Err(
-            "The move command is CLI-only and requires the superseedr client to be stopped."
-                .to_string(),
-        );
-    }
+    let _ = request;
     Ok(())
 }
 
@@ -9654,6 +10143,7 @@ fn build_persist_payload(
 
     PersistPayload {
         settings: client_configs.clone(),
+        storage_move_request_ids: Vec::new(),
         rss_state,
         network_history,
         activity_history,
@@ -12082,15 +12572,13 @@ mod tests {
     }
 
     #[test]
-    fn running_client_rejects_cli_only_move_requests() {
-        let error = super::validate_runtime_control_request(&ControlRequest::MoveTorrent {
+    fn running_client_accepts_live_move_requests() {
+        let result = super::validate_runtime_control_request(&ControlRequest::MoveTorrent {
             info_hash_hex: "1111111111111111111111111111111111111111".to_string(),
             download_path: PathBuf::from("/fictional-downloads"),
-        })
-        .expect_err("runtime move should be rejected");
+        });
 
-        assert!(error.contains("CLI-only"));
-        assert!(error.contains("stopped"));
+        assert!(result.is_ok());
     }
 
     #[tokio::test]
@@ -16498,6 +16986,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn storage_path_override_fences_stale_metrics_until_state_confirms_move() {
+        let _guard = lock_shared_env();
+        let _temp_paths = configure_temp_app_paths_for_test();
+        let settings = crate::config::Settings {
+            client_port: 0,
+            ..Default::default()
+        };
+        let mut app = App::new(settings, AppRuntimeMode::Normal)
+            .await
+            .expect("build app");
+        let info_hash = b"storage_path_fence".to_vec();
+        let old_path = PathBuf::from("/synthetic/old-location");
+        let new_path = PathBuf::from("/synthetic/new-location");
+
+        let mut display = TorrentDisplayState::default();
+        display.latest_state.info_hash = info_hash.clone();
+        display.latest_state.download_path = Some(new_path.clone());
+        app.app_state.torrents.insert(info_hash.clone(), display);
+        app.storage_path_overrides
+            .insert(info_hash.clone(), new_path.clone());
+
+        let (tx, rx) = watch::channel(TorrentMetrics::default());
+        app.torrent_metric_watch_rxs.insert(info_hash.clone(), rx);
+        tx.send(TorrentMetrics {
+            info_hash: info_hash.clone(),
+            download_path: Some(old_path),
+            ..Default::default()
+        })
+        .expect("send stale metrics");
+        app.drain_latest_torrent_metrics();
+
+        assert_eq!(
+            app.app_state.torrents[&info_hash]
+                .latest_state
+                .download_path
+                .as_ref(),
+            Some(&new_path)
+        );
+        assert!(app.storage_path_overrides.contains_key(&info_hash));
+
+        tx.send(TorrentMetrics {
+            info_hash: info_hash.clone(),
+            download_path: Some(new_path.clone()),
+            ..Default::default()
+        })
+        .expect("send confirmed metrics");
+        app.drain_latest_torrent_metrics();
+
+        assert_eq!(
+            app.app_state.torrents[&info_hash]
+                .latest_state
+                .download_path
+                .as_ref(),
+            Some(&new_path)
+        );
+        assert!(!app.storage_path_overrides.contains_key(&info_hash));
+
+        let _ = app.shutdown_tx.send(());
+        set_app_paths_override_for_tests(None);
+    }
+
+    #[tokio::test]
     async fn completed_torrents_restored_as_complete_do_not_rejournal_on_metrics_refresh() {
         let _guard = lock_shared_env();
         let _temp_paths = configure_temp_app_paths_for_test();
@@ -17806,6 +18356,7 @@ mod tests {
 
         let payload = PersistPayload {
             settings: crate::config::Settings::default(),
+            storage_move_request_ids: Vec::new(),
             rss_state: crate::persistence::rss::RssPersistedState::default(),
             network_history: Some(super::NetworkHistoryPersistRequest {
                 request_id: 7,

--- a/src/control_service.rs
+++ b/src/control_service.rs
@@ -949,6 +949,10 @@ impl OfflineMoveTransaction {
             )
         }
     }
+
+    pub fn rollback(self) -> Result<(), String> {
+        rollback_staged_move_files(&self.staged_files)
+    }
 }
 
 fn ensure_copy_space(destination: &Path, required_space: u64) -> Result<(), String> {
@@ -1135,6 +1139,10 @@ pub enum ControlExecutionPlan {
         next_settings: Settings,
         success_message: String,
     },
+    MoveTorrent {
+        info_hash_hex: String,
+        download_path: PathBuf,
+    },
     AddTorrentFile {
         source_path: PathBuf,
         download_path: Option<PathBuf>,
@@ -1255,20 +1263,15 @@ pub fn plan_control_request(
             download_path,
         } => {
             let info_hash = decode_info_hash(info_hash_hex)?;
-            let Some(index) = find_torrent_settings_index_by_info_hash(settings, &info_hash) else {
+            let Some(_index) = find_torrent_settings_index_by_info_hash(settings, &info_hash)
+            else {
                 return Err(format!("Torrent '{}' was not found", info_hash_hex));
             };
             let canonical_download_path = validate_move_download_path(download_path)?;
             build_move_payload_plan(settings, info_hash_hex, &canonical_download_path)?;
-            let mut next_settings = settings.clone();
-            next_settings.torrents[index].download_path = Some(canonical_download_path.clone());
-            Ok(ControlExecutionPlan::ApplySettings {
-                next_settings,
-                success_message: format!(
-                    "Prepared download path update for torrent '{}' to '{}'",
-                    info_hash_hex,
-                    canonical_download_path.display()
-                ),
+            Ok(ControlExecutionPlan::MoveTorrent {
+                info_hash_hex: info_hash_hex.clone(),
+                download_path: canonical_download_path,
             })
         }
         ControlRequest::SetTorrentConfig {
@@ -1387,6 +1390,9 @@ pub fn apply_offline_control_request(
         } => {
             *settings = next_settings;
             Ok(success_message)
+        }
+        ControlExecutionPlan::MoveTorrent { .. } => {
+            unreachable!("offline move requests are handled before planning")
         }
         ControlExecutionPlan::AddTorrentFile {
             source_path,

--- a/src/integrations/cli.rs
+++ b/src/integrations/cli.rs
@@ -190,7 +190,7 @@ pub enum Commands {
         #[arg(help = "Priority to apply")]
         priority: CliPriority,
     },
-    #[command(about = "Move a torrent while the superseedr client is stopped")]
+    #[command(about = "Move a torrent payload to a new download directory")]
     Move {
         #[arg(value_name = "INFO_HASH_HEX", help = "Torrent info hash")]
         info_hash_hex: String,

--- a/src/integrity_scheduler.rs
+++ b/src/integrity_scheduler.rs
@@ -249,6 +249,21 @@ impl IntegrityScheduler {
         }
     }
 
+    pub fn on_storage_moved(&mut self, info_hash: &[u8]) {
+        if let Some(state) = self.torrents.get_mut(info_hash) {
+            state.probe_epoch = state.probe_epoch.saturating_add(1);
+            if state.in_flight {
+                state.in_flight = false;
+                self.in_flight_probe_batches = self.in_flight_probe_batches.saturating_sub(1);
+            }
+            state.next_probe_file_index = 0;
+            state.current_sweep_problem_files.clear();
+            state.pending_metadata = false;
+            state.next_due_at = self.now;
+            state.last_probe_started_at = None;
+        }
+    }
+
     pub fn on_data_availability_fault(&mut self, info_hash: &[u8]) {
         let shared_saved_location = self
             .torrents

--- a/src/main.rs
+++ b/src/main.rs
@@ -2375,12 +2375,6 @@ fn process_cli_request(
             info_hash_hex,
             path,
         } => {
-            if leader_is_running {
-                return Err(io::Error::new(
-                    io::ErrorKind::WouldBlock,
-                    "Stop the running superseedr client before using the move command.",
-                ));
-            }
             let request = build_move_torrent_request(settings, info_hash_hex, path)
                 .map_err(|message| io::Error::new(io::ErrorKind::InvalidInput, message))?;
             process_control_requests(
@@ -3844,8 +3838,13 @@ mod tests {
     }
 
     #[test]
-    fn move_command_rejects_a_running_client_before_touching_payloads() {
+    fn move_command_queues_for_a_running_client() {
+        let _guard = shared_env_guard().lock().unwrap();
+        let app_paths = tempdir().expect("create app paths");
+        let _restore = set_test_app_paths(app_paths.path());
         let destination = tempdir().expect("create destination");
+        let settings = sample_settings();
+        config::ensure_watch_directories(&settings).expect("create watch directories");
         let cli = Cli {
             json: false,
             input: None,
@@ -3855,11 +3854,16 @@ mod tests {
             }),
         };
 
-        let error = process_cli_request(&cli, &Settings::default(), false, true, OutputMode::Text)
-            .expect_err("running client should reject move");
+        process_cli_request(&cli, &settings, false, true, OutputMode::Text)
+            .expect("running client should queue move");
 
-        assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
-        assert!(error.to_string().contains("Stop the running"));
+        let watch_path = resolve_cli_command_sink(&settings).expect("command watch path");
+        let queued_controls = fs::read_dir(watch_path)
+            .expect("read command watch path")
+            .filter_map(Result::ok)
+            .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "control"))
+            .count();
+        assert_eq!(queued_controls, 1);
     }
 
     #[test]

--- a/src/torrent_manager/manager.rs
+++ b/src/torrent_manager/manager.rs
@@ -35,6 +35,7 @@ use crate::torrent_manager::state::TorrentStatus;
 use crate::torrent_manager::state::TrackerState;
 use crate::torrent_manager::ManagerCommand;
 use crate::torrent_manager::ManagerEvent;
+use crate::torrent_manager::PauseDrainResult;
 #[cfg(feature = "synthetic-load")]
 use crate::torrent_manager::SyntheticPeerConnectFailure;
 
@@ -80,6 +81,7 @@ use tokio::signal;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::oneshot;
 use tokio::sync::watch;
 
 use tokio::task::JoinHandle;
@@ -441,6 +443,11 @@ enum FileProbeBatchPreparation {
     Scan(PreparedFileProbeBatch),
 }
 
+struct PendingPauseDrain {
+    response: oneshot::Sender<Result<PauseDrainResult, String>>,
+    result: PauseDrainResult,
+}
+
 pub struct TorrentManager {
     state: TorrentState,
 
@@ -468,6 +475,8 @@ pub struct TorrentManager {
 
     in_flight_uploads: HashMap<String, HashMap<BlockInfo, JoinHandle<()>>>,
     in_flight_writes: HashMap<u32, Vec<JoinHandle<()>>>,
+    pending_pause_drains: Vec<PendingPauseDrain>,
+    storage_path_response: Option<oneshot::Sender<Result<(), String>>>,
 
     #[cfg(feature = "dht")]
     #[allow(dead_code)]
@@ -677,6 +686,8 @@ impl TorrentManager {
             manager_event_tx,
             in_flight_uploads: HashMap::new(),
             in_flight_writes: HashMap::new(),
+            pending_pause_drains: Vec::new(),
+            storage_path_response: None,
             settings,
             resource_manager,
             global_dl_bucket,
@@ -815,10 +826,57 @@ impl TorrentManager {
         self.sync_dht_demand();
     }
 
+    fn begin_pause(&mut self, response: Option<oneshot::Sender<Result<PauseDrainResult, String>>>) {
+        let result = PauseDrainResult {
+            was_already_paused: self.state.is_paused,
+            storage_relocation: self.state.validate_storage_relocation(),
+        };
+        self.apply_action(Action::Pause);
+        if let Some(response) = response {
+            self.pending_pause_drains
+                .push(PendingPauseDrain { response, result });
+        }
+    }
+
+    fn resume(&mut self, response: Option<oneshot::Sender<()>>) {
+        for pending in self.pending_pause_drains.drain(..) {
+            let _ = pending
+                .response
+                .send(Err("Pause drain was cancelled by resume".to_string()));
+        }
+        self.apply_action(Action::Resume);
+        if let Some(response) = response {
+            let _ = response.send(());
+        }
+    }
+
+    fn try_complete_pause_drains(&mut self) {
+        if self.pending_pause_drains.is_empty()
+            || !self.state.is_paused
+            || !self.state.peers.is_empty()
+            || !self.state.verifying_pieces.is_empty()
+            || !self.state.writing_pieces.is_empty()
+            || !self.in_flight_writes.is_empty()
+            || !self.in_flight_uploads.is_empty()
+        {
+            return;
+        }
+
+        for pending in self.pending_pause_drains.drain(..) {
+            let _ = pending.response.send(Ok(pending.result));
+        }
+    }
+
     // Handles the aftermath of the mutate effects
     fn handle_effect(&mut self, effect: Effect) {
         match effect {
             Effect::DoNothing => {}
+
+            Effect::StoragePathApplied { result } => {
+                if let Some(response) = self.storage_path_response.take() {
+                    let _ = response.send(result);
+                }
+            }
 
             Effect::EmitManagerEvent(event) => {
                 let _ = self.manager_event_tx.try_send(event);
@@ -3186,8 +3244,8 @@ impl TorrentManager {
                         ManagerCommand::SetDataAvailability(available) => {
                             self.apply_action(Action::SetDataAvailability { available });
                         }
-                        ManagerCommand::Pause => self.apply_action(Action::Pause),
-                        ManagerCommand::Resume => self.apply_action(Action::Resume),
+                        ManagerCommand::Pause { response } => self.begin_pause(response),
+                        ManagerCommand::Resume { response } => self.resume(response),
                         ManagerCommand::DeleteFile => {
                             self.apply_action(Action::Delete);
                             break Ok(());
@@ -3207,6 +3265,13 @@ impl TorrentManager {
                                 file_priorities,
                                 container_name,
                             });
+                        }
+                        ManagerCommand::ApplyStoragePath {
+                            torrent_data_path,
+                            response,
+                        } => {
+                            self.storage_path_response = Some(response);
+                            self.apply_action(Action::ApplyStoragePath { torrent_data_path });
                         }
                         ManagerCommand::SetDataRate(new_rate_ms) => {
                             self.data_rate_ms = new_rate_ms;
@@ -3650,6 +3715,7 @@ impl TorrentManager {
                     }
                 }
             }
+            self.try_complete_pause_drains();
         }
     }
 }
@@ -4162,6 +4228,34 @@ mod resource_tests {
             .expect("manager from torrent");
 
         assert_eq!(manager.data_rate_ms, DataRate::Rate20s.as_ms());
+    }
+
+    #[tokio::test]
+    async fn pause_acknowledgement_waits_for_piece_verification_to_drain() {
+        let mut manager =
+            TorrentManager::from_torrent(build_test_params(), create_dummy_torrent(1))
+                .expect("manager from torrent");
+        manager.state.torrent_status = TorrentStatus::Standard;
+        manager.state.verifying_pieces.insert(0);
+
+        let (response_tx, mut response_rx) = oneshot::channel();
+        manager.begin_pause(Some(response_tx));
+
+        manager.try_complete_pause_drains();
+        assert!(matches!(
+            response_rx.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
+        assert!(manager.state.is_paused);
+
+        manager.state.verifying_pieces.clear();
+        manager.try_complete_pause_drains();
+        let result = response_rx
+            .await
+            .expect("pause response")
+            .expect("pause drain result");
+        assert!(!result.was_already_paused);
+        assert!(result.storage_relocation.is_ok());
     }
 
     #[tokio::test]

--- a/src/torrent_manager/mod.rs
+++ b/src/torrent_manager/mod.rs
@@ -21,6 +21,7 @@ use crate::app::FilePriority;
 use crate::app::TorrentMetrics;
 
 use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio::time::Duration;
 
@@ -178,6 +179,12 @@ pub enum ManagerEvent {
     },
 }
 
+#[derive(Debug)]
+pub struct PauseDrainResult {
+    pub was_already_paused: bool,
+    pub storage_relocation: Result<(), String>,
+}
+
 #[cfg(feature = "synthetic-load")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SyntheticPeerConnectFailure {
@@ -194,7 +201,7 @@ pub enum SyntheticPeerConnectFailure {
     OtherIo,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum ManagerCommand {
     #[cfg(feature = "synthetic-load")]
     ConnectToPeer(SocketAddr),
@@ -209,8 +216,12 @@ pub enum ManagerCommand {
         max_files: usize,
     },
     SetDataAvailability(bool),
-    Pause,
-    Resume,
+    Pause {
+        response: Option<oneshot::Sender<Result<PauseDrainResult, String>>>,
+    },
+    Resume {
+        response: Option<oneshot::Sender<()>>,
+    },
     Shutdown,
     DeleteFile,
     SetDataRate(u64),
@@ -219,6 +230,10 @@ pub enum ManagerCommand {
         torrent_data_path: PathBuf,
         file_priorities: HashMap<usize, FilePriority>,
         container_name: Option<String>,
+    },
+    ApplyStoragePath {
+        torrent_data_path: PathBuf,
+        response: oneshot::Sender<Result<(), String>>,
     },
 }
 

--- a/src/torrent_manager/state.rs
+++ b/src/torrent_manager/state.rs
@@ -45,6 +45,21 @@ const KNOWN_SEEDER_TTL: Duration = Duration::from_secs(60 * 60);
 // to avoid churn storms. This is intentionally independent of resource-manager limits.
 const PEER_ADMISSION_QUALITY_THRESHOLD: usize = 400;
 
+fn storage_layout_matches(current: &MultiFileInfo, candidate: &MultiFileInfo) -> bool {
+    current.total_size == candidate.total_size
+        && current.files.len() == candidate.files.len()
+        && current
+            .files
+            .iter()
+            .zip(&candidate.files)
+            .all(|(current, candidate)| {
+                current.length == candidate.length
+                    && current.global_start_offset == candidate.global_start_offset
+                    && current.is_padding == candidate.is_padding
+                    && current.is_skipped == candidate.is_skipped
+            })
+}
+
 pub type PeerAddr = SocketAddr;
 
 #[derive(Debug, Clone)]
@@ -172,6 +187,9 @@ pub enum Action {
         file_priorities: HashMap<usize, FilePriority>,
         container_name: Option<String>,
     },
+    ApplyStoragePath {
+        torrent_data_path: PathBuf,
+    },
     SetDataAvailability {
         available: bool,
     },
@@ -274,6 +292,9 @@ pub enum Effect {
         left: usize,
         uploaded: usize,
         downloaded: usize,
+    },
+    StoragePathApplied {
+        result: Result<(), String>,
     },
 }
 
@@ -1296,6 +1317,9 @@ impl TorrentState {
                 block_offset,
                 data,
             } => {
+                if self.is_paused {
+                    return vec![Effect::DoNothing];
+                }
                 if piece_index as usize >= self.piece_manager.bitfield.len() {
                     return vec![Effect::DoNothing];
                 }
@@ -2289,6 +2313,35 @@ impl TorrentState {
                 effects
             }
 
+            Action::ApplyStoragePath { torrent_data_path } => {
+                let result = self.validate_storage_relocation().and_then(|()| {
+                    if !self.is_paused {
+                        return Err(
+                            "Torrent storage can only be relocated while paused".to_string()
+                        );
+                    }
+                    self.build_multi_file_info(&torrent_data_path, self.container_name.as_deref())
+                        .and_then(|(multi_file_info, resolved_container_name)| {
+                            let previous = self.multi_file_info.as_ref().ok_or_else(|| {
+                                "Torrent storage is not initialized".to_string()
+                            })?;
+                            if !storage_layout_matches(previous, &multi_file_info) {
+                                return Err(
+                                    "Rebuilt destination storage layout does not match the active layout"
+                                        .to_string(),
+                                );
+                            }
+
+                            self.torrent_data_path = Some(torrent_data_path);
+                            self.container_name = resolved_container_name;
+                            self.multi_file_info = Some(multi_file_info);
+                            Ok(())
+                        })
+                });
+
+                vec![Effect::StoragePathApplied { result }]
+            }
+
             Action::SetDataAvailability { available } => {
                 self.data_available = available;
                 self.update(Action::RecalculateChokes { random_seed: 0 })
@@ -2544,75 +2597,95 @@ impl TorrentState {
         updates
     }
 
-    pub fn rebuild_multi_file_info(&mut self) {
-        // Guard 1: Ensure metadata exists
-        let torrent = match &self.torrent {
-            Some(t) => t,
-            None => {
-                event!(
-                    Level::DEBUG,
-                    "rebuild_multi_file_info: Skipping. No torrent metadata available."
-                );
-                return;
+    pub(crate) fn validate_storage_relocation(&self) -> Result<(), String> {
+        if matches!(
+            self.torrent_status,
+            TorrentStatus::AwaitingMetadata | TorrentStatus::Validating
+        ) {
+            return Err(format!(
+                "Storage cannot be moved while the torrent is {:?}",
+                self.torrent_status
+            ));
+        }
+        if self.torrent.is_none()
+            || self.torrent_data_path.is_none()
+            || self.multi_file_info.is_none()
+        {
+            return Err("Torrent storage is not initialized".to_string());
+        }
+        Ok(())
+    }
+
+    fn build_multi_file_info(
+        &self,
+        path: &Path,
+        container_name: Option<&str>,
+    ) -> Result<(MultiFileInfo, Option<String>), String> {
+        let torrent = self
+            .torrent
+            .as_ref()
+            .ok_or_else(|| "Torrent metadata is not available".to_string())?;
+        if path.as_os_str().is_empty() {
+            return Err("Torrent data path is empty".to_string());
+        }
+
+        let (effective_path, resolved_container_name) = match container_name {
+            Some(name) if !name.is_empty() => (path.join(name), Some(name.to_string())),
+            Some(_) => (path.to_path_buf(), Some(String::new())),
+            None if !torrent.info.files.is_empty() => {
+                let unique_name =
+                    format!("{} [{}]", torrent.info.name, hex::encode(&self.info_hash));
+                (path.join(&unique_name), Some(unique_name))
             }
+            None => (path.to_path_buf(), None),
         };
 
-        // Guard 2: Handle the Option<PathBuf>
-        let path = match &self.torrent_data_path {
-            Some(p) if !p.as_os_str().is_empty() => p,
-            Some(_) => {
-                event!(Level::WARN,
-                    torrent_name = %torrent.info.name,
-                    "rebuild_multi_file_info: torrent_data_path is Some, but the path is empty."
-                );
-                return;
-            }
-            None => {
-                event!(Level::WARN,
-                    torrent_name = %torrent.info.name,
-                    "rebuild_multi_file_info: torrent_data_path is None."
-                );
-                return;
-            }
-        };
-
-        let effective_path = match &self.container_name {
-            // Case A: User specified a folder
-            Some(name) if !name.is_empty() => path.join(name),
-
-            // Case B: User explicitly said "No Folder" (Empty String)
-            Some(_) => path.clone(),
-
-            // Case C: Auto/Default (None) -> Intelligent Behavior
-            None => {
-                let is_multi_file = !torrent.info.files.is_empty();
-                // BitTorrent standard: multi-file torrents use folders
-                if is_multi_file {
-                    let info_hash_hex = hex::encode(&self.info_hash);
-                    let unique_name = format!("{} [{}]", torrent.info.name, info_hash_hex);
-                    self.container_name = Some(unique_name.clone());
-                    path.join(unique_name)
-                } else {
-                    path.clone()
-                }
-            }
-        };
-        self.multi_file_info = MultiFileInfo::new(
+        let multi_file_info = MultiFileInfo::new(
             &effective_path,
             &torrent.info.name,
-            if torrent.info.files.is_empty() { None } else { Some(&torrent.info.files) },
-            if torrent.info.files.is_empty() { Some(torrent.info.length as u64) } else { None },
+            if torrent.info.files.is_empty() {
+                None
+            } else {
+                Some(&torrent.info.files)
+            },
+            if torrent.info.files.is_empty() {
+                Some(torrent.info.length as u64)
+            } else {
+                None
+            },
             &self.file_priorities,
-        ).map_err(|e| {
-            event!(Level::ERROR, error = %e, "rebuild_multi_file_info: Failed to create MultiFileInfo");
-            e
-        }).ok();
+        )
+        .map_err(|error| error.to_string())?;
 
-        if self.multi_file_info.is_some() {
-            event!(Level::DEBUG,
-                torrent_name = %torrent.info.name,
-                "rebuild_multi_file_info: Storage successfully initialized in state."
+        Ok((multi_file_info, resolved_container_name))
+    }
+
+    pub fn rebuild_multi_file_info(&mut self) {
+        let Some(path) = self.torrent_data_path.clone() else {
+            event!(
+                Level::WARN,
+                "rebuild_multi_file_info: torrent_data_path is None."
             );
+            return;
+        };
+
+        match self.build_multi_file_info(&path, self.container_name.as_deref()) {
+            Ok((multi_file_info, resolved_container_name)) => {
+                self.multi_file_info = Some(multi_file_info);
+                self.container_name = resolved_container_name;
+                event!(
+                    Level::DEBUG,
+                    "rebuild_multi_file_info: Storage successfully initialized in state."
+                );
+            }
+            Err(error) => {
+                self.multi_file_info = None;
+                event!(
+                    Level::ERROR,
+                    error = %error,
+                    "rebuild_multi_file_info: Failed to create MultiFileInfo"
+                );
+            }
         }
     }
 
@@ -7899,6 +7972,101 @@ mod tests {
             state.peers[&peer_id].pending_requests.is_empty(),
             "Peer should have 0 pending requests when path is missing"
         );
+    }
+
+    fn create_storage_relocation_state(is_paused: bool) -> TorrentState {
+        let mut state = create_empty_state();
+        state.torrent = Some(create_dummy_torrent(3));
+        state.torrent_status = TorrentStatus::Standard;
+        state.is_paused = is_paused;
+        state.torrent_data_path = Some(PathBuf::from("/tmp/synthetic-source"));
+        state.piece_manager.set_initial_fields(3, false);
+        state.piece_manager.mark_as_complete(0);
+        state.piece_manager.need_queue = vec![1, 2];
+        state.session_total_downloaded = 4096;
+        state.rebuild_multi_file_info();
+        state
+    }
+
+    #[test]
+    fn storage_relocation_rejects_validation() {
+        let mut state = create_storage_relocation_state(true);
+        state.torrent_status = TorrentStatus::Validating;
+
+        let result = state.validate_storage_relocation();
+
+        assert!(matches!(result, Err(error) if error.contains("Validating")));
+        assert_eq!(
+            state.torrent_data_path.as_deref(),
+            Some(Path::new("/tmp/synthetic-source"))
+        );
+    }
+
+    #[test]
+    fn storage_relocation_requires_pause() {
+        let mut state = create_storage_relocation_state(false);
+
+        let effects = state.update(Action::ApplyStoragePath {
+            torrent_data_path: PathBuf::from("/tmp/synthetic-destination"),
+        });
+
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::StoragePathApplied { result: Err(error) }
+                if error.contains("while paused")
+        )));
+        assert_eq!(
+            state.torrent_data_path.as_deref(),
+            Some(Path::new("/tmp/synthetic-source"))
+        );
+    }
+
+    #[test]
+    fn storage_relocation_switches_only_the_storage_layout() {
+        let mut state = create_storage_relocation_state(true);
+        let original_bitfield = state.piece_manager.bitfield.clone();
+        let original_need_queue = state.piece_manager.need_queue.clone();
+        let original_downloaded = state.session_total_downloaded;
+
+        let applied = state.update(Action::ApplyStoragePath {
+            torrent_data_path: PathBuf::from("/tmp/synthetic-destination"),
+        });
+        assert!(applied
+            .iter()
+            .any(|effect| matches!(effect, Effect::StoragePathApplied { result: Ok(()) })));
+        assert_eq!(
+            state.torrent_data_path.as_deref(),
+            Some(Path::new("/tmp/synthetic-destination"))
+        );
+        assert!(state.multi_file_info.as_ref().is_some_and(|layout| {
+            layout
+                .files
+                .iter()
+                .all(|file| file.path.starts_with("/tmp/synthetic-destination"))
+        }));
+        assert_eq!(state.piece_manager.bitfield, original_bitfield);
+        assert_eq!(state.piece_manager.need_queue, original_need_queue);
+        assert_eq!(state.session_total_downloaded, original_downloaded);
+        assert_eq!(state.torrent_status, TorrentStatus::Standard);
+        assert!(state.is_paused);
+    }
+
+    #[test]
+    fn paused_state_discards_late_peer_blocks() {
+        let mut state = create_storage_relocation_state(true);
+        let downloaded = state.session_total_downloaded;
+
+        let effects = state.update(Action::IncomingBlock {
+            peer_id: "synthetic-peer".to_string(),
+            piece_index: 1,
+            block_offset: 0,
+            data: vec![0; 16_384],
+        });
+
+        assert!(matches!(effects.as_slice(), [Effect::DoNothing]));
+        assert!(state.verifying_pieces.is_empty());
+        assert!(state.writing_pieces.is_empty());
+        assert_eq!(state.session_total_downloaded, downloaded);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- allow `superseedr move` to relocate a torrent while the client is online
- make pause optionally acknowledge only after peers and in-flight verification, write, and upload work drain
- reuse the checked move transaction, persist the destination before updating runtime state, resume the original running state, then remove the source
- discard late blocks while paused and fence stale persistence and metrics snapshots

## Safety

- reject relocation while metadata is loading or validation is active
- roll back the staged destination after a definite persistence failure
- retain both locations and remain paused when persistence or application outcome is ambiguous

## Validation

- `cargo test -q` (103 library tests and 1,659 application tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --all-targets --all-features`
- live Linux ISO tests covering running, paused, mid-download, and validating-state relocation paths