### PR TITLE
Redesign the TUI journal screen

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2075,6 +2075,7 @@ impl JournalFilter {
 pub struct JournalUiState {
     pub filter: JournalFilter,
     pub selected_index: usize,
+    pub scroll_offset: usize,
     pub status_message: Option<String>,
     pub is_searching: bool,
     pub search_query: String,
@@ -2086,6 +2087,7 @@ impl Default for JournalUiState {
         Self {
             filter: JournalFilter::default(),
             selected_index: 0,
+            scroll_offset: 0,
             status_message: None,
             is_searching: false,
             search_query: String::new(),
@@ -4933,6 +4935,8 @@ impl App {
     ) -> bool {
         match mode {
             AppMode::PowerSaving => ui_needs_redraw,
+            // The one-second stats tick dirties the Journal often enough to refresh live ages.
+            AppMode::Journal => ui_needs_redraw,
             AppMode::Normal => ui_needs_redraw || normal_animation_active,
             _ => true,
         }
@@ -10734,6 +10738,12 @@ mod tests {
             true,
             false
         ));
+    }
+
+    #[test]
+    fn should_only_draw_dirty_in_journal_mode() {
+        assert!(!App::should_draw_this_frame(&AppMode::Journal, false, true));
+        assert!(App::should_draw_this_frame(&AppMode::Journal, true, false));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1894,7 +1894,7 @@ impl JournalFilter {
     pub fn label(self) -> &'static str {
         match self {
             Self::All => "ALL",
-            Self::Queue => "QUEUE",
+            Self::Queue => "INGEST",
             Self::Commands => "COMMANDS",
             Self::Health => "HEALTH",
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -2072,11 +2072,26 @@ impl JournalFilter {
     }
 }
 
-#[derive(Default)]
 pub struct JournalUiState {
     pub filter: JournalFilter,
     pub selected_index: usize,
     pub status_message: Option<String>,
+    pub is_searching: bool,
+    pub search_query: String,
+    pub search_mode: SearchMode,
+}
+
+impl Default for JournalUiState {
+    fn default() -> Self {
+        Self {
+            filter: JournalFilter::default(),
+            selected_index: 0,
+            status_message: None,
+            is_searching: false,
+            search_query: String::new(),
+            search_mode: SearchMode::Regex,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -577,6 +577,13 @@ fn build_help_items(settings: &Settings, app_state: &AppState) -> Vec<HelpItem> 
     action_item!(
         HelpSection::Screens,
         "Journal",
+        "Page Up / Page Down",
+        "Move through journal activities by one visible page",
+        ActionTone::Navigate
+    );
+    action_item!(
+        HelpSection::Screens,
+        "Journal",
         "/",
         "Search the current journal filter; use Tab to toggle fuzzy or regex matching",
         ActionTone::Search

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -577,6 +577,13 @@ fn build_help_items(settings: &Settings, app_state: &AppState) -> Vec<HelpItem> 
     action_item!(
         HelpSection::Screens,
         "Journal",
+        "/",
+        "Search the current journal filter; use Tab to toggle fuzzy or regex matching",
+        ActionTone::Search
+    );
+    action_item!(
+        HelpSection::Screens,
+        "Journal",
         "Y",
         "Replay selected archived torrent, magnet, or path source",
         ActionTone::Replay

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -1004,60 +1004,34 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
 
     let area = centered_rect(88, 94, f.area());
     f.render_widget(Clear, area);
+    let screen_regions = help_screen_regions(f.area(), search_panel_active);
 
-    let (search_area, help_area) = if search_panel_active && area.height >= 7 {
-        let chunks = Layout::vertical([Constraint::Length(3), Constraint::Min(1)]).split(area);
-        (Some(chunks[0]), chunks[1])
-    } else {
-        (None, area)
-    };
-
-    if let Some(search_area) = search_area {
+    draw_help_tabs(f, screen_regions.header, app_state, ctx);
+    draw_help_controls(f, screen_regions.footer, app_state, ctx);
+    if let Some(search_area) = screen_regions.search {
         draw_help_search_panel(f, search_area, app_state, items.len(), ctx);
     }
-
-    let layout = Layout::vertical([
-        Constraint::Length(1),
-        Constraint::Min(1),
-        Constraint::Length(1),
-    ])
-    .split(help_area);
-    let header_area = layout[0];
-    let panel_area = layout[1];
-    let footer_area = layout[2];
-
-    draw_help_tabs(f, header_area, app_state, ctx);
-    draw_help_controls(f, footer_area, app_state, ctx);
 
     let outer_block = Block::default()
         .borders(Borders::ALL)
         .border_style(ctx.apply(Style::default().fg(ctx.theme.semantic.border)))
         .padding(Padding::new(2, 2, 0, 0));
-    let inner = outer_block.inner(panel_area);
-    f.render_widget(outer_block, panel_area);
+    let inner = outer_block.inner(screen_regions.panel);
+    f.render_widget(outer_block, screen_regions.panel);
 
     if inner.height == 0 || inner.width == 0 {
         return;
     }
 
-    let mut constraints = Vec::new();
-    if let Some(warning_text) = &app_state.system_warning {
-        let warning_width = inner.width.saturating_sub(2).max(1) as usize;
-        let warning_lines = (warning_text.len() as f64 / warning_width as f64).ceil() as u16;
-        let warning_height = warning_lines.saturating_add(1).clamp(2, 3);
-        constraints.push(Constraint::Length(warning_height));
-    }
-    constraints.push(Constraint::Min(1));
+    let panel_regions = help_panel_regions(inner, app_state.system_warning.as_deref());
 
-    let chunks = Layout::vertical(constraints).split(inner);
-    let mut chunk_idx = 0;
-
-    if let Some(warning_text) = &app_state.system_warning {
-        draw_warning(f, chunks[chunk_idx], warning_text, ctx);
-        chunk_idx += 1;
+    if let (Some(warning_area), Some(warning_text)) =
+        (panel_regions.warning, app_state.system_warning.as_deref())
+    {
+        draw_warning(f, warning_area, warning_text, ctx);
     }
 
-    draw_help_table(f, chunks[chunk_idx], app_state, &items, ctx);
+    draw_help_table(f, panel_regions.content, app_state, &items, ctx);
 }
 
 fn draw_warning(f: &mut Frame, area: Rect, warning_text: &str, ctx: &ThemeContext) {
@@ -1165,6 +1139,72 @@ fn help_table_capacity(area: Rect) -> usize {
     area.height.max(1) as usize
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct HelpScreenRegions {
+    header: Rect,
+    search: Option<Rect>,
+    panel: Rect,
+    footer: Rect,
+}
+
+fn help_screen_regions(screen_area: Rect, search_active: bool) -> HelpScreenRegions {
+    let area = centered_rect(88, 94, screen_area);
+    let show_search = search_active && area.height >= 6;
+    if show_search {
+        let regions = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
+        .split(area);
+        HelpScreenRegions {
+            header: regions[0],
+            search: Some(regions[1]),
+            panel: regions[2],
+            footer: regions[3],
+        }
+    } else {
+        let regions = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
+        .split(area);
+        HelpScreenRegions {
+            header: regions[0],
+            search: None,
+            panel: regions[1],
+            footer: regions[2],
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct HelpPanelRegions {
+    warning: Option<Rect>,
+    content: Rect,
+}
+
+fn help_warning_height(area: Rect, warning_text: &str) -> u16 {
+    let warning_width = area.width.saturating_sub(2).max(1) as usize;
+    let warning_lines = (warning_text.len() as f64 / warning_width as f64).ceil() as u16;
+    warning_lines.saturating_add(1).clamp(2, 3)
+}
+
+fn help_panel_regions(inner: Rect, warning_text: Option<&str>) -> HelpPanelRegions {
+    let warning_height = warning_text.map(|text| help_warning_height(inner, text));
+    let (warning, content) = if let Some(height) = warning_height {
+        let regions =
+            Layout::vertical([Constraint::Length(height), Constraint::Min(1)]).split(inner);
+        (Some(regions[0]), regions[1])
+    } else {
+        (None, inner)
+    };
+
+    HelpPanelRegions { warning, content }
+}
+
 fn clamped_scroll_offset(scroll_offset: usize, len: usize, visible_count: usize) -> usize {
     if len <= visible_count {
         return 0;
@@ -1179,38 +1219,16 @@ fn help_table_area_for_state(app_state: &AppState) -> Rect {
 
     let search_panel_active =
         app_state.ui.help.is_searching || !app_state.ui.help.search_query.is_empty();
-    let area = centered_rect(88, 94, app_state.screen_area);
-    let help_area = if search_panel_active && area.height >= 7 {
-        Layout::vertical([Constraint::Length(3), Constraint::Min(1)]).split(area)[1]
-    } else {
-        area
-    };
-    let panel_area = Layout::vertical([
-        Constraint::Length(1),
-        Constraint::Min(1),
-        Constraint::Length(1),
-    ])
-    .split(help_area)[1];
+    let screen_regions = help_screen_regions(app_state.screen_area, search_panel_active);
     let inner = Block::default()
         .borders(Borders::ALL)
         .padding(Padding::new(2, 2, 0, 0))
-        .inner(panel_area);
+        .inner(screen_regions.panel);
 
     if inner.height == 0 || inner.width == 0 {
         return inner;
     }
-
-    let mut constraints = Vec::new();
-    if let Some(warning_text) = &app_state.system_warning {
-        let warning_width = inner.width.saturating_sub(2).max(1) as usize;
-        let warning_lines = (warning_text.len() as f64 / warning_width as f64).ceil() as u16;
-        let warning_height = warning_lines.saturating_add(1).clamp(2, 3);
-        constraints.push(Constraint::Length(warning_height));
-    }
-    constraints.push(Constraint::Min(1));
-
-    let chunks = Layout::vertical(constraints).split(inner);
-    chunks[usize::from(app_state.system_warning.is_some())]
+    help_panel_regions(inner, app_state.system_warning.as_deref()).content
 }
 
 fn help_visible_count_for_state(app_state: &AppState) -> usize {
@@ -1484,6 +1502,48 @@ mod tests {
             &mut app_state,
         );
         assert_eq!(app_state.ui.help.scroll_offset, 0);
+    }
+
+    #[test]
+    fn layout_keeps_search_above_the_content_panel_below_the_header() {
+        let screen_regions = help_screen_regions(Rect::new(0, 0, 120, 40), true);
+        let inner = Block::default()
+            .borders(Borders::ALL)
+            .padding(Padding::new(2, 2, 0, 0))
+            .inner(screen_regions.panel);
+        let panel_regions = help_panel_regions(inner, Some("Service notice"));
+        let search = screen_regions.search.expect("search region");
+        let warning = panel_regions.warning.expect("warning region");
+
+        assert!(screen_regions.header.bottom() <= search.y);
+        assert!(search.bottom() <= screen_regions.panel.y);
+        assert!(screen_regions.panel.bottom() <= screen_regions.footer.y);
+        assert!(warning.y >= inner.y);
+        assert!(warning.bottom() <= panel_regions.content.y);
+        assert!(panel_regions.content.bottom() <= inner.bottom());
+    }
+
+    #[test]
+    fn scroll_capacity_uses_the_rendered_content_region_with_search() {
+        let mut app_state = AppState {
+            mode: AppMode::Help,
+            screen_area: Rect::new(0, 0, 120, 30),
+            system_warning: Some("Service notice".to_string()),
+            ..Default::default()
+        };
+        app_state.ui.help.is_searching = true;
+        let screen_regions = help_screen_regions(app_state.screen_area, true);
+        let inner = Block::default()
+            .borders(Borders::ALL)
+            .padding(Padding::new(2, 2, 0, 0))
+            .inner(screen_regions.panel);
+        let expected = help_panel_regions(inner, app_state.system_warning.as_deref()).content;
+
+        assert_eq!(help_table_area_for_state(&app_state), expected);
+        assert_eq!(
+            help_visible_count_for_state(&app_state),
+            expected.height as usize
+        );
     }
 
     #[test]

--- a/src/tui/screens/input_panel.rs
+++ b/src/tui/screens/input_panel.rs
@@ -11,7 +11,19 @@ pub(crate) fn draw_prompt_panel(
     area: Rect,
     title: String,
     value: String,
+    trailing_spans: Vec<Span<'static>>,
+    ctx: &ThemeContext,
+) {
+    draw_prompt_panel_with_cursor(f, area, title, value, trailing_spans, true, ctx);
+}
+
+pub(crate) fn draw_prompt_panel_with_cursor(
+    f: &mut Frame,
+    area: Rect,
+    title: String,
+    value: String,
     mut trailing_spans: Vec<Span<'static>>,
+    show_cursor: bool,
     ctx: &ThemeContext,
 ) {
     let mut line_spans = vec![
@@ -20,8 +32,13 @@ pub(crate) fn draw_prompt_panel(
             ctx.apply(Style::default().fg(ctx.state_selected()).bold()),
         ),
         Span::raw(value),
-        Span::styled("_", ctx.apply(Style::default().fg(ctx.state_warning()))),
     ];
+    if show_cursor {
+        line_spans.push(Span::styled(
+            "_",
+            ctx.apply(Style::default().fg(ctx.state_warning())),
+        ));
+    }
     line_spans.append(&mut trailing_spans);
 
     let block = Block::default()

--- a/src/tui/screens/journal.rs
+++ b/src/tui/screens/journal.rs
@@ -1,17 +1,22 @@
 // SPDX-FileCopyrightText: 2026 The superseedr Contributors
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use crate::app::{AppCommand, AppMode, AppState, JournalFilter};
+use crate::app::{AppCommand, AppMode, AppState, JournalFilter, SearchMode};
 use crate::persistence::event_journal::{
     EventCategory, EventDetails, EventJournalEntry, EventType,
 };
 use crate::theme::ThemeContext;
 use crate::tui::action_style::{footer_key_style, ActionTone};
 use crate::tui::app_command::spawn_app_command_sender;
-use crate::tui::formatters::{sanitize_text, truncate_with_ellipsis};
+use crate::tui::formatters::{centered_rect, sanitize_text, truncate_with_ellipsis};
 use crate::tui::screen_context::ScreenContext;
+use crate::tui::screens::input_panel::draw_prompt_panel;
 use chrono::{DateTime, Local};
-use ratatui::crossterm::event::{Event as CrosstermEvent, KeyCode, KeyEventKind};
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
+use ratatui::crossterm::event::{
+    Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
+};
 use ratatui::prelude::{Alignment, Constraint, Frame, Line, Modifier, Span, Style};
 use ratatui::widgets::{Block, Borders, Cell, Clear, Padding, Paragraph, Row, Table, TableState};
 use std::collections::HashMap;
@@ -26,20 +31,48 @@ enum JournalAction {
     MoveUp,
     MoveDown,
     ReplaySelected,
+    SearchStart,
+    SearchInsert(char),
+    SearchBackspace,
+    SearchClear,
+    SearchCommit,
+    SearchCancel,
+    ToggleSearchMode,
 }
 
-fn map_key_to_journal_action(key_code: KeyCode, key_kind: KeyEventKind) -> Option<JournalAction> {
-    if !matches!(key_kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+fn map_key_to_journal_action(key: KeyEvent, search_panel_active: bool) -> Option<JournalAction> {
+    if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
         return None;
     }
 
-    match key_code {
+    let has_ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    let has_alt = key.modifiers.contains(KeyModifiers::ALT);
+
+    if search_panel_active && matches!(key.code, KeyCode::Tab) {
+        return Some(JournalAction::ToggleSearchMode);
+    }
+
+    if search_panel_active {
+        return match key.code {
+            KeyCode::Esc => Some(JournalAction::SearchCancel),
+            KeyCode::Enter => Some(JournalAction::SearchCommit),
+            KeyCode::Backspace => Some(JournalAction::SearchBackspace),
+            KeyCode::Char('u') if has_ctrl => Some(JournalAction::SearchClear),
+            KeyCode::Up => Some(JournalAction::MoveUp),
+            KeyCode::Down => Some(JournalAction::MoveDown),
+            KeyCode::Char(c) if !has_ctrl && !has_alt => Some(JournalAction::SearchInsert(c)),
+            _ => None,
+        };
+    }
+
+    match key.code {
         KeyCode::Esc | KeyCode::Char('q') => Some(JournalAction::ToNormal),
         KeyCode::Tab => Some(JournalAction::FilterNext),
         KeyCode::BackTab => Some(JournalAction::FilterPrev),
         KeyCode::Up | KeyCode::Char('k') => Some(JournalAction::MoveUp),
         KeyCode::Down | KeyCode::Char('j') => Some(JournalAction::MoveDown),
         KeyCode::Char('Y') => Some(JournalAction::ReplaySelected),
+        KeyCode::Char('/') => Some(JournalAction::SearchStart),
         _ => None,
     }
 }
@@ -67,7 +100,9 @@ fn handle_event_inner(
         return;
     };
 
-    let Some(action) = map_key_to_journal_action(key.code, key.kind) else {
+    let search_panel_active =
+        app_state.ui.journal.is_searching || !app_state.ui.journal.search_query.is_empty();
+    let Some(action) = map_key_to_journal_action(key, search_panel_active) else {
         return;
     };
 
@@ -96,6 +131,38 @@ fn handle_event_inner(
         }
         JournalAction::ReplaySelected => {
             replay_selected_entry(app_state, app_command_tx, shutdown_tx)
+        }
+        JournalAction::SearchStart => {
+            app_state.ui.journal.is_searching = true;
+            app_state.ui.journal.search_mode = SearchMode::Regex;
+            app_state.ui.journal.selected_index = 0;
+        }
+        JournalAction::SearchInsert(c) => {
+            app_state.ui.journal.search_query.push(c);
+            app_state.ui.journal.selected_index = 0;
+        }
+        JournalAction::SearchBackspace => {
+            app_state.ui.journal.search_query.pop();
+            app_state.ui.journal.selected_index = 0;
+        }
+        JournalAction::SearchClear => {
+            app_state.ui.journal.search_query.clear();
+            app_state.ui.journal.selected_index = 0;
+        }
+        JournalAction::SearchCommit => {
+            app_state.ui.journal.is_searching = false;
+        }
+        JournalAction::SearchCancel => {
+            app_state.ui.journal.is_searching = false;
+            app_state.ui.journal.search_query.clear();
+            app_state.ui.journal.selected_index = 0;
+        }
+        JournalAction::ToggleSearchMode => {
+            app_state.ui.journal.search_mode = match app_state.ui.journal.search_mode {
+                SearchMode::Fuzzy => SearchMode::Regex,
+                SearchMode::Regex => SearchMode::Fuzzy,
+            };
+            app_state.ui.journal.selected_index = 0;
         }
     }
 }
@@ -127,14 +194,12 @@ struct ActivityKey<'a> {
 #[derive(Debug)]
 struct JournalActivity<'a> {
     entries: Vec<&'a EventJournalEntry>,
-    latest_position: usize,
 }
 
 impl<'a> JournalActivity<'a> {
-    fn new(entry: &'a EventJournalEntry, position: usize) -> Self {
+    fn new(entry: &'a EventJournalEntry) -> Self {
         Self {
             entries: vec![entry],
-            latest_position: position,
         }
     }
 
@@ -150,15 +215,6 @@ impl<'a> JournalActivity<'a> {
             .iter()
             .rev()
             .find(|entry| entry.source_path.is_some() || entry.source_watch_folder.is_some())
-            .copied()
-            .unwrap_or_else(|| self.latest())
-    }
-
-    fn torrent_entry(&self) -> &'a EventJournalEntry {
-        self.entries
-            .iter()
-            .rev()
-            .find(|entry| entry.torrent_name.is_some() || entry.info_hash_hex.is_some())
             .copied()
             .unwrap_or_else(|| self.latest())
     }
@@ -203,36 +259,81 @@ fn activity_key(entry: &EventJournalEntry) -> Option<ActivityKey<'_>> {
 
 fn journal_activities(app_state: &AppState) -> Vec<JournalActivity<'_>> {
     let mut activities = Vec::<JournalActivity<'_>>::new();
-    let mut open_activities = HashMap::<ActivityKey<'_>, Vec<usize>>::new();
+    let mut pending_terminal_activities = HashMap::<ActivityKey<'_>, Vec<usize>>::new();
 
-    for (position, entry) in app_state.event_journal_state.entries.iter().enumerate() {
+    for entry in app_state.event_journal_state.entries.iter().rev() {
         if !entry_matches_filter(entry, app_state.ui.journal.filter) {
             continue;
         }
 
         match (activity_phase(entry), activity_key(entry)) {
-            (ActivityPhase::Queued, Some(key)) => {
-                let activity_index = activities.len();
-                activities.push(JournalActivity::new(entry, position));
-                open_activities.entry(key).or_default().push(activity_index);
-            }
             (ActivityPhase::Terminal, Some(key)) => {
-                let open_activity = open_activities
+                let activity_index = activities.len();
+                activities.push(JournalActivity::new(entry));
+                pending_terminal_activities
+                    .entry(key)
+                    .or_default()
+                    .push(activity_index);
+            }
+            (ActivityPhase::Queued, Some(key)) => {
+                let terminal_activity = pending_terminal_activities
                     .get_mut(&key)
                     .and_then(|activity_indices| activity_indices.pop());
-                if let Some(activity_index) = open_activity {
-                    activities[activity_index].entries.push(entry);
-                    activities[activity_index].latest_position = position;
+                if let Some(activity_index) = terminal_activity {
+                    activities[activity_index].entries.insert(0, entry);
                 } else {
-                    activities.push(JournalActivity::new(entry, position));
+                    activities.push(JournalActivity::new(entry));
                 }
             }
-            _ => activities.push(JournalActivity::new(entry, position)),
+            _ => activities.push(JournalActivity::new(entry)),
         }
     }
 
-    activities.sort_by_key(|activity| std::cmp::Reverse(activity.latest_position));
+    let query = app_state.ui.journal.search_query.trim();
+    if !query.is_empty() {
+        match app_state.ui.journal.search_mode {
+            SearchMode::Fuzzy => {
+                let matcher = SkimMatcherV2::default();
+                let query = query.to_lowercase();
+                activities.retain(|activity| {
+                    matcher
+                        .fuzzy_match(&activity_search_haystack(activity).to_lowercase(), &query)
+                        .is_some()
+                });
+            }
+            SearchMode::Regex => {
+                let regex = regex::RegexBuilder::new(query)
+                    .case_insensitive(true)
+                    .build();
+                if let Ok(regex) = regex {
+                    activities
+                        .retain(|activity| regex.is_match(&activity_search_haystack(activity)));
+                } else {
+                    activities.clear();
+                }
+            }
+        }
+    }
     activities
+}
+
+fn activity_search_haystack(activity: &JournalActivity<'_>) -> String {
+    activity
+        .entries
+        .iter()
+        .flat_map(|entry| {
+            [
+                event_type_label(entry).to_string(),
+                command_action_label(entry),
+                torrent_label(entry, false),
+                source_label(entry, false),
+                detail_text(Some(entry), false),
+                entry.host_id.clone().unwrap_or_default(),
+                entry.info_hash_hex.clone().unwrap_or_default(),
+            ]
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn event_type_label(entry: &EventJournalEntry) -> &'static str {
@@ -285,36 +386,6 @@ fn torrent_label(entry: &EventJournalEntry, anonymize: bool) -> String {
         .torrent_name
         .as_ref()
         .map(|name| sanitize_text(name))
-        .unwrap_or_else(|| "-".to_string())
-}
-
-fn live_completion_percent(entry: &EventJournalEntry, app_state: &AppState) -> Option<f64> {
-    if let Some(info_hash_hex) = entry.info_hash_hex.as_deref() {
-        if let Some(display) = app_state
-            .torrents
-            .iter()
-            .find(|(info_hash, _)| hex::encode(info_hash.as_slice()) == info_hash_hex)
-            .map(|(_, display)| display)
-        {
-            return Some(crate::app::torrent_completion_percent(
-                &display.latest_state,
-            ));
-        }
-    }
-
-    entry.torrent_name.as_ref().and_then(|torrent_name| {
-        app_state
-            .torrents
-            .values()
-            .filter(|display| display.latest_state.torrent_name == *torrent_name)
-            .map(|display| crate::app::torrent_completion_percent(&display.latest_state))
-            .max_by(|left, right| left.total_cmp(right))
-    })
-}
-
-fn progress_label(entry: &EventJournalEntry, app_state: &AppState) -> String {
-    live_completion_percent(entry, app_state)
-        .map(|pct| format!("{pct:.0}%"))
         .unwrap_or_else(|| "-".to_string())
 }
 
@@ -476,40 +547,24 @@ enum JournalColumn {
     Time,
     Status,
     Subject,
-    Done,
-    Source,
 }
 
-fn columns_for_filter(filter: JournalFilter) -> Vec<JournalColumn> {
-    match filter {
-        JournalFilter::All => vec![
-            JournalColumn::Time,
-            JournalColumn::Status,
-            JournalColumn::Subject,
-            JournalColumn::Done,
-            JournalColumn::Source,
-        ],
-        JournalFilter::Queue => vec![
-            JournalColumn::Time,
-            JournalColumn::Status,
-            JournalColumn::Subject,
-            JournalColumn::Done,
-            JournalColumn::Source,
-        ],
-        JournalFilter::Commands => {
-            vec![
-                JournalColumn::Time,
-                JournalColumn::Status,
-                JournalColumn::Subject,
-                JournalColumn::Source,
-            ]
-        }
-        JournalFilter::Health => vec![
-            JournalColumn::Time,
-            JournalColumn::Status,
-            JournalColumn::Subject,
-        ],
-    }
+fn columns_for_filter(_filter: JournalFilter) -> Vec<JournalColumn> {
+    vec![
+        JournalColumn::Time,
+        JournalColumn::Status,
+        JournalColumn::Subject,
+    ]
+}
+
+fn journal_table_window(len: usize, selected_index: usize, table_height: u16) -> (usize, usize) {
+    let capacity = usize::from(table_height.saturating_sub(1).max(1));
+    let end = if selected_index < capacity {
+        capacity.min(len)
+    } else {
+        selected_index.saturating_add(1).min(len)
+    };
+    (end.saturating_sub(capacity), end)
 }
 
 fn column_header(column: JournalColumn, filter: JournalFilter) -> &'static str {
@@ -518,20 +573,7 @@ fn column_header(column: JournalColumn, filter: JournalFilter) -> &'static str {
         (JournalColumn::Subject, _) => "Torrent",
         (JournalColumn::Time, _) => "Time",
         (JournalColumn::Status, _) => "Status",
-        (JournalColumn::Done, _) => "Done",
-        (JournalColumn::Source, _) => "Source",
     }
-}
-
-fn visible_columns(filter: JournalFilter, width: u16) -> Vec<JournalColumn> {
-    columns_for_filter(filter)
-        .into_iter()
-        .filter(|column| match column {
-            JournalColumn::Source => width >= 96,
-            JournalColumn::Done => width >= 76,
-            _ => true,
-        })
-        .collect()
 }
 
 fn column_header_style(column: JournalColumn, ctx: &ThemeContext) -> Style {
@@ -539,8 +581,6 @@ fn column_header_style(column: JournalColumn, ctx: &ThemeContext) -> Style {
         JournalColumn::Time => ctx.theme.semantic.subtext0,
         JournalColumn::Status => ctx.state_warning(),
         JournalColumn::Subject => ctx.accent_sky(),
-        JournalColumn::Done => ctx.state_success(),
-        JournalColumn::Source => ctx.accent_sapphire(),
     };
     ctx.apply(Style::default().fg(color).bold())
 }
@@ -550,8 +590,6 @@ fn column_constraint(column: JournalColumn, filter: JournalFilter) -> Constraint
         (_, JournalColumn::Time) => Constraint::Length(13),
         (_, JournalColumn::Status) => Constraint::Length(22),
         (_, JournalColumn::Subject) => Constraint::Fill(1),
-        (_, JournalColumn::Done) => Constraint::Length(7),
-        (_, JournalColumn::Source) => Constraint::Length(22),
     }
 }
 
@@ -605,20 +643,31 @@ fn activity_status_cell(activity: &JournalActivity<'_>, ctx: &ThemeContext) -> C
 fn activity_subject_label(activity: &JournalActivity<'_>, anonymize: bool) -> String {
     let entry = activity.latest();
     if matches!(entry.category, EventCategory::Control) {
-        command_action_label(entry)
-    } else {
-        torrent_label(activity.torrent_entry(), anonymize)
+        return command_action_label(entry);
     }
-}
 
-fn activity_progress_label(activity: &JournalActivity<'_>, app_state: &AppState) -> String {
+    if anonymize {
+        return "Torrent".to_string();
+    }
+
     activity
         .entries
         .iter()
         .rev()
-        .find(|entry| live_completion_percent(entry, app_state).is_some())
-        .map(|entry| progress_label(entry, app_state))
-        .unwrap_or_else(|| "-".to_string())
+        .filter_map(|entry| entry.torrent_name.as_deref())
+        .find(|name| !name.trim().is_empty())
+        .map(sanitize_text)
+        .or_else(|| {
+            let source = activity.source_entry();
+            source
+                .source_path
+                .as_deref()
+                .or(source.source_watch_folder.as_deref())
+                .and_then(Path::file_name)
+                .map(|name| sanitize_text(&name.to_string_lossy()))
+        })
+        .filter(|label| !label.trim().is_empty())
+        .unwrap_or_else(|| "Pending metadata".to_string())
 }
 
 fn column_cell(
@@ -636,13 +685,6 @@ fn column_cell(
             app_state.anonymize_torrent_names,
         ))
         .style(ctx.apply(Style::default().fg(ctx.theme.semantic.text))),
-        JournalColumn::Done => Cell::from(activity_progress_label(activity, app_state))
-            .style(ctx.apply(Style::default().fg(ctx.state_success()).bold())),
-        JournalColumn::Source => Cell::from(source_label(
-            activity.source_entry(),
-            app_state.anonymize_torrent_names,
-        ))
-        .style(ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1))),
     }
 }
 
@@ -708,20 +750,33 @@ fn activity_detail_lines(
 pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
     let app_state = screen.app.state;
     let ctx = screen.theme;
-    let area = f.area();
-    let popup = crate::tui::formatters::centered_rect(94, 94, area);
-    let popup_layout = ratatui::layout::Layout::vertical([
+    let activities = journal_activities(app_state);
+    let search_panel_active =
+        app_state.ui.journal.is_searching || !app_state.ui.journal.search_query.is_empty();
+    let area = centered_rect(88, 94, f.area());
+    f.render_widget(Clear, area);
+
+    let (search_area, journal_area) = if search_panel_active && area.height >= 7 {
+        let chunks = ratatui::layout::Layout::vertical([Constraint::Length(3), Constraint::Min(1)])
+            .split(area);
+        (Some(chunks[0]), chunks[1])
+    } else {
+        (None, area)
+    };
+    if let Some(search_area) = search_area {
+        draw_journal_search_panel(f, search_area, app_state, activities.len(), ctx);
+    }
+
+    let layout = ratatui::layout::Layout::vertical([
         Constraint::Length(1),
-        Constraint::Min(0),
+        Constraint::Min(1),
         Constraint::Length(1),
     ])
-    .split(popup);
-    let filter_area = popup_layout[0];
-    let panel_area = popup_layout[1];
-    let footer_area = popup_layout[2];
-    f.render_widget(Clear, popup);
+    .split(journal_area);
+    let header_area = layout[0];
+    let panel_area = layout[1];
+    let footer_area = layout[2];
 
-    let activities = journal_activities(app_state);
     let entry_count = activities
         .iter()
         .map(|activity| activity.entries.len())
@@ -736,11 +791,6 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
     } else {
         format!("{activity_label} · {entry_count} records")
     };
-    let count_width = u16::try_from(count_label.chars().count()).unwrap_or(u16::MAX);
-    let header_areas =
-        ratatui::layout::Layout::horizontal([Constraint::Min(0), Constraint::Length(count_width)])
-            .split(filter_area);
-
     let filter_spans = [
         JournalFilter::All,
         JournalFilter::Queue,
@@ -750,41 +800,41 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
     .iter()
     .enumerate()
     .flat_map(|(index, filter)| {
+        let color = journal_filter_color(*filter, ctx);
         let style = if *filter == app_state.ui.journal.filter {
-            ctx.apply(
-                Style::default()
-                    .fg(ctx.state_warning())
-                    .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
-            )
+            ctx.apply(Style::default().fg(color).add_modifier(Modifier::BOLD))
         } else {
-            ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0))
+            ctx.apply(Style::default().fg(color))
         };
         let mut spans = vec![Span::styled(filter.label(), style)];
         if index < 3 {
-            spans.push(Span::raw("   "));
+            spans.push(Span::raw("  "));
         }
         spans
     })
     .collect::<Vec<_>>();
+
     f.render_widget(
         Paragraph::new(Line::from(filter_spans)).alignment(Alignment::Center),
-        header_areas[0],
+        header_area,
     );
     f.render_widget(
         Paragraph::new(count_label)
             .alignment(Alignment::Right)
             .style(ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1))),
-        header_areas[1],
+        header_area,
     );
 
-    let panel = Block::default()
-        .title(Span::styled(
-            " Event Journal ",
-            ctx.apply(Style::default().fg(ctx.state_selected()).bold()),
-        ))
+    let mut panel = Block::default()
         .borders(Borders::ALL)
         .border_style(ctx.apply(Style::default().fg(ctx.theme.semantic.border)))
         .padding(Padding::new(2, 2, 0, 0));
+    if let Some(message) = &app_state.ui.journal.status_message {
+        panel = panel.title_bottom(Span::styled(
+            format!(" {} ", sanitize_text(message)),
+            ctx.apply(Style::default().fg(ctx.state_warning()).bold()),
+        ));
+    }
     let inner = panel.inner(panel_area);
     f.render_widget(panel, panel_area);
 
@@ -792,24 +842,29 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
         return;
     }
 
+    let selected_index = app_state
+        .ui
+        .journal
+        .selected_index
+        .min(activities.len().saturating_sub(1));
+    let selected_activity = activities.get(selected_index);
+    let detail_lines = activity_detail_lines(selected_activity, app_state, ctx, inner.width);
+    let detail_height = u16::try_from(detail_lines.len())
+        .unwrap_or(u16::MAX)
+        .min(4)
+        .min(inner.height.saturating_sub(4));
+    let spacer_height = u16::from(detail_height > 0);
     let rows = ratatui::layout::Layout::vertical([
-        Constraint::Length(1),
-        Constraint::Min(5),
-        Constraint::Length(1),
-        Constraint::Length(4),
+        Constraint::Min(3),
+        Constraint::Length(spacer_height),
+        Constraint::Length(detail_height),
     ])
     .split(inner);
 
-    if let Some(message) = &app_state.ui.journal.status_message {
-        f.render_widget(
-            Paragraph::new(sanitize_text(message))
-                .style(ctx.apply(Style::default().fg(ctx.state_warning()))),
-            rows[0],
-        );
-    }
-
-    let columns = visible_columns(app_state.ui.journal.filter, rows[1].width);
-    let body_rows = activities
+    let columns = columns_for_filter(app_state.ui.journal.filter);
+    let (window_start, window_end) =
+        journal_table_window(activities.len(), selected_index, rows[0].height);
+    let body_rows = activities[window_start..window_end]
         .iter()
         .map(|activity| {
             Row::new(
@@ -819,7 +874,6 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
                     .map(|column| column_cell(column, activity, app_state, ctx))
                     .collect::<Vec<_>>(),
             )
-            .bottom_margin(1)
         })
         .collect::<Vec<_>>();
 
@@ -836,44 +890,36 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
         .collect::<Vec<_>>();
 
     let table = Table::new(body_rows, constraints)
-        .header(Row::new(header_cells).bottom_margin(1))
-        .column_spacing(2)
+        .header(Row::new(header_cells))
+        .column_spacing(1)
         .row_highlight_style(
             ctx.apply(
                 Style::default()
                     .fg(ctx.state_warning())
                     .add_modifier(Modifier::BOLD),
             ),
-        )
-        .highlight_symbol("▌ ");
+        );
 
-    let selected_index = app_state
-        .ui
-        .journal
-        .selected_index
-        .min(activities.len().saturating_sub(1));
     let mut table_state = TableState::default();
     if !activities.is_empty() {
-        table_state.select(Some(selected_index));
+        table_state.select(Some(selected_index.saturating_sub(window_start)));
     }
-    f.render_stateful_widget(table, rows[1], &mut table_state);
+    f.render_stateful_widget(table, rows[0], &mut table_state);
 
-    let selected_activity = activities.get(selected_index);
-    f.render_widget(
-        Paragraph::new(activity_detail_lines(
-            selected_activity,
-            app_state,
-            ctx,
-            rows[3].width,
-        ))
-        .alignment(Alignment::Left),
-        rows[3],
-    );
+    if detail_height > 0 {
+        f.render_widget(
+            Paragraph::new(detail_lines).alignment(Alignment::Left),
+            rows[2],
+        );
+    }
 
     let mut footer_spans = Vec::new();
     let mut push_action = |key: &str, label: &str, tone: ActionTone| {
         if !footer_spans.is_empty() {
-            footer_spans.push(Span::raw("   "));
+            footer_spans.push(Span::styled(
+                " | ",
+                ctx.apply(Style::default().fg(ctx.theme.semantic.overlay0)),
+            ));
         }
         footer_spans.push(Span::styled(
             format!("[{key}]"),
@@ -884,18 +930,76 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
             ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0)),
         ));
     };
-    push_action("↑/↓", "nav", ActionTone::Navigate);
-    push_action("Tab", "filter", ActionTone::Mode);
-    push_action("Shift+Y", "replay", ActionTone::Replay);
-    push_action("Esc", "back", ActionTone::Cancel);
+    if search_panel_active {
+        push_action("type", "query", ActionTone::Edit);
+        push_action("Tab", "mode", ActionTone::Mode);
+        push_action("Enter", "keep", ActionTone::Confirm);
+        push_action("Esc", "clear", ActionTone::Cancel);
+        push_action("↑/↓", "nav", ActionTone::Navigate);
+    } else {
+        push_action("Esc", "back", ActionTone::Cancel);
+        push_action("Tab", "filter", ActionTone::Mode);
+        push_action("/", "search", ActionTone::Search);
+        push_action("↑/↓", "nav", ActionTone::Navigate);
+        push_action("Shift+Y", "replay", ActionTone::Replay);
+    }
     let footer_hint = Paragraph::new(Line::from(footer_spans)).alignment(Alignment::Center);
     f.render_widget(footer_hint, footer_area);
+}
+
+fn journal_filter_color(filter: JournalFilter, ctx: &ThemeContext) -> ratatui::style::Color {
+    match filter {
+        JournalFilter::All => ctx.state_selected(),
+        JournalFilter::Queue => ctx.state_warning(),
+        JournalFilter::Commands => ctx.accent_sapphire(),
+        JournalFilter::Health => ctx.state_success(),
+    }
+}
+
+fn draw_journal_search_panel(
+    f: &mut Frame,
+    area: ratatui::prelude::Rect,
+    app_state: &AppState,
+    visible_count: usize,
+    ctx: &ThemeContext,
+) {
+    let mut trailing_spans = journal_search_mode_spans(app_state, ctx);
+    trailing_spans.push(Span::styled(
+        format!("  {visible_count} matches"),
+        ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0)),
+    ));
+    draw_prompt_panel(
+        f,
+        area,
+        " Journal Search ".to_string(),
+        sanitize_text(&app_state.ui.journal.search_query),
+        trailing_spans,
+        ctx,
+    );
+}
+
+fn journal_search_mode_spans(app_state: &AppState, ctx: &ThemeContext) -> Vec<Span<'static>> {
+    let (fuzzy_style, regex_style) = match app_state.ui.journal.search_mode {
+        SearchMode::Fuzzy => (
+            ctx.apply(Style::default().fg(ctx.state_selected()).bold()),
+            ctx.apply(Style::default().fg(ctx.theme.semantic.overlay0)),
+        ),
+        SearchMode::Regex => (
+            ctx.apply(Style::default().fg(ctx.theme.semantic.overlay0)),
+            ctx.apply(Style::default().fg(ctx.state_selected()).bold()),
+        ),
+    };
+    vec![
+        Span::raw("  "),
+        Span::styled("Fuzzy", fuzzy_style),
+        Span::raw(" / "),
+        Span::styled("Regex", regex_style),
+    ]
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{TorrentDisplayState, TorrentMetrics};
     use crate::config::Settings;
     use crate::dht_service::{DhtStatus, DhtWaveTelemetry};
     use crate::persistence::event_journal::{EventCategory, EventJournalState, EventScope};
@@ -1005,6 +1109,55 @@ mod tests {
     }
 
     #[test]
+    fn journal_search_filters_activities_and_toggles_mode() {
+        let mut app_state = base_state();
+        let (tx, _rx) = mpsc::channel(1);
+
+        handle_event(
+            CrosstermEvent::Key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE)),
+            &mut app_state,
+            &tx,
+        );
+        for character in "sample beta".chars() {
+            handle_event(
+                CrosstermEvent::Key(KeyEvent::new(KeyCode::Char(character), KeyModifiers::NONE)),
+                &mut app_state,
+                &tx,
+            );
+        }
+
+        assert!(app_state.ui.journal.is_searching);
+        assert_eq!(app_state.ui.journal.search_mode, SearchMode::Regex);
+        assert_eq!(journal_activities(&app_state).len(), 1);
+        assert_eq!(journal_activities(&app_state)[0].latest().id, 2);
+
+        handle_event(
+            CrosstermEvent::Key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
+            &mut app_state,
+            &tx,
+        );
+        assert_eq!(app_state.ui.journal.search_mode, SearchMode::Fuzzy);
+    }
+
+    #[test]
+    fn journal_escape_clears_search_before_closing() {
+        let mut app_state = base_state();
+        let (tx, _rx) = mpsc::channel(1);
+        app_state.ui.journal.is_searching = true;
+        app_state.ui.journal.search_query = "sample".to_string();
+
+        handle_event(
+            CrosstermEvent::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+            &mut app_state,
+            &tx,
+        );
+
+        assert!(matches!(app_state.mode, AppMode::Journal));
+        assert!(!app_state.ui.journal.is_searching);
+        assert!(app_state.ui.journal.search_query.is_empty());
+    }
+
+    #[test]
     fn filter_selection_matches_requested_groups() {
         let mut app_state = base_state();
 
@@ -1059,6 +1212,48 @@ mod tests {
         assert_eq!(
             activity_subject_label(&activities[0], false),
             "Sample Delta"
+        );
+    }
+
+    #[test]
+    fn queued_activity_without_metadata_uses_source_filename_as_subject() {
+        let mut app_state = base_state();
+        app_state.ui.journal.filter = JournalFilter::Queue;
+        app_state.event_journal_state.entries = vec![EventJournalEntry {
+            id: 12,
+            category: EventCategory::Ingest,
+            event_type: EventType::IngestQueued,
+            source_path: Some(Path::new("/watch/pending-item.magnet").to_path_buf()),
+            correlation_id: Some("pending-source".to_string()),
+            ..Default::default()
+        }];
+
+        let activities = journal_activities(&app_state);
+
+        assert_eq!(activities.len(), 1);
+        assert_eq!(
+            activity_subject_label(&activities[0], false),
+            "pending-item.magnet"
+        );
+    }
+
+    #[test]
+    fn activity_without_name_or_source_uses_pending_metadata_label() {
+        let mut app_state = base_state();
+        app_state.ui.journal.filter = JournalFilter::Queue;
+        app_state.event_journal_state.entries = vec![EventJournalEntry {
+            id: 13,
+            category: EventCategory::Ingest,
+            event_type: EventType::IngestQueued,
+            ..Default::default()
+        }];
+
+        let activities = journal_activities(&app_state);
+
+        assert_eq!(activities.len(), 1);
+        assert_eq!(
+            activity_subject_label(&activities[0], false),
+            "Pending metadata"
         );
     }
 
@@ -1250,6 +1445,15 @@ mod tests {
     }
 
     #[test]
+    fn table_window_builds_only_the_visible_rows_around_selection() {
+        assert_eq!(journal_table_window(100, 0, 6), (0, 5));
+        assert_eq!(journal_table_window(100, 4, 6), (0, 5));
+        assert_eq!(journal_table_window(100, 5, 6), (1, 6));
+        assert_eq!(journal_table_window(100, 73, 6), (69, 74));
+        assert_eq!(journal_table_window(3, 2, 6), (0, 3));
+    }
+
+    #[test]
     fn grouped_activity_renders_once_and_keeps_both_stage_details() {
         let mut app_state = base_state();
         app_state.ui.journal.filter = JournalFilter::Queue;
@@ -1342,29 +1546,6 @@ mod tests {
     }
 
     #[test]
-    fn progress_label_uses_live_torrent_metrics_when_info_hash_matches() {
-        let mut app_state = base_state();
-        let info_hash = vec![0x11; 20];
-        app_state.event_journal_state.entries[0].info_hash_hex = Some(hex::encode(&info_hash));
-        app_state.torrents.insert(
-            info_hash,
-            TorrentDisplayState {
-                latest_state: TorrentMetrics {
-                    number_of_pieces_total: 10,
-                    number_of_pieces_completed: 4,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-        );
-
-        assert_eq!(
-            progress_label(&app_state.event_journal_state.entries[0], &app_state),
-            "40%"
-        );
-    }
-
-    #[test]
     fn anonymized_journal_hides_torrent_names_and_paths() {
         let entry = EventJournalEntry {
             torrent_name: Some("Sample Alpha".to_string()),
@@ -1400,7 +1581,7 @@ mod tests {
         };
 
         assert_eq!(command_action_label(&entry), "pause");
-        assert_eq!(columns_for_filter(JournalFilter::Commands).len(), 4);
+        assert_eq!(columns_for_filter(JournalFilter::Commands).len(), 3);
         assert_eq!(
             column_header(
                 columns_for_filter(JournalFilter::Commands)[1],
@@ -1415,23 +1596,19 @@ mod tests {
             ),
             "Action"
         );
-        assert_eq!(
-            column_header(
-                columns_for_filter(JournalFilter::Commands)[3],
-                JournalFilter::Commands
-            ),
-            "Source"
-        );
         assert_eq!(command_action_label(&entry), "pause");
     }
 
     #[test]
-    fn health_filter_hides_source_column() {
-        let columns = columns_for_filter(JournalFilter::Health);
-        assert_eq!(columns.len(), 3);
-        assert!(columns
-            .iter()
-            .all(|column| !matches!(column, JournalColumn::Source)));
+    fn every_filter_uses_the_same_three_core_columns() {
+        for filter in [
+            JournalFilter::All,
+            JournalFilter::Queue,
+            JournalFilter::Commands,
+            JournalFilter::Health,
+        ] {
+            assert_eq!(columns_for_filter(filter).len(), 3);
+        }
     }
 
     #[test]

--- a/src/tui/screens/journal.rs
+++ b/src/tui/screens/journal.rs
@@ -10,7 +10,7 @@ use crate::tui::action_style::{footer_key_style, ActionTone};
 use crate::tui::app_command::spawn_app_command_sender;
 use crate::tui::formatters::{centered_rect, sanitize_text, truncate_with_ellipsis};
 use crate::tui::screen_context::ScreenContext;
-use crate::tui::screens::input_panel::draw_prompt_panel;
+use crate::tui::screens::input_panel::draw_prompt_panel_with_cursor;
 use chrono::{DateTime, Local, Utc};
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
@@ -20,6 +20,7 @@ use ratatui::crossterm::event::{
 use ratatui::prelude::{Alignment, Constraint, Frame, Line, Modifier, Rect, Span, Style};
 use ratatui::widgets::{Block, Borders, Cell, Clear, Padding, Paragraph, Row, Table, TableState};
 use std::collections::HashMap;
+use std::fmt::Write;
 use std::path::{Component, Path};
 use tokio::sync::{broadcast, mpsc};
 
@@ -42,7 +43,7 @@ enum JournalAction {
     ToggleSearchMode,
 }
 
-fn map_key_to_journal_action(key: KeyEvent, search_panel_active: bool) -> Option<JournalAction> {
+fn map_key_to_journal_action(key: KeyEvent, search_editing: bool) -> Option<JournalAction> {
     if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
         return None;
     }
@@ -50,11 +51,11 @@ fn map_key_to_journal_action(key: KeyEvent, search_panel_active: bool) -> Option
     let has_ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
     let has_alt = key.modifiers.contains(KeyModifiers::ALT);
 
-    if search_panel_active && matches!(key.code, KeyCode::Tab) {
+    if search_editing && matches!(key.code, KeyCode::Tab) {
         return Some(JournalAction::ToggleSearchMode);
     }
 
-    if search_panel_active {
+    if search_editing {
         return match key.code {
             KeyCode::Esc => Some(JournalAction::SearchCancel),
             KeyCode::Enter => Some(JournalAction::SearchCommit),
@@ -106,9 +107,7 @@ fn handle_event_inner(
         return;
     };
 
-    let search_panel_active =
-        app_state.ui.journal.is_searching || !app_state.ui.journal.search_query.is_empty();
-    let Some(action) = map_key_to_journal_action(key, search_panel_active) else {
+    let Some(action) = map_key_to_journal_action(key, app_state.ui.journal.is_searching) else {
         return;
     };
 
@@ -119,20 +118,38 @@ fn handle_event_inner(
         JournalAction::FilterNext => {
             app_state.ui.journal.filter = app_state.ui.journal.filter.next();
             app_state.ui.journal.selected_index = 0;
+            app_state.ui.journal.scroll_offset = 0;
         }
         JournalAction::FilterPrev => {
             app_state.ui.journal.filter = app_state.ui.journal.filter.prev();
             app_state.ui.journal.selected_index = 0;
+            app_state.ui.journal.scroll_offset = 0;
         }
         JournalAction::MoveUp => {
             app_state.ui.journal.selected_index =
                 app_state.ui.journal.selected_index.saturating_sub(1);
+            app_state.ui.journal.scroll_offset = app_state
+                .ui
+                .journal
+                .scroll_offset
+                .min(app_state.ui.journal.selected_index);
         }
         JournalAction::MoveDown => {
             let len = journal_activities(app_state).len();
             if len > 0 {
+                let page_rows = journal_page_rows(app_state);
                 app_state.ui.journal.selected_index =
                     (app_state.ui.journal.selected_index + 1).min(len - 1);
+                if app_state.ui.journal.selected_index
+                    >= app_state.ui.journal.scroll_offset.saturating_add(page_rows)
+                {
+                    app_state.ui.journal.scroll_offset = app_state
+                        .ui
+                        .journal
+                        .selected_index
+                        .saturating_add(1)
+                        .saturating_sub(page_rows);
+                }
             }
         }
         JournalAction::MovePageUp => {
@@ -142,6 +159,12 @@ fn handle_event_inner(
                 .journal
                 .selected_index
                 .saturating_sub(page_rows);
+            app_state.ui.journal.scroll_offset = app_state
+                .ui
+                .journal
+                .scroll_offset
+                .saturating_sub(page_rows)
+                .min(app_state.ui.journal.selected_index);
         }
         JournalAction::MovePageDown => {
             let len = journal_activities(app_state).len();
@@ -153,6 +176,12 @@ fn handle_event_inner(
                     .selected_index
                     .saturating_add(page_rows)
                     .min(len - 1);
+                app_state.ui.journal.scroll_offset = app_state
+                    .ui
+                    .journal
+                    .scroll_offset
+                    .saturating_add(page_rows)
+                    .min(len.saturating_sub(page_rows));
             }
         }
         JournalAction::ReplaySelected => {
@@ -162,18 +191,22 @@ fn handle_event_inner(
             app_state.ui.journal.is_searching = true;
             app_state.ui.journal.search_mode = SearchMode::Regex;
             app_state.ui.journal.selected_index = 0;
+            app_state.ui.journal.scroll_offset = 0;
         }
         JournalAction::SearchInsert(c) => {
             app_state.ui.journal.search_query.push(c);
             app_state.ui.journal.selected_index = 0;
+            app_state.ui.journal.scroll_offset = 0;
         }
         JournalAction::SearchBackspace => {
             app_state.ui.journal.search_query.pop();
             app_state.ui.journal.selected_index = 0;
+            app_state.ui.journal.scroll_offset = 0;
         }
         JournalAction::SearchClear => {
             app_state.ui.journal.search_query.clear();
             app_state.ui.journal.selected_index = 0;
+            app_state.ui.journal.scroll_offset = 0;
         }
         JournalAction::SearchCommit => {
             app_state.ui.journal.is_searching = false;
@@ -182,6 +215,7 @@ fn handle_event_inner(
             app_state.ui.journal.is_searching = false;
             app_state.ui.journal.search_query.clear();
             app_state.ui.journal.selected_index = 0;
+            app_state.ui.journal.scroll_offset = 0;
         }
         JournalAction::ToggleSearchMode => {
             app_state.ui.journal.search_mode = match app_state.ui.journal.search_mode {
@@ -189,8 +223,10 @@ fn handle_event_inner(
                 SearchMode::Regex => SearchMode::Fuzzy,
             };
             app_state.ui.journal.selected_index = 0;
+            app_state.ui.journal.scroll_offset = 0;
         }
     }
+    app_state.ui.needs_redraw = true;
 }
 
 fn entry_matches_filter(entry: &EventJournalEntry, filter: JournalFilter) -> bool {
@@ -219,29 +255,45 @@ struct ActivityKey<'a> {
 
 #[derive(Debug)]
 struct JournalActivity<'a> {
-    entries: Vec<&'a EventJournalEntry>,
+    first: &'a EventJournalEntry,
+    second: Option<&'a EventJournalEntry>,
 }
 
 impl<'a> JournalActivity<'a> {
     fn new(entry: &'a EventJournalEntry) -> Self {
         Self {
-            entries: vec![entry],
+            first: entry,
+            second: None,
         }
     }
 
+    fn prepend(&mut self, entry: &'a EventJournalEntry) {
+        debug_assert!(self.second.is_none());
+        self.second = Some(self.first);
+        self.first = entry;
+    }
+
+    fn entries(&self) -> impl DoubleEndedIterator<Item = &'a EventJournalEntry> {
+        [Some(self.first), self.second].into_iter().flatten()
+    }
+
+    fn len(&self) -> usize {
+        1 + usize::from(self.second.is_some())
+    }
+
+    #[cfg(test)]
+    fn entry(&self, index: usize) -> Option<&'a EventJournalEntry> {
+        self.entries().nth(index)
+    }
+
     fn latest(&self) -> &'a EventJournalEntry {
-        self.entries
-            .last()
-            .copied()
-            .expect("journal activities always contain an entry")
+        self.second.unwrap_or(self.first)
     }
 
     fn source_entry(&self) -> &'a EventJournalEntry {
-        self.entries
-            .iter()
+        self.entries()
             .rev()
             .find(|entry| entry.source_path.is_some() || entry.source_watch_folder.is_some())
-            .copied()
             .unwrap_or_else(|| self.latest())
     }
 }
@@ -285,7 +337,8 @@ fn activity_key(entry: &EventJournalEntry) -> Option<ActivityKey<'_>> {
 
 fn journal_activities(app_state: &AppState) -> Vec<JournalActivity<'_>> {
     let mut activities = Vec::<JournalActivity<'_>>::new();
-    let mut pending_terminal_activities = HashMap::<ActivityKey<'_>, Vec<usize>>::new();
+    let mut pending_terminal_activities = HashMap::<ActivityKey<'_>, usize>::new();
+    let mut previous_pending_activity = Vec::<Option<usize>>::new();
 
     for entry in app_state.event_journal_state.entries.iter().rev() {
         if !entry_matches_filter(entry, app_state.ui.journal.filter) {
@@ -296,22 +349,26 @@ fn journal_activities(app_state: &AppState) -> Vec<JournalActivity<'_>> {
             (ActivityPhase::Terminal, Some(key)) => {
                 let activity_index = activities.len();
                 activities.push(JournalActivity::new(entry));
-                pending_terminal_activities
-                    .entry(key)
-                    .or_default()
-                    .push(activity_index);
+                previous_pending_activity
+                    .push(pending_terminal_activities.insert(key, activity_index));
             }
             (ActivityPhase::Queued, Some(key)) => {
-                let terminal_activity = pending_terminal_activities
-                    .get_mut(&key)
-                    .and_then(|activity_indices| activity_indices.pop());
-                if let Some(activity_index) = terminal_activity {
-                    activities[activity_index].entries.insert(0, entry);
+                if let Some(activity_index) = pending_terminal_activities.get(&key).copied() {
+                    if let Some(previous) = previous_pending_activity[activity_index] {
+                        pending_terminal_activities.insert(key, previous);
+                    } else {
+                        pending_terminal_activities.remove(&key);
+                    }
+                    activities[activity_index].prepend(entry);
                 } else {
                     activities.push(JournalActivity::new(entry));
+                    previous_pending_activity.push(None);
                 }
             }
-            _ => activities.push(JournalActivity::new(entry)),
+            _ => {
+                activities.push(JournalActivity::new(entry));
+                previous_pending_activity.push(None);
+            }
         }
     }
 
@@ -319,11 +376,10 @@ fn journal_activities(app_state: &AppState) -> Vec<JournalActivity<'_>> {
     if !query.is_empty() {
         match app_state.ui.journal.search_mode {
             SearchMode::Fuzzy => {
-                let matcher = SkimMatcherV2::default();
-                let query = query.to_lowercase();
+                let matcher = SkimMatcherV2::default().ignore_case();
                 activities.retain(|activity| {
                     matcher
-                        .fuzzy_match(&activity_search_haystack(activity).to_lowercase(), &query)
+                        .fuzzy_match(&activity_search_haystack(activity), query)
                         .is_some()
                 });
             }
@@ -332,8 +388,7 @@ fn journal_activities(app_state: &AppState) -> Vec<JournalActivity<'_>> {
                     .case_insensitive(true)
                     .build();
                 if let Ok(regex) = regex {
-                    activities
-                        .retain(|activity| regex.is_match(&activity_search_haystack(activity)));
+                    activities.retain(|activity| activity_matches_regex(activity, &regex));
                 } else {
                     activities.clear();
                 }
@@ -344,22 +399,78 @@ fn journal_activities(app_state: &AppState) -> Vec<JournalActivity<'_>> {
 }
 
 fn activity_search_haystack(activity: &JournalActivity<'_>) -> String {
-    activity
-        .entries
-        .iter()
-        .flat_map(|entry| {
-            [
-                event_type_label(entry).to_string(),
-                command_action_label(entry),
-                torrent_label(entry, false),
-                source_label(entry, false),
-                detail_text(Some(entry), false),
-                entry.host_id.clone().unwrap_or_default(),
-                entry.info_hash_hex.clone().unwrap_or_default(),
-            ]
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
+    let mut haystack = String::with_capacity(activity.len().saturating_mul(192));
+    for entry in activity.entries() {
+        append_search_field(&mut haystack, event_type_label(entry));
+        if let EventDetails::Control { action, .. } = &entry.details {
+            append_search_field(&mut haystack, action);
+        }
+        append_search_field(&mut haystack, entry.torrent_name.as_deref().unwrap_or("-"));
+        if let Some(path) = entry
+            .source_path
+            .as_deref()
+            .or(entry.source_watch_folder.as_deref())
+        {
+            if !haystack.is_empty() {
+                haystack.push(' ');
+            }
+            let _ = write!(haystack, "{}", path.display());
+        } else {
+            append_search_field(&mut haystack, "-");
+        }
+        append_search_field(
+            &mut haystack,
+            entry.message.as_deref().unwrap_or("No details recorded."),
+        );
+        if let Some(host_id) = entry.host_id.as_deref() {
+            append_search_field(&mut haystack, host_id);
+        }
+        if let Some(info_hash) = entry.info_hash_hex.as_deref() {
+            append_search_field(&mut haystack, info_hash);
+        }
+    }
+    haystack
+}
+
+fn append_search_field(haystack: &mut String, field: &str) {
+    if field.is_empty() {
+        return;
+    }
+    if !haystack.is_empty() {
+        haystack.push(' ');
+    }
+    haystack.push_str(field);
+}
+
+fn activity_matches_regex(activity: &JournalActivity<'_>, regex: &regex::Regex) -> bool {
+    activity.entries().any(|entry| {
+        regex.is_match(event_type_label(entry))
+            || matches!(
+                &entry.details,
+                EventDetails::Control { action, .. } if regex.is_match(action)
+            )
+            || entry
+                .torrent_name
+                .as_deref()
+                .map_or_else(|| regex.is_match("-"), |name| regex.is_match(name))
+            || entry
+                .source_path
+                .as_deref()
+                .or(entry.source_watch_folder.as_deref())
+                .map_or_else(
+                    || regex.is_match("-"),
+                    |path| regex.is_match(&path.to_string_lossy()),
+                )
+            || regex.is_match(entry.message.as_deref().unwrap_or("No details recorded."))
+            || entry
+                .host_id
+                .as_deref()
+                .is_some_and(|host_id| regex.is_match(host_id))
+            || entry
+                .info_hash_hex
+                .as_deref()
+                .is_some_and(|info_hash| regex.is_match(info_hash))
+    })
 }
 
 fn event_type_label(entry: &EventJournalEntry) -> &'static str {
@@ -383,36 +494,6 @@ fn command_action_label(entry: &EventJournalEntry) -> String {
         EventDetails::Control { action, .. } => sanitize_text(action),
         _ => event_type_label(entry).to_string(),
     }
-}
-
-fn source_label(entry: &EventJournalEntry, anonymize: bool) -> String {
-    if anonymize {
-        return "/path/to/source".to_string();
-    }
-
-    entry
-        .source_path
-        .as_ref()
-        .map(|path| compact_path_label(path, 1))
-        .or_else(|| {
-            entry
-                .source_watch_folder
-                .as_ref()
-                .map(|path| compact_path_label(path, 1))
-        })
-        .unwrap_or_else(|| "-".to_string())
-}
-
-fn torrent_label(entry: &EventJournalEntry, anonymize: bool) -> String {
-    if anonymize {
-        return "Torrent".to_string();
-    }
-
-    entry
-        .torrent_name
-        .as_ref()
-        .map(|name| sanitize_text(name))
-        .unwrap_or_else(|| "-".to_string())
 }
 
 fn preferred_source_text(entry: &EventJournalEntry) -> Option<String> {
@@ -555,8 +636,7 @@ fn replay_selected_entry(
     };
 
     let Some(source_path) = activity
-        .entries
-        .iter()
+        .entries()
         .rev()
         .find_map(|entry| entry.source_path.as_ref())
     else {
@@ -612,14 +692,24 @@ fn columns_for_filter(_filter: JournalFilter) -> Vec<JournalColumn> {
     ]
 }
 
-fn journal_table_window(len: usize, selected_index: usize, table_height: u16) -> (usize, usize) {
+fn journal_table_window(
+    len: usize,
+    selected_index: usize,
+    requested_offset: usize,
+    table_height: u16,
+) -> (usize, usize) {
     let capacity = usize::from(table_height.saturating_sub(1).max(1));
-    let end = if selected_index < capacity {
-        capacity.min(len)
-    } else {
-        selected_index.saturating_add(1).min(len)
-    };
-    (end.saturating_sub(capacity), end)
+    let max_offset = len.saturating_sub(capacity);
+    let mut start = requested_offset.min(max_offset);
+    if selected_index < start {
+        start = selected_index;
+    } else if selected_index >= start.saturating_add(capacity) {
+        start = selected_index
+            .saturating_add(1)
+            .saturating_sub(capacity)
+            .min(max_offset);
+    }
+    (start, start.saturating_add(capacity).min(len))
 }
 
 fn journal_detail_height(inner_height: u16) -> u16 {
@@ -769,7 +859,7 @@ fn event_status_style(entry: &EventJournalEntry, ctx: &ThemeContext) -> Style {
 
 fn activity_status_spans(activity: &JournalActivity<'_>, ctx: &ThemeContext) -> Vec<Span<'static>> {
     let mut spans = Vec::new();
-    for (index, entry) in activity.entries.iter().enumerate() {
+    for (index, entry) in activity.entries().enumerate() {
         if index > 0 {
             spans.push(Span::styled(
                 " → ",
@@ -800,8 +890,7 @@ fn activity_subject_label(activity: &JournalActivity<'_>, anonymize: bool) -> St
     }
 
     activity
-        .entries
-        .iter()
+        .entries()
         .rev()
         .filter_map(|entry| entry.torrent_name.as_deref())
         .find(|name| !name.trim().is_empty())
@@ -853,8 +942,7 @@ fn activity_detail_line(
     let latest = activity.latest();
     let timestamp = detailed_timestamp(&latest.ts_iso);
     let status_width = activity
-        .entries
-        .iter()
+        .entries()
         .enumerate()
         .map(|(index, entry)| {
             usize::from(index > 0) * 3 + 2 + event_type_label(entry).chars().count()
@@ -918,10 +1006,7 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
     f.render_widget(Clear, area);
     let screen_regions = journal_screen_regions(f.area(), search_panel_active);
 
-    let entry_count = activities
-        .iter()
-        .map(|activity| activity.entries.len())
-        .sum::<usize>();
+    let entry_count = activities.iter().map(JournalActivity::len).sum::<usize>();
     let activity_label = if activities.len() == 1 {
         "1 activity".to_string()
     } else {
@@ -1021,6 +1106,7 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
     let (window_start, window_end) = journal_table_window(
         activities.len(),
         selected_index,
+        app_state.ui.journal.scroll_offset,
         content_regions.table.height,
     );
     let now = Utc::now();
@@ -1112,7 +1198,7 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
             ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0)),
         ));
     };
-    if search_panel_active {
+    if app_state.ui.journal.is_searching {
         push_action("type", "query", ActionTone::Edit);
         push_action("Tab", "mode", ActionTone::Mode);
         push_action("Enter", "keep", ActionTone::Confirm);
@@ -1172,12 +1258,13 @@ fn draw_journal_search_panel(
         format!("  {visible_count} matches"),
         ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0)),
     ));
-    draw_prompt_panel(
+    draw_prompt_panel_with_cursor(
         f,
         area,
         " Journal Search ".to_string(),
         sanitize_text(&app_state.ui.journal.search_query),
         trailing_spans,
+        app_state.ui.journal.is_searching,
         ctx,
     );
 }
@@ -1456,6 +1543,81 @@ mod tests {
     }
 
     #[test]
+    fn journal_enter_keeps_query_and_returns_to_normal_navigation() {
+        let mut app_state = base_state();
+        let (tx, _rx) = mpsc::channel(1);
+        app_state.ui.journal.is_searching = true;
+        app_state.ui.journal.search_query = "sample".to_string();
+
+        handle_event(
+            CrosstermEvent::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+            &mut app_state,
+            &tx,
+        );
+        handle_event(
+            CrosstermEvent::Key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
+            &mut app_state,
+            &tx,
+        );
+
+        assert!(!app_state.ui.journal.is_searching);
+        assert_eq!(app_state.ui.journal.search_query, "sample");
+        assert_eq!(app_state.ui.journal.filter, JournalFilter::Queue);
+        assert_eq!(app_state.ui.journal.search_mode, SearchMode::Regex);
+    }
+
+    #[test]
+    fn retained_search_query_hides_the_edit_cursor() {
+        let mut app_state = base_state();
+        let (tx, _rx) = mpsc::channel(1);
+        app_state.ui.journal.is_searching = true;
+        app_state.ui.journal.search_query = "sample".to_string();
+
+        let editing = render_journal_text(&app_state, 120, 40);
+        assert!(editing.contains("sample_"), "{editing}");
+
+        handle_event(
+            CrosstermEvent::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+            &mut app_state,
+            &tx,
+        );
+
+        let retained = render_journal_text(&app_state, 120, 40);
+        assert!(retained.contains("sample"), "{retained}");
+        assert!(!retained.contains("sample_"), "{retained}");
+    }
+
+    #[test]
+    fn regex_search_matches_fields_without_a_joined_haystack() {
+        let entry = EventJournalEntry {
+            category: EventCategory::Ingest,
+            event_type: EventType::IngestAdded,
+            torrent_name: Some("Sample Item".to_string()),
+            source_path: Some(Path::new("/watch/sample-source.magnet").to_path_buf()),
+            host_id: Some("node-alpha".to_string()),
+            info_hash_hex: Some("a1b2c3".to_string()),
+            message: Some("Ingest completed normally".to_string()),
+            ..Default::default()
+        };
+        let activity = JournalActivity::new(&entry);
+
+        for pattern in [
+            "added",
+            "sample item",
+            "sample-source",
+            "node-alpha",
+            "a1b2c3",
+            "completed normally",
+        ] {
+            let regex = regex::RegexBuilder::new(pattern)
+                .case_insensitive(true)
+                .build()
+                .expect("valid search regex");
+            assert!(activity_matches_regex(&activity, &regex), "{pattern}");
+        }
+    }
+
+    #[test]
     fn filter_selection_matches_requested_groups() {
         let mut app_state = base_state();
 
@@ -1504,8 +1666,8 @@ mod tests {
         let activities = journal_activities(&app_state);
 
         assert_eq!(activities.len(), 1);
-        assert_eq!(activities[0].entries.len(), 2);
-        assert_eq!(activities[0].entries[0].id, 10);
+        assert_eq!(activities[0].len(), 2);
+        assert_eq!(activities[0].entry(0).expect("queued entry").id, 10);
         assert_eq!(activities[0].latest().id, 11);
         assert_eq!(
             activity_subject_label(&activities[0], false),
@@ -1578,9 +1740,9 @@ mod tests {
         let activities = journal_activities(&app_state);
 
         assert_eq!(activities.len(), 2);
-        assert_eq!(activities[0].entries.len(), 2);
+        assert_eq!(activities[0].len(), 2);
         assert_eq!(activities[0].latest().id, 23);
-        assert_eq!(activities[1].entries.len(), 2);
+        assert_eq!(activities[1].len(), 2);
         assert_eq!(activities[1].latest().id, 21);
     }
 
@@ -1606,9 +1768,9 @@ mod tests {
         let activities = journal_activities(&app_state);
 
         assert_eq!(activities.len(), 2);
-        assert_eq!(activities[0].entries[0].id, 25);
+        assert_eq!(activities[0].entry(0).expect("queued entry").id, 25);
         assert_eq!(activities[0].latest().id, 26);
-        assert_eq!(activities[1].entries.len(), 1);
+        assert_eq!(activities[1].len(), 1);
         assert_eq!(activities[1].latest().id, 24);
     }
 
@@ -1655,15 +1817,17 @@ mod tests {
         let activities = journal_activities(&app_state);
 
         assert_eq!(activities.len(), 3);
-        assert_eq!(activities[0].entries.len(), 2);
+        assert_eq!(activities[0].len(), 2);
         assert_eq!(
-            activities[0].entries[0].host_id.as_deref(),
+            activities[0]
+                .entry(0)
+                .expect("queued entry")
+                .host_id
+                .as_deref(),
             Some("host-beta")
         );
         assert_eq!(activities[0].latest().id, 30);
-        assert!(activities[1..]
-            .iter()
-            .all(|activity| activity.entries.len() == 1));
+        assert!(activities[1..].iter().all(|activity| activity.len() == 1));
     }
 
     #[test]
@@ -1704,9 +1868,9 @@ mod tests {
         let activities = journal_activities(&app_state);
 
         assert_eq!(activities.len(), 2);
-        assert_eq!(activities[0].entries[0].id, 31);
+        assert_eq!(activities[0].entry(0).expect("queued entry").id, 31);
         assert_eq!(activities[0].latest().id, 33);
-        assert_eq!(activities[1].entries[0].id, 30);
+        assert_eq!(activities[1].entry(0).expect("queued entry").id, 30);
         assert_eq!(activities[1].latest().id, 32);
     }
 
@@ -1744,11 +1908,11 @@ mod tests {
 
     #[test]
     fn table_window_builds_only_the_visible_rows_around_selection() {
-        assert_eq!(journal_table_window(100, 0, 6), (0, 5));
-        assert_eq!(journal_table_window(100, 4, 6), (0, 5));
-        assert_eq!(journal_table_window(100, 5, 6), (1, 6));
-        assert_eq!(journal_table_window(100, 73, 6), (69, 74));
-        assert_eq!(journal_table_window(3, 2, 6), (0, 3));
+        assert_eq!(journal_table_window(100, 0, 0, 6), (0, 5));
+        assert_eq!(journal_table_window(100, 4, 0, 6), (0, 5));
+        assert_eq!(journal_table_window(100, 5, 0, 6), (1, 6));
+        assert_eq!(journal_table_window(100, 73, 69, 6), (69, 74));
+        assert_eq!(journal_table_window(3, 2, 0, 6), (0, 3));
     }
 
     #[test]
@@ -1763,7 +1927,7 @@ mod tests {
     fn page_keys_move_by_the_visible_table_capacity() {
         let mut app_state = base_state();
         app_state.screen_area = ratatui::prelude::Rect::new(0, 0, 120, 30);
-        app_state.event_journal_state.entries = (0..40)
+        app_state.event_journal_state.entries = (0..100)
             .map(|id| EventJournalEntry {
                 id,
                 category: EventCategory::Ingest,
@@ -1781,6 +1945,23 @@ mod tests {
             &tx,
         );
         assert_eq!(app_state.ui.journal.selected_index, page_rows);
+        assert_eq!(app_state.ui.journal.scroll_offset, page_rows);
+
+        let screen_regions = journal_screen_regions(app_state.screen_area, false);
+        let inner = Block::default()
+            .borders(Borders::ALL)
+            .padding(Padding::new(2, 2, 0, 0))
+            .inner(screen_regions.panel);
+        assert_eq!(
+            journal_table_window(
+                100,
+                app_state.ui.journal.selected_index,
+                app_state.ui.journal.scroll_offset,
+                journal_content_regions(inner).table.height,
+            )
+            .0,
+            page_rows
+        );
 
         handle_event(
             CrosstermEvent::Key(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE)),
@@ -1788,6 +1969,7 @@ mod tests {
             &tx,
         );
         assert_eq!(app_state.ui.journal.selected_index, 0);
+        assert_eq!(app_state.ui.journal.scroll_offset, 0);
     }
 
     #[test]
@@ -1906,8 +2088,8 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(torrent_label(&entry, true), "Torrent");
-        assert_eq!(source_label(&entry, true), "/path/to/source");
+        let activity = JournalActivity::new(&entry);
+        assert_eq!(activity_subject_label(&activity, true), "Torrent");
 
         let details = detail_text(Some(&entry), true);
         assert!(!details.contains("Sample Alpha"));

--- a/src/tui/screens/journal.rs
+++ b/src/tui/screens/journal.rs
@@ -402,9 +402,7 @@ fn activity_search_haystack(activity: &JournalActivity<'_>) -> String {
     let mut haystack = String::with_capacity(activity.len().saturating_mul(192));
     for entry in activity.entries() {
         append_search_field(&mut haystack, event_type_label(entry));
-        if let EventDetails::Control { action, .. } = &entry.details {
-            append_search_field(&mut haystack, action);
-        }
+        append_control_search_fields(&mut haystack, &entry.details);
         append_search_field(&mut haystack, entry.torrent_name.as_deref().unwrap_or("-"));
         if let Some(path) = entry
             .source_path
@@ -442,13 +440,67 @@ fn append_search_field(haystack: &mut String, field: &str) {
     haystack.push_str(field);
 }
 
+fn append_control_search_fields(haystack: &mut String, details: &EventDetails) {
+    let EventDetails::Control {
+        action,
+        target_info_hash_hex,
+        file_index,
+        file_path,
+        priority,
+        ..
+    } = details
+    else {
+        return;
+    };
+
+    append_search_field(haystack, action);
+    if let Some(info_hash) = target_info_hash_hex.as_deref() {
+        append_search_field(haystack, info_hash);
+    }
+    if let Some(file_index) = file_index {
+        if !haystack.is_empty() {
+            haystack.push(' ');
+        }
+        let _ = write!(haystack, "{file_index}");
+    }
+    if let Some(file_path) = file_path.as_deref() {
+        append_search_field(haystack, file_path);
+    }
+    if let Some(priority) = priority.as_deref() {
+        append_search_field(haystack, priority);
+    }
+}
+
+fn control_details_match_regex(details: &EventDetails, regex: &regex::Regex) -> bool {
+    let EventDetails::Control {
+        action,
+        target_info_hash_hex,
+        file_index,
+        file_path,
+        priority,
+        ..
+    } = details
+    else {
+        return false;
+    };
+
+    regex.is_match(action)
+        || target_info_hash_hex
+            .as_deref()
+            .is_some_and(|info_hash| regex.is_match(info_hash))
+        || file_index.is_some_and(|index| regex.is_match(&index.to_string()))
+        || file_path
+            .as_deref()
+            .is_some_and(|path| regex.is_match(path))
+        || priority
+            .as_deref()
+            .is_some_and(|priority| regex.is_match(priority))
+}
+
 fn activity_matches_regex(activity: &JournalActivity<'_>, regex: &regex::Regex) -> bool {
     activity.entries().any(|entry| {
         regex.is_match(event_type_label(entry))
-            || matches!(
-                &entry.details,
-                EventDetails::Control { action, .. } if regex.is_match(action)
-            )
+            || control_details_match_regex(&entry.details, regex)
             || entry
                 .torrent_name
                 .as_deref()
@@ -1614,6 +1666,38 @@ mod tests {
                 .build()
                 .expect("valid search regex");
             assert!(activity_matches_regex(&activity, &regex), "{pattern}");
+        }
+    }
+
+    #[test]
+    fn command_search_matches_control_targets_in_both_modes() {
+        let mut app_state = base_state();
+        app_state.ui.journal.filter = JournalFilter::Commands;
+        app_state.event_journal_state.entries = vec![EventJournalEntry {
+            category: EventCategory::Control,
+            event_type: EventType::ControlQueued,
+            message: Some("Queued control request.".to_string()),
+            details: EventDetails::Control {
+                origin: crate::persistence::event_journal::ControlOrigin::CliOnline,
+                action: "set_file_priority".to_string(),
+                target_info_hash_hex: Some("feedcafe1234".to_string()),
+                file_index: Some(731),
+                file_path: Some("content/segment-omega.bin".to_string()),
+                priority: Some("High".to_string()),
+            },
+            ..Default::default()
+        }];
+
+        for mode in [SearchMode::Fuzzy, SearchMode::Regex] {
+            app_state.ui.journal.search_mode = mode;
+            for query in ["feedcafe", "731", "segment-omega", "high"] {
+                app_state.ui.journal.search_query = query.to_string();
+                assert_eq!(
+                    journal_activities(&app_state).len(),
+                    1,
+                    "{mode:?} search should match {query}"
+                );
+            }
         }
     }
 

--- a/src/tui/screens/journal.rs
+++ b/src/tui/screens/journal.rs
@@ -11,7 +11,7 @@ use crate::tui::app_command::spawn_app_command_sender;
 use crate::tui::formatters::{centered_rect, sanitize_text, truncate_with_ellipsis};
 use crate::tui::screen_context::ScreenContext;
 use crate::tui::screens::input_panel::draw_prompt_panel;
-use chrono::{DateTime, Local};
+use chrono::{DateTime, Local, Utc};
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
 use ratatui::crossterm::event::{
@@ -30,6 +30,8 @@ enum JournalAction {
     FilterPrev,
     MoveUp,
     MoveDown,
+    MovePageUp,
+    MovePageDown,
     ReplaySelected,
     SearchStart,
     SearchInsert(char),
@@ -60,6 +62,8 @@ fn map_key_to_journal_action(key: KeyEvent, search_panel_active: bool) -> Option
             KeyCode::Char('u') if has_ctrl => Some(JournalAction::SearchClear),
             KeyCode::Up => Some(JournalAction::MoveUp),
             KeyCode::Down => Some(JournalAction::MoveDown),
+            KeyCode::PageUp => Some(JournalAction::MovePageUp),
+            KeyCode::PageDown => Some(JournalAction::MovePageDown),
             KeyCode::Char(c) if !has_ctrl && !has_alt => Some(JournalAction::SearchInsert(c)),
             _ => None,
         };
@@ -71,6 +75,8 @@ fn map_key_to_journal_action(key: KeyEvent, search_panel_active: bool) -> Option
         KeyCode::BackTab => Some(JournalAction::FilterPrev),
         KeyCode::Up | KeyCode::Char('k') => Some(JournalAction::MoveUp),
         KeyCode::Down | KeyCode::Char('j') => Some(JournalAction::MoveDown),
+        KeyCode::PageUp => Some(JournalAction::MovePageUp),
+        KeyCode::PageDown => Some(JournalAction::MovePageDown),
         KeyCode::Char('Y') => Some(JournalAction::ReplaySelected),
         KeyCode::Char('/') => Some(JournalAction::SearchStart),
         _ => None,
@@ -127,6 +133,26 @@ fn handle_event_inner(
             if len > 0 {
                 app_state.ui.journal.selected_index =
                     (app_state.ui.journal.selected_index + 1).min(len - 1);
+            }
+        }
+        JournalAction::MovePageUp => {
+            let page_rows = journal_page_rows(app_state);
+            app_state.ui.journal.selected_index = app_state
+                .ui
+                .journal
+                .selected_index
+                .saturating_sub(page_rows);
+        }
+        JournalAction::MovePageDown => {
+            let len = journal_activities(app_state).len();
+            if len > 0 {
+                let page_rows = journal_page_rows(app_state);
+                app_state.ui.journal.selected_index = app_state
+                    .ui
+                    .journal
+                    .selected_index
+                    .saturating_add(page_rows)
+                    .min(len - 1);
             }
         }
         JournalAction::ReplaySelected => {
@@ -418,6 +444,35 @@ fn detailed_timestamp(ts_iso: &str) -> String {
         .unwrap_or_else(|_| ts_iso.to_string())
 }
 
+fn time_since_label(ts_iso: &str, now: &DateTime<Utc>) -> String {
+    let Ok(timestamp) = DateTime::parse_from_rfc3339(ts_iso) else {
+        return "-".to_string();
+    };
+    let elapsed_seconds = now
+        .signed_duration_since(timestamp.with_timezone(&Utc))
+        .num_seconds();
+    if elapsed_seconds <= 0 {
+        return "now".to_string();
+    }
+
+    let days = elapsed_seconds / 86_400;
+    let hours = (elapsed_seconds % 86_400) / 3_600;
+    let minutes = (elapsed_seconds % 3_600) / 60;
+    let seconds = elapsed_seconds % 60;
+
+    if days > 0 {
+        format!("{days}d {hours}h ago")
+    } else if hours > 0 {
+        let minute_unit = if minutes == 1 { "min" } else { "mins" };
+        format!("{hours}h {minutes}{minute_unit} ago")
+    } else if minutes > 0 {
+        let minute_unit = if minutes == 1 { "min" } else { "mins" };
+        format!("{minutes}{minute_unit} {seconds}s ago")
+    } else {
+        format!("{seconds}s ago")
+    }
+}
+
 fn compact_path_label(path: &Path, depth: usize) -> String {
     let components = path
         .components()
@@ -545,6 +600,7 @@ fn replay_selected_entry(
 #[derive(Clone, Copy)]
 enum JournalColumn {
     Time,
+    TimeSince,
     Status,
     Subject,
 }
@@ -552,6 +608,7 @@ enum JournalColumn {
 fn columns_for_filter(_filter: JournalFilter) -> Vec<JournalColumn> {
     vec![
         JournalColumn::Time,
+        JournalColumn::TimeSince,
         JournalColumn::Status,
         JournalColumn::Subject,
     ]
@@ -567,19 +624,66 @@ fn journal_table_window(len: usize, selected_index: usize, table_height: u16) ->
     (end.saturating_sub(capacity), end)
 }
 
+fn journal_detail_height(inner_height: u16) -> u16 {
+    u16::from(inner_height >= 5)
+}
+
+fn journal_page_rows(app_state: &AppState) -> usize {
+    let screen_area = app_state.screen_area;
+    if screen_area.width == 0 || screen_area.height == 0 {
+        return 1;
+    }
+
+    let area = centered_rect(88, 94, screen_area);
+    let search_panel_active =
+        app_state.ui.journal.is_searching || !app_state.ui.journal.search_query.is_empty();
+    let journal_area = if search_panel_active && area.height >= 7 {
+        ratatui::layout::Layout::vertical([Constraint::Length(3), Constraint::Min(1)]).split(area)
+            [1]
+    } else {
+        area
+    };
+    let panel_area = ratatui::layout::Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Min(1),
+        Constraint::Length(1),
+    ])
+    .split(journal_area)[1];
+    let inner = Block::default()
+        .borders(Borders::ALL)
+        .padding(Padding::new(2, 2, 0, 0))
+        .inner(panel_area);
+    let detail_height = journal_detail_height(inner.height);
+    let spacer_height = u16::from(detail_height > 0);
+    let table_height = ratatui::layout::Layout::vertical([
+        Constraint::Min(3),
+        Constraint::Length(spacer_height),
+        Constraint::Length(detail_height),
+    ])
+    .split(inner)[0]
+        .height;
+
+    usize::from(table_height.saturating_sub(1).max(1))
+}
+
 fn column_header(column: JournalColumn, filter: JournalFilter) -> &'static str {
     match (column, filter) {
         (JournalColumn::Subject, JournalFilter::Commands) => "Action",
         (JournalColumn::Subject, _) => "Torrent",
         (JournalColumn::Time, _) => "Time",
+        (JournalColumn::TimeSince, _) => "Time Since",
         (JournalColumn::Status, _) => "Status",
     }
 }
 
-fn column_header_style(column: JournalColumn, ctx: &ThemeContext) -> Style {
+fn column_header_style(column: JournalColumn, filter: JournalFilter, ctx: &ThemeContext) -> Style {
     let color = match column {
-        JournalColumn::Time => ctx.theme.semantic.subtext0,
+        JournalColumn::Time => ctx.accent_peach(),
+        JournalColumn::TimeSince => ctx.accent_teal(),
         JournalColumn::Status => ctx.state_warning(),
+        JournalColumn::Subject if matches!(filter, JournalFilter::Commands) => {
+            ctx.accent_sapphire()
+        }
         JournalColumn::Subject => ctx.accent_sky(),
     };
     ctx.apply(Style::default().fg(color).bold())
@@ -588,6 +692,7 @@ fn column_header_style(column: JournalColumn, ctx: &ThemeContext) -> Style {
 fn column_constraint(column: JournalColumn, filter: JournalFilter) -> Constraint {
     match (filter, column) {
         (_, JournalColumn::Time) => Constraint::Length(13),
+        (_, JournalColumn::TimeSince) => Constraint::Length(15),
         (_, JournalColumn::Status) => Constraint::Length(22),
         (_, JournalColumn::Subject) => Constraint::Fill(1),
     }
@@ -622,7 +727,7 @@ fn event_status_style(entry: &EventJournalEntry, ctx: &ThemeContext) -> Style {
     }
 }
 
-fn activity_status_cell(activity: &JournalActivity<'_>, ctx: &ThemeContext) -> Cell<'static> {
+fn activity_status_spans(activity: &JournalActivity<'_>, ctx: &ThemeContext) -> Vec<Span<'static>> {
     let mut spans = Vec::new();
     for (index, entry) in activity.entries.iter().enumerate() {
         if index > 0 {
@@ -637,7 +742,11 @@ fn activity_status_cell(activity: &JournalActivity<'_>, ctx: &ThemeContext) -> C
             event_status_style(entry, ctx),
         ));
     }
-    Cell::from(Line::from(spans))
+    spans
+}
+
+fn activity_status_cell(activity: &JournalActivity<'_>, ctx: &ThemeContext) -> Cell<'static> {
+    Cell::from(Line::from(activity_status_spans(activity, ctx)))
 }
 
 fn activity_subject_label(activity: &JournalActivity<'_>, anonymize: bool) -> String {
@@ -674,11 +783,14 @@ fn column_cell(
     column: JournalColumn,
     activity: &JournalActivity<'_>,
     app_state: &AppState,
+    now: &DateTime<Utc>,
     ctx: &ThemeContext,
 ) -> Cell<'static> {
     match column {
         JournalColumn::Time => Cell::from(pretty_timestamp(&activity.latest().ts_iso))
             .style(ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0))),
+        JournalColumn::TimeSince => Cell::from(time_since_label(&activity.latest().ts_iso, now))
+            .style(ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1))),
         JournalColumn::Status => activity_status_cell(activity, ctx),
         JournalColumn::Subject => Cell::from(activity_subject_label(
             activity,
@@ -688,63 +800,75 @@ fn column_cell(
     }
 }
 
-fn activity_detail_lines(
+fn activity_detail_line(
     activity: Option<&JournalActivity<'_>>,
     app_state: &AppState,
     ctx: &ThemeContext,
     width: u16,
-) -> Vec<Line<'static>> {
+) -> Line<'static> {
     let Some(activity) = activity else {
-        return vec![Line::from(Span::styled(
+        return Line::from(Span::styled(
             "No journal activities yet.",
             ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1)),
-        ))];
+        ));
     };
 
-    let record_message_width = usize::from(width.saturating_sub(35));
-    let mut lines = activity
+    let latest = activity.latest();
+    let timestamp = detailed_timestamp(&latest.ts_iso);
+    let status_width = activity
         .entries
         .iter()
-        .map(|entry| {
-            let message = detail_text(Some(entry), app_state.anonymize_torrent_names);
-            Line::from(vec![
-                Span::styled("● ", event_status_style(entry, ctx)),
-                Span::styled(
-                    format!("{:<10}", event_type_label(entry)),
-                    event_status_style(entry, ctx),
-                ),
-                Span::styled(
-                    format!("{}  ", detailed_timestamp(&entry.ts_iso)),
-                    ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0)),
-                ),
-                Span::styled(
-                    truncate_with_ellipsis(&message, record_message_width),
-                    ctx.apply(Style::default().fg(ctx.theme.semantic.text)),
-                ),
-            ])
+        .enumerate()
+        .map(|(index, entry)| {
+            usize::from(index > 0) * 3 + 2 + event_type_label(entry).chars().count()
         })
-        .collect::<Vec<_>>();
+        .sum::<usize>();
+    let timestamp_width = timestamp.chars().count() + 4;
+    let source = (width >= 84)
+        .then(|| preferred_source_text(activity.source_entry()))
+        .flatten()
+        .map(|source| {
+            if app_state.anonymize_torrent_names {
+                "/path/to/source".to_string()
+            } else {
+                sanitize_text(&source)
+            }
+        })
+        .map(|source| truncate_with_ellipsis(&source, usize::from(width / 5).max(16)));
+    let source_width = source
+        .as_ref()
+        .map(|source| 10 + source.chars().count())
+        .unwrap_or(0);
+    let message_width = usize::from(width)
+        .saturating_sub(status_width)
+        .saturating_sub(timestamp_width)
+        .saturating_sub(source_width);
+    let message = truncate_with_ellipsis(
+        &detail_text(Some(latest), app_state.anonymize_torrent_names),
+        message_width,
+    );
 
-    if let Some(source) = preferred_source_text(activity.source_entry()) {
-        let source = if app_state.anonymize_torrent_names {
-            "/path/to/source".to_string()
-        } else {
-            sanitize_text(&source)
-        };
-        let source = truncate_with_ellipsis(&source, usize::from(width.saturating_sub(10)));
-        lines.push(Line::from(vec![
-            Span::styled(
-                "  Source  ",
-                ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0)),
-            ),
-            Span::styled(
-                source,
-                ctx.apply(Style::default().fg(ctx.accent_sapphire())),
-            ),
-        ]));
+    let mut spans = activity_status_spans(activity, ctx);
+    spans.push(Span::styled(
+        format!("  {timestamp}  "),
+        ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0)),
+    ));
+    spans.push(Span::styled(
+        message,
+        ctx.apply(Style::default().fg(ctx.theme.semantic.text)),
+    ));
+    if let Some(source) = source {
+        spans.push(Span::styled(
+            "  Source  ",
+            ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0)),
+        ));
+        spans.push(Span::styled(
+            source,
+            ctx.apply(Style::default().fg(ctx.accent_sapphire())),
+        ));
     }
 
-    lines
+    Line::from(spans)
 }
 
 pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
@@ -848,11 +972,8 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
         .selected_index
         .min(activities.len().saturating_sub(1));
     let selected_activity = activities.get(selected_index);
-    let detail_lines = activity_detail_lines(selected_activity, app_state, ctx, inner.width);
-    let detail_height = u16::try_from(detail_lines.len())
-        .unwrap_or(u16::MAX)
-        .min(4)
-        .min(inner.height.saturating_sub(4));
+    let detail_line = activity_detail_line(selected_activity, app_state, ctx, inner.width);
+    let detail_height = journal_detail_height(inner.height);
     let spacer_height = u16::from(detail_height > 0);
     let rows = ratatui::layout::Layout::vertical([
         Constraint::Min(3),
@@ -864,6 +985,7 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
     let columns = columns_for_filter(app_state.ui.journal.filter);
     let (window_start, window_end) =
         journal_table_window(activities.len(), selected_index, rows[0].height);
+    let now = Utc::now();
     let body_rows = activities[window_start..window_end]
         .iter()
         .map(|activity| {
@@ -871,7 +993,7 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
                 columns
                     .iter()
                     .copied()
-                    .map(|column| column_cell(column, activity, app_state, ctx))
+                    .map(|column| column_cell(column, activity, app_state, &now, ctx))
                     .collect::<Vec<_>>(),
             )
         })
@@ -884,8 +1006,9 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
     let header_cells = columns
         .iter()
         .map(|column| {
-            Cell::from(column_header(*column, app_state.ui.journal.filter))
-                .style(column_header_style(*column, ctx))
+            Cell::from(column_header(*column, app_state.ui.journal.filter)).style(
+                column_header_style(*column, app_state.ui.journal.filter, ctx),
+            )
         })
         .collect::<Vec<_>>();
 
@@ -908,7 +1031,7 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
 
     if detail_height > 0 {
         f.render_widget(
-            Paragraph::new(detail_lines).alignment(Alignment::Left),
+            Paragraph::new(detail_line).alignment(Alignment::Left),
             rows[2],
         );
     }
@@ -935,12 +1058,12 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
         push_action("Tab", "mode", ActionTone::Mode);
         push_action("Enter", "keep", ActionTone::Confirm);
         push_action("Esc", "clear", ActionTone::Cancel);
-        push_action("↑/↓", "nav", ActionTone::Navigate);
+        push_action("↑/↓ PgUp/PgDn", "nav", ActionTone::Navigate);
     } else {
         push_action("Esc", "back", ActionTone::Cancel);
         push_action("Tab", "filter", ActionTone::Mode);
         push_action("/", "search", ActionTone::Search);
-        push_action("↑/↓", "nav", ActionTone::Navigate);
+        push_action("↑/↓ PgUp/PgDn", "nav", ActionTone::Navigate);
         push_action("Shift+Y", "replay", ActionTone::Replay);
     }
     let footer_hint = Paragraph::new(Line::from(footer_spans)).alignment(Alignment::Center);
@@ -1454,7 +1577,46 @@ mod tests {
     }
 
     #[test]
-    fn grouped_activity_renders_once_and_keeps_both_stage_details() {
+    fn detail_region_keeps_a_stable_height() {
+        assert_eq!(journal_detail_height(30), 1);
+        assert_eq!(journal_detail_height(8), 1);
+        assert_eq!(journal_detail_height(5), 1);
+        assert_eq!(journal_detail_height(4), 0);
+    }
+
+    #[test]
+    fn page_keys_move_by_the_visible_table_capacity() {
+        let mut app_state = base_state();
+        app_state.screen_area = ratatui::prelude::Rect::new(0, 0, 120, 30);
+        app_state.event_journal_state.entries = (0..40)
+            .map(|id| EventJournalEntry {
+                id,
+                category: EventCategory::Ingest,
+                event_type: EventType::IngestAdded,
+                torrent_name: Some(format!("Sample Item {id}")),
+                ..Default::default()
+            })
+            .collect();
+        let page_rows = journal_page_rows(&app_state);
+        let (tx, _rx) = mpsc::channel(1);
+
+        handle_event(
+            CrosstermEvent::Key(KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE)),
+            &mut app_state,
+            &tx,
+        );
+        assert_eq!(app_state.ui.journal.selected_index, page_rows);
+
+        handle_event(
+            CrosstermEvent::Key(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE)),
+            &mut app_state,
+            &tx,
+        );
+        assert_eq!(app_state.ui.journal.selected_index, 0);
+    }
+
+    #[test]
+    fn grouped_activity_uses_one_line_with_latest_detail() {
         let mut app_state = base_state();
         app_state.ui.journal.filter = JournalFilter::Queue;
         app_state.ui.journal.selected_index = 99;
@@ -1487,16 +1649,13 @@ mod tests {
         assert!(rendered.contains("1 activity"), "{rendered}");
         assert!(rendered.contains("2 records"), "{rendered}");
         assert_eq!(rendered.matches("Sample Delta").count(), 1, "{rendered}");
-        assert!(rendered.contains("Queued ingest item"), "{rendered}");
         assert!(rendered.contains("Added ingest item"), "{rendered}");
-        assert!(
-            rendered.contains("/watch/sample-delta.magnet"),
-            "{rendered}"
-        );
+        assert!(!rendered.contains("Queued ingest item"), "{rendered}");
+        assert!(rendered.contains("/watch/sample"), "{rendered}");
     }
 
     #[test]
-    fn narrow_render_keeps_each_stage_and_source_on_separate_rows() {
+    fn narrow_render_keeps_latest_detail_on_one_line() {
         let mut app_state = base_state();
         app_state.ui.journal.filter = JournalFilter::Queue;
         app_state.event_journal_state.entries = vec![
@@ -1525,12 +1684,8 @@ mod tests {
 
         let rendered = render_journal_text(&app_state, 80, 24);
 
-        assert!(rendered.contains("Queue detail"), "{rendered}");
         assert!(rendered.contains("Result detail"), "{rendered}");
-        assert!(
-            rendered.contains("/watch/sample-epsilon.magnet"),
-            "{rendered}"
-        );
+        assert!(!rendered.contains("Queue detail"), "{rendered}");
     }
 
     #[test]
@@ -1543,6 +1698,25 @@ mod tests {
     fn pretty_timestamp_formats_rfc3339_values() {
         let label = pretty_timestamp("2026-03-15T14:26:28Z");
         assert!(label.contains("Mar"));
+    }
+
+    #[test]
+    fn time_since_label_uses_two_live_time_units() {
+        let now = DateTime::parse_from_rfc3339("2026-03-15T15:00:00Z")
+            .expect("valid now timestamp")
+            .with_timezone(&Utc);
+
+        assert_eq!(time_since_label("2026-03-15T15:00:00Z", &now), "now");
+        assert_eq!(time_since_label("2026-03-15T14:59:40Z", &now), "20s ago");
+        assert_eq!(
+            time_since_label("2026-03-15T14:29:40Z", &now),
+            "30mins 20s ago"
+        );
+        assert_eq!(
+            time_since_label("2026-03-15T12:55:00Z", &now),
+            "2h 5mins ago"
+        );
+        assert_eq!(time_since_label("invalid", &now), "-");
     }
 
     #[test]
@@ -1581,17 +1755,24 @@ mod tests {
         };
 
         assert_eq!(command_action_label(&entry), "pause");
-        assert_eq!(columns_for_filter(JournalFilter::Commands).len(), 3);
+        assert_eq!(columns_for_filter(JournalFilter::Commands).len(), 4);
         assert_eq!(
             column_header(
                 columns_for_filter(JournalFilter::Commands)[1],
+                JournalFilter::Commands
+            ),
+            "Time Since"
+        );
+        assert_eq!(
+            column_header(
+                columns_for_filter(JournalFilter::Commands)[2],
                 JournalFilter::Commands
             ),
             "Status"
         );
         assert_eq!(
             column_header(
-                columns_for_filter(JournalFilter::Commands)[2],
+                columns_for_filter(JournalFilter::Commands)[3],
                 JournalFilter::Commands
             ),
             "Action"
@@ -1600,14 +1781,14 @@ mod tests {
     }
 
     #[test]
-    fn every_filter_uses_the_same_three_core_columns() {
+    fn every_filter_uses_the_same_four_core_columns() {
         for filter in [
             JournalFilter::All,
             JournalFilter::Queue,
             JournalFilter::Commands,
             JournalFilter::Health,
         ] {
-            assert_eq!(columns_for_filter(filter).len(), 3);
+            assert_eq!(columns_for_filter(filter).len(), 4);
         }
     }
 

--- a/src/tui/screens/journal.rs
+++ b/src/tui/screens/journal.rs
@@ -17,7 +17,7 @@ use fuzzy_matcher::FuzzyMatcher;
 use ratatui::crossterm::event::{
     Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
 };
-use ratatui::prelude::{Alignment, Constraint, Frame, Line, Modifier, Span, Style};
+use ratatui::prelude::{Alignment, Constraint, Frame, Line, Modifier, Rect, Span, Style};
 use ratatui::widgets::{Block, Borders, Cell, Clear, Padding, Paragraph, Row, Table, TableState};
 use std::collections::HashMap;
 use std::path::{Component, Path};
@@ -463,11 +463,9 @@ fn time_since_label(ts_iso: &str, now: &DateTime<Utc>) -> String {
     if days > 0 {
         format!("{days}d {hours}h ago")
     } else if hours > 0 {
-        let minute_unit = if minutes == 1 { "min" } else { "mins" };
-        format!("{hours}h {minutes}{minute_unit} ago")
+        format!("{hours:>2}h {minutes}m ago")
     } else if minutes > 0 {
-        let minute_unit = if minutes == 1 { "min" } else { "mins" };
-        format!("{minutes}{minute_unit} {seconds}s ago")
+        format!("{minutes}m {seconds}s ago")
     } else {
         format!("{seconds}s ago")
     }
@@ -628,40 +626,82 @@ fn journal_detail_height(inner_height: u16) -> u16 {
     u16::from(inner_height >= 5)
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct JournalScreenRegions {
+    header: Rect,
+    search: Option<Rect>,
+    panel: Rect,
+    footer: Rect,
+}
+
+fn journal_screen_regions(screen_area: Rect, search_active: bool) -> JournalScreenRegions {
+    let area = centered_rect(88, 94, screen_area);
+    let show_search = search_active && area.height >= 6;
+    if show_search {
+        let regions = ratatui::layout::Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
+        .split(area);
+        JournalScreenRegions {
+            header: regions[0],
+            search: Some(regions[1]),
+            panel: regions[2],
+            footer: regions[3],
+        }
+    } else {
+        let regions = ratatui::layout::Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
+        .split(area);
+        JournalScreenRegions {
+            header: regions[0],
+            search: None,
+            panel: regions[1],
+            footer: regions[2],
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct JournalContentRegions {
+    table: Rect,
+    detail: Rect,
+}
+
+fn journal_content_regions(content: Rect) -> JournalContentRegions {
+    let detail_height = journal_detail_height(content.height);
+    let spacer_height = u16::from(detail_height > 0);
+    let regions = ratatui::layout::Layout::vertical([
+        Constraint::Min(3),
+        Constraint::Length(spacer_height),
+        Constraint::Length(detail_height),
+    ])
+    .split(content);
+    JournalContentRegions {
+        table: regions[0],
+        detail: regions[2],
+    }
+}
+
 fn journal_page_rows(app_state: &AppState) -> usize {
     let screen_area = app_state.screen_area;
     if screen_area.width == 0 || screen_area.height == 0 {
         return 1;
     }
 
-    let area = centered_rect(88, 94, screen_area);
     let search_panel_active =
         app_state.ui.journal.is_searching || !app_state.ui.journal.search_query.is_empty();
-    let journal_area = if search_panel_active && area.height >= 7 {
-        ratatui::layout::Layout::vertical([Constraint::Length(3), Constraint::Min(1)]).split(area)
-            [1]
-    } else {
-        area
-    };
-    let panel_area = ratatui::layout::Layout::vertical([
-        Constraint::Length(1),
-        Constraint::Min(1),
-        Constraint::Length(1),
-    ])
-    .split(journal_area)[1];
+    let screen_regions = journal_screen_regions(screen_area, search_panel_active);
     let inner = Block::default()
         .borders(Borders::ALL)
         .padding(Padding::new(2, 2, 0, 0))
-        .inner(panel_area);
-    let detail_height = journal_detail_height(inner.height);
-    let spacer_height = u16::from(detail_height > 0);
-    let table_height = ratatui::layout::Layout::vertical([
-        Constraint::Min(3),
-        Constraint::Length(spacer_height),
-        Constraint::Length(detail_height),
-    ])
-    .split(inner)[0]
-        .height;
+        .inner(screen_regions.panel);
+    let table_height = journal_content_regions(inner).table.height;
 
     usize::from(table_height.saturating_sub(1).max(1))
 }
@@ -807,10 +847,7 @@ fn activity_detail_line(
     width: u16,
 ) -> Line<'static> {
     let Some(activity) = activity else {
-        return Line::from(Span::styled(
-            "No journal activities yet.",
-            ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1)),
-        ));
+        return Line::default();
     };
 
     let latest = activity.latest();
@@ -879,27 +916,7 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
         app_state.ui.journal.is_searching || !app_state.ui.journal.search_query.is_empty();
     let area = centered_rect(88, 94, f.area());
     f.render_widget(Clear, area);
-
-    let (search_area, journal_area) = if search_panel_active && area.height >= 7 {
-        let chunks = ratatui::layout::Layout::vertical([Constraint::Length(3), Constraint::Min(1)])
-            .split(area);
-        (Some(chunks[0]), chunks[1])
-    } else {
-        (None, area)
-    };
-    if let Some(search_area) = search_area {
-        draw_journal_search_panel(f, search_area, app_state, activities.len(), ctx);
-    }
-
-    let layout = ratatui::layout::Layout::vertical([
-        Constraint::Length(1),
-        Constraint::Min(1),
-        Constraint::Length(1),
-    ])
-    .split(journal_area);
-    let header_area = layout[0];
-    let panel_area = layout[1];
-    let footer_area = layout[2];
+    let screen_regions = journal_screen_regions(f.area(), search_panel_active);
 
     let entry_count = activities
         .iter()
@@ -938,16 +955,41 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
     })
     .collect::<Vec<_>>();
 
+    let filter_width = filter_spans
+        .iter()
+        .map(|span| span.content.chars().count())
+        .sum::<usize>();
+    let count_width = count_label.chars().count();
+    let symmetric_gutter = count_width.saturating_add(1);
+    let show_count = usize::from(screen_regions.header.width)
+        >= filter_width.saturating_add(symmetric_gutter.saturating_mul(2));
+    let (filter_area, count_area) = if show_count {
+        let gutter_width = u16::try_from(symmetric_gutter).unwrap_or(u16::MAX);
+        let regions = ratatui::layout::Layout::horizontal([
+            Constraint::Length(gutter_width),
+            Constraint::Min(1),
+            Constraint::Length(gutter_width),
+        ])
+        .split(screen_regions.header);
+        (regions[1], Some(regions[2]))
+    } else {
+        (screen_regions.header, None)
+    };
     f.render_widget(
         Paragraph::new(Line::from(filter_spans)).alignment(Alignment::Center),
-        header_area,
+        filter_area,
     );
-    f.render_widget(
-        Paragraph::new(count_label)
-            .alignment(Alignment::Right)
-            .style(ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1))),
-        header_area,
-    );
+    if let Some(count_area) = count_area {
+        f.render_widget(
+            Paragraph::new(count_label)
+                .alignment(Alignment::Right)
+                .style(ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1))),
+            count_area,
+        );
+    }
+    if let Some(search_area) = screen_regions.search {
+        draw_journal_search_panel(f, search_area, app_state, activities.len(), ctx);
+    }
 
     let mut panel = Block::default()
         .borders(Borders::ALL)
@@ -959,8 +1001,8 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
             ctx.apply(Style::default().fg(ctx.state_warning()).bold()),
         ));
     }
-    let inner = panel.inner(panel_area);
-    f.render_widget(panel, panel_area);
+    let inner = panel.inner(screen_regions.panel);
+    f.render_widget(panel, screen_regions.panel);
 
     if inner.width == 0 || inner.height == 0 {
         return;
@@ -973,18 +1015,14 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
         .min(activities.len().saturating_sub(1));
     let selected_activity = activities.get(selected_index);
     let detail_line = activity_detail_line(selected_activity, app_state, ctx, inner.width);
-    let detail_height = journal_detail_height(inner.height);
-    let spacer_height = u16::from(detail_height > 0);
-    let rows = ratatui::layout::Layout::vertical([
-        Constraint::Min(3),
-        Constraint::Length(spacer_height),
-        Constraint::Length(detail_height),
-    ])
-    .split(inner);
+    let content_regions = journal_content_regions(inner);
 
     let columns = columns_for_filter(app_state.ui.journal.filter);
-    let (window_start, window_end) =
-        journal_table_window(activities.len(), selected_index, rows[0].height);
+    let (window_start, window_end) = journal_table_window(
+        activities.len(),
+        selected_index,
+        content_regions.table.height,
+    );
     let now = Utc::now();
     let body_rows = activities[window_start..window_end]
         .iter()
@@ -1027,12 +1065,33 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
     if !activities.is_empty() {
         table_state.select(Some(selected_index.saturating_sub(window_start)));
     }
-    f.render_stateful_widget(table, rows[0], &mut table_state);
+    f.render_stateful_widget(table, content_regions.table, &mut table_state);
 
-    if detail_height > 0 {
+    if activities.is_empty() && content_regions.table.height > 1 {
+        let empty_body = Rect::new(
+            content_regions.table.x,
+            content_regions.table.y.saturating_add(1),
+            content_regions.table.width,
+            content_regions.table.height.saturating_sub(1),
+        );
+        let message = journal_empty_message(
+            app_state.ui.journal.filter,
+            !app_state.ui.journal.search_query.trim().is_empty(),
+        );
+        f.render_widget(
+            Paragraph::new(message)
+                .alignment(Alignment::Center)
+                .style(ctx.apply(
+                    Style::default().fg(journal_filter_color(app_state.ui.journal.filter, ctx)),
+                )),
+            centered_line_rect(empty_body),
+        );
+    }
+
+    if content_regions.detail.height > 0 {
         f.render_widget(
             Paragraph::new(detail_line).alignment(Alignment::Left),
-            rows[2],
+            content_regions.detail,
         );
     }
 
@@ -1067,7 +1126,7 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
         push_action("Shift+Y", "replay", ActionTone::Replay);
     }
     let footer_hint = Paragraph::new(Line::from(footer_spans)).alignment(Alignment::Center);
-    f.render_widget(footer_hint, footer_area);
+    f.render_widget(footer_hint, screen_regions.footer);
 }
 
 fn journal_filter_color(filter: JournalFilter, ctx: &ThemeContext) -> ratatui::style::Color {
@@ -1077,6 +1136,28 @@ fn journal_filter_color(filter: JournalFilter, ctx: &ThemeContext) -> ratatui::s
         JournalFilter::Commands => ctx.accent_sapphire(),
         JournalFilter::Health => ctx.state_success(),
     }
+}
+
+fn journal_empty_message(filter: JournalFilter, search_active: bool) -> &'static str {
+    match (filter, search_active) {
+        (JournalFilter::All, false) => "No journal activity yet.",
+        (JournalFilter::Queue, false) => "No ingest activity yet.",
+        (JournalFilter::Commands, false) => "No command activity yet.",
+        (JournalFilter::Health, false) => "No health activity yet.",
+        (JournalFilter::All, true) => "No journal activity matches the search.",
+        (JournalFilter::Queue, true) => "No ingest activity matches the search.",
+        (JournalFilter::Commands, true) => "No command activity matches the search.",
+        (JournalFilter::Health, true) => "No health activity matches the search.",
+    }
+}
+
+fn centered_line_rect(area: Rect) -> Rect {
+    Rect::new(
+        area.x,
+        area.y.saturating_add(area.height.saturating_sub(1) / 2),
+        area.width,
+        u16::from(area.height > 0),
+    )
 }
 
 fn draw_journal_search_panel(
@@ -1129,6 +1210,7 @@ mod tests {
     use crate::theme::ThemeContext;
     use crate::tui::screen_context::ScreenContext;
     use ratatui::backend::TestBackend;
+    use ratatui::buffer::Buffer;
     use ratatui::crossterm::event::{KeyEvent, KeyModifiers};
     use ratatui::Terminal;
     use std::fs;
@@ -1177,7 +1259,7 @@ mod tests {
         handle_event_inner(event, app_state, app_command_tx, None);
     }
 
-    fn render_journal_text(app_state: &AppState, width: u16, height: u16) -> String {
+    fn render_journal_buffer(app_state: &AppState, width: u16, height: u16) -> Buffer {
         let backend = TestBackend::new(width, height);
         let mut terminal = Terminal::new(backend).expect("create journal test terminal");
         let dht_status = DhtStatus::default();
@@ -1198,7 +1280,11 @@ mod tests {
             })
             .expect("draw journal test frame");
 
-        let buffer = terminal.backend().buffer();
+        terminal.backend().buffer().clone()
+    }
+
+    fn render_journal_text(app_state: &AppState, width: u16, height: u16) -> String {
+        let buffer = render_journal_buffer(app_state, width, height);
         (0..height)
             .map(|y| {
                 (0..width)
@@ -1229,6 +1315,95 @@ mod tests {
             &tx,
         );
         assert_eq!(app_state.ui.journal.filter, JournalFilter::Commands);
+    }
+
+    #[test]
+    fn header_filter_items_keep_their_colors() {
+        let app_state = base_state();
+        let width = 120;
+        let height = 40;
+        let buffer = render_journal_buffer(&app_state, width, height);
+        let screen_regions = journal_screen_regions(Rect::new(0, 0, width, height), false);
+        let filter_y = screen_regions.header.y;
+        let filter_text = (0..width)
+            .filter_map(|x| buffer.cell((x, filter_y)).map(|cell| cell.symbol()))
+            .collect::<String>();
+        let ctx = ThemeContext::new(app_state.theme, 0.0);
+
+        for filter in [
+            JournalFilter::All,
+            JournalFilter::Queue,
+            JournalFilter::Commands,
+            JournalFilter::Health,
+        ] {
+            let label_x = filter_text
+                .find(filter.label())
+                .expect("filter label should render inside the panel")
+                as u16;
+            assert_eq!(
+                buffer.cell((label_x, filter_y)).expect("filter cell").fg,
+                journal_filter_color(filter, &ctx)
+            );
+        }
+    }
+
+    #[test]
+    fn layout_keeps_header_and_search_above_the_content_panel() {
+        let screen_regions = journal_screen_regions(Rect::new(0, 0, 120, 40), true);
+        let search = screen_regions.search.expect("search region");
+
+        assert!(screen_regions.header.bottom() <= search.y);
+        assert!(search.bottom() <= screen_regions.panel.y);
+        assert!(screen_regions.panel.bottom() <= screen_regions.footer.y);
+    }
+
+    #[test]
+    fn page_capacity_uses_the_rendered_table_region_with_search() {
+        let mut app_state = base_state();
+        app_state.screen_area = Rect::new(0, 0, 120, 30);
+        app_state.ui.journal.is_searching = true;
+        let screen_regions = journal_screen_regions(app_state.screen_area, true);
+        let inner = Block::default()
+            .borders(Borders::ALL)
+            .padding(Padding::new(2, 2, 0, 0))
+            .inner(screen_regions.panel);
+        let table = journal_content_regions(inner).table;
+
+        assert_eq!(
+            journal_page_rows(&app_state),
+            usize::from(table.height.saturating_sub(1).max(1))
+        );
+    }
+
+    #[test]
+    fn empty_filters_render_specific_states() {
+        let mut app_state = base_state();
+        app_state.event_journal_state.entries.clear();
+
+        for (filter, message) in [
+            (JournalFilter::All, "No journal activity yet."),
+            (JournalFilter::Queue, "No ingest activity yet."),
+            (JournalFilter::Commands, "No command activity yet."),
+            (JournalFilter::Health, "No health activity yet."),
+        ] {
+            app_state.ui.journal.filter = filter;
+            let rendered = render_journal_text(&app_state, 120, 40);
+            assert!(rendered.contains(message), "{rendered}");
+        }
+    }
+
+    #[test]
+    fn empty_search_uses_matching_state() {
+        let mut app_state = base_state();
+        app_state.ui.journal.filter = JournalFilter::Commands;
+        app_state.ui.journal.search_query = "no matching command".to_string();
+
+        let rendered = render_journal_text(&app_state, 120, 40);
+
+        assert!(
+            rendered.contains("No command activity matches the search."),
+            "{rendered}"
+        );
     }
 
     #[test]
@@ -1710,11 +1885,12 @@ mod tests {
         assert_eq!(time_since_label("2026-03-15T14:59:40Z", &now), "20s ago");
         assert_eq!(
             time_since_label("2026-03-15T14:29:40Z", &now),
-            "30mins 20s ago"
+            "30m 20s ago"
         );
+        assert_eq!(time_since_label("2026-03-15T12:55:00Z", &now), " 2h 5m ago");
         assert_eq!(
-            time_since_label("2026-03-15T12:55:00Z", &now),
-            "2h 5mins ago"
+            time_since_label("2026-03-15T13:14:00Z", &now),
+            " 1h 46m ago"
         );
         assert_eq!(time_since_label("invalid", &now), "-");
     }

--- a/src/tui/screens/journal.rs
+++ b/src/tui/screens/journal.rs
@@ -402,7 +402,7 @@ fn activity_search_haystack(activity: &JournalActivity<'_>) -> String {
     let mut haystack = String::with_capacity(activity.len().saturating_mul(192));
     for entry in activity.entries() {
         append_search_field(&mut haystack, event_type_label(entry));
-        append_control_search_fields(&mut haystack, &entry.details);
+        append_event_detail_search_fields(&mut haystack, &entry.details);
         append_search_field(&mut haystack, entry.torrent_name.as_deref().unwrap_or("-"));
         if let Some(path) = entry
             .source_path
@@ -440,67 +440,89 @@ fn append_search_field(haystack: &mut String, field: &str) {
     haystack.push_str(field);
 }
 
-fn append_control_search_fields(haystack: &mut String, details: &EventDetails) {
-    let EventDetails::Control {
-        action,
-        target_info_hash_hex,
-        file_index,
-        file_path,
-        priority,
-        ..
-    } = details
-    else {
-        return;
-    };
+fn append_search_number(haystack: &mut String, number: usize) {
+    if !haystack.is_empty() {
+        haystack.push(' ');
+    }
+    let _ = write!(haystack, "{number}");
+}
 
-    append_search_field(haystack, action);
-    if let Some(info_hash) = target_info_hash_hex.as_deref() {
-        append_search_field(haystack, info_hash);
-    }
-    if let Some(file_index) = file_index {
-        if !haystack.is_empty() {
-            haystack.push(' ');
+fn append_event_detail_search_fields(haystack: &mut String, details: &EventDetails) {
+    match details {
+        EventDetails::Control {
+            action,
+            target_info_hash_hex,
+            file_index,
+            file_path,
+            priority,
+            ..
+        } => {
+            append_search_field(haystack, action);
+            if let Some(info_hash) = target_info_hash_hex.as_deref() {
+                append_search_field(haystack, info_hash);
+            }
+            if let Some(file_index) = file_index {
+                append_search_number(haystack, *file_index);
+            }
+            if let Some(file_path) = file_path.as_deref() {
+                append_search_field(haystack, file_path);
+            }
+            if let Some(priority) = priority.as_deref() {
+                append_search_field(haystack, priority);
+            }
         }
-        let _ = write!(haystack, "{file_index}");
-    }
-    if let Some(file_path) = file_path.as_deref() {
-        append_search_field(haystack, file_path);
-    }
-    if let Some(priority) = priority.as_deref() {
-        append_search_field(haystack, priority);
+        EventDetails::DataHealth {
+            issue_count,
+            issue_files,
+        } => {
+            append_search_number(haystack, *issue_count);
+            for issue_file in issue_files {
+                append_search_field(haystack, issue_file);
+            }
+        }
+        _ => {}
     }
 }
 
-fn control_details_match_regex(details: &EventDetails, regex: &regex::Regex) -> bool {
-    let EventDetails::Control {
-        action,
-        target_info_hash_hex,
-        file_index,
-        file_path,
-        priority,
-        ..
-    } = details
-    else {
-        return false;
-    };
-
-    regex.is_match(action)
-        || target_info_hash_hex
-            .as_deref()
-            .is_some_and(|info_hash| regex.is_match(info_hash))
-        || file_index.is_some_and(|index| regex.is_match(&index.to_string()))
-        || file_path
-            .as_deref()
-            .is_some_and(|path| regex.is_match(path))
-        || priority
-            .as_deref()
-            .is_some_and(|priority| regex.is_match(priority))
+fn event_details_match_regex(details: &EventDetails, regex: &regex::Regex) -> bool {
+    match details {
+        EventDetails::Control {
+            action,
+            target_info_hash_hex,
+            file_index,
+            file_path,
+            priority,
+            ..
+        } => {
+            regex.is_match(action)
+                || target_info_hash_hex
+                    .as_deref()
+                    .is_some_and(|info_hash| regex.is_match(info_hash))
+                || file_index.is_some_and(|index| regex.is_match(&index.to_string()))
+                || file_path
+                    .as_deref()
+                    .is_some_and(|path| regex.is_match(path))
+                || priority
+                    .as_deref()
+                    .is_some_and(|priority| regex.is_match(priority))
+        }
+        EventDetails::DataHealth {
+            issue_count,
+            issue_files,
+        } => {
+            regex.is_match(&issue_count.to_string())
+                || issue_files
+                    .iter()
+                    .any(|issue_file| regex.is_match(issue_file))
+        }
+        _ => false,
+    }
 }
 
 fn activity_matches_regex(activity: &JournalActivity<'_>, regex: &regex::Regex) -> bool {
     activity.entries().any(|entry| {
         regex.is_match(event_type_label(entry))
-            || control_details_match_regex(&entry.details, regex)
+            || event_details_match_regex(&entry.details, regex)
             || entry
                 .torrent_name
                 .as_deref()
@@ -1691,6 +1713,37 @@ mod tests {
         for mode in [SearchMode::Fuzzy, SearchMode::Regex] {
             app_state.ui.journal.search_mode = mode;
             for query in ["feedcafe", "731", "segment-omega", "high"] {
+                app_state.ui.journal.search_query = query.to_string();
+                assert_eq!(
+                    journal_activities(&app_state).len(),
+                    1,
+                    "{mode:?} search should match {query}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn health_search_matches_issue_details_in_both_modes() {
+        let mut app_state = base_state();
+        app_state.ui.journal.filter = JournalFilter::Health;
+        app_state.event_journal_state.entries = vec![EventJournalEntry {
+            category: EventCategory::DataHealth,
+            event_type: EventType::DataUnavailable,
+            message: Some("Health probe found unavailable data.".to_string()),
+            details: EventDetails::DataHealth {
+                issue_count: 731,
+                issue_files: vec![
+                    "content/missing-ember.bin".to_string(),
+                    "content/corrupt-slate.bin".to_string(),
+                ],
+            },
+            ..Default::default()
+        }];
+
+        for mode in [SearchMode::Fuzzy, SearchMode::Regex] {
+            app_state.ui.journal.search_mode = mode;
+            for query in ["731", "missing-ember", "corrupt-slate"] {
                 app_state.ui.journal.search_query = query.to_string();
                 assert_eq!(
                     journal_activities(&app_state).len(),

--- a/src/tui/screens/journal.rs
+++ b/src/tui/screens/journal.rs
@@ -5,14 +5,16 @@ use crate::app::{AppCommand, AppMode, AppState, JournalFilter};
 use crate::persistence::event_journal::{
     EventCategory, EventDetails, EventJournalEntry, EventType,
 };
+use crate::theme::ThemeContext;
 use crate::tui::action_style::{footer_key_style, ActionTone};
 use crate::tui::app_command::spawn_app_command_sender;
-use crate::tui::formatters::sanitize_text;
+use crate::tui::formatters::{sanitize_text, truncate_with_ellipsis};
 use crate::tui::screen_context::ScreenContext;
 use chrono::{DateTime, Local};
 use ratatui::crossterm::event::{Event as CrosstermEvent, KeyCode, KeyEventKind};
 use ratatui::prelude::{Alignment, Constraint, Frame, Line, Modifier, Span, Style};
-use ratatui::widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, TableState, Wrap};
+use ratatui::widgets::{Block, Borders, Cell, Clear, Padding, Paragraph, Row, Table, TableState};
+use std::collections::HashMap;
 use std::path::{Component, Path};
 use tokio::sync::{broadcast, mpsc};
 
@@ -86,7 +88,7 @@ fn handle_event_inner(
                 app_state.ui.journal.selected_index.saturating_sub(1);
         }
         JournalAction::MoveDown => {
-            let len = filtered_entries(app_state).len();
+            let len = journal_activities(app_state).len();
             if len > 0 {
                 app_state.ui.journal.selected_index =
                     (app_state.ui.journal.selected_index + 1).min(len - 1);
@@ -107,14 +109,130 @@ fn entry_matches_filter(entry: &EventJournalEntry, filter: JournalFilter) -> boo
     }
 }
 
-fn filtered_entries(app_state: &AppState) -> Vec<&EventJournalEntry> {
-    app_state
-        .event_journal_state
-        .entries
-        .iter()
-        .rev()
-        .filter(|entry| entry_matches_filter(entry, app_state.ui.journal.filter))
-        .collect()
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ActivityPhase {
+    Queued,
+    Terminal,
+    Standalone,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct ActivityKey<'a> {
+    category: u8,
+    scope: u8,
+    host_id: Option<&'a str>,
+    correlation_id: &'a str,
+}
+
+#[derive(Debug)]
+struct JournalActivity<'a> {
+    entries: Vec<&'a EventJournalEntry>,
+    latest_position: usize,
+}
+
+impl<'a> JournalActivity<'a> {
+    fn new(entry: &'a EventJournalEntry, position: usize) -> Self {
+        Self {
+            entries: vec![entry],
+            latest_position: position,
+        }
+    }
+
+    fn latest(&self) -> &'a EventJournalEntry {
+        self.entries
+            .last()
+            .copied()
+            .expect("journal activities always contain an entry")
+    }
+
+    fn source_entry(&self) -> &'a EventJournalEntry {
+        self.entries
+            .iter()
+            .rev()
+            .find(|entry| entry.source_path.is_some() || entry.source_watch_folder.is_some())
+            .copied()
+            .unwrap_or_else(|| self.latest())
+    }
+
+    fn torrent_entry(&self) -> &'a EventJournalEntry {
+        self.entries
+            .iter()
+            .rev()
+            .find(|entry| entry.torrent_name.is_some() || entry.info_hash_hex.is_some())
+            .copied()
+            .unwrap_or_else(|| self.latest())
+    }
+}
+
+fn activity_phase(entry: &EventJournalEntry) -> ActivityPhase {
+    match (entry.category, entry.event_type) {
+        (EventCategory::Ingest, EventType::IngestQueued)
+        | (EventCategory::Control, EventType::ControlQueued) => ActivityPhase::Queued,
+        (
+            EventCategory::Ingest,
+            EventType::IngestAdded
+            | EventType::IngestDuplicate
+            | EventType::IngestInvalid
+            | EventType::IngestFailed,
+        )
+        | (EventCategory::Control, EventType::ControlApplied | EventType::ControlFailed) => {
+            ActivityPhase::Terminal
+        }
+        _ => ActivityPhase::Standalone,
+    }
+}
+
+fn activity_key(entry: &EventJournalEntry) -> Option<ActivityKey<'_>> {
+    let category = match entry.category {
+        EventCategory::Ingest => 0,
+        EventCategory::Control => 1,
+        _ => return None,
+    };
+    let scope = match entry.scope {
+        crate::persistence::event_journal::EventScope::Host => 0,
+        crate::persistence::event_journal::EventScope::Shared => 1,
+    };
+
+    Some(ActivityKey {
+        category,
+        scope,
+        host_id: entry.host_id.as_deref(),
+        correlation_id: entry.correlation_id.as_deref()?,
+    })
+}
+
+fn journal_activities(app_state: &AppState) -> Vec<JournalActivity<'_>> {
+    let mut activities = Vec::<JournalActivity<'_>>::new();
+    let mut open_activities = HashMap::<ActivityKey<'_>, Vec<usize>>::new();
+
+    for (position, entry) in app_state.event_journal_state.entries.iter().enumerate() {
+        if !entry_matches_filter(entry, app_state.ui.journal.filter) {
+            continue;
+        }
+
+        match (activity_phase(entry), activity_key(entry)) {
+            (ActivityPhase::Queued, Some(key)) => {
+                let activity_index = activities.len();
+                activities.push(JournalActivity::new(entry, position));
+                open_activities.entry(key).or_default().push(activity_index);
+            }
+            (ActivityPhase::Terminal, Some(key)) => {
+                let open_activity = open_activities
+                    .get_mut(&key)
+                    .and_then(|activity_indices| activity_indices.pop());
+                if let Some(activity_index) = open_activity {
+                    activities[activity_index].entries.push(entry);
+                    activities[activity_index].latest_position = position;
+                } else {
+                    activities.push(JournalActivity::new(entry, position));
+                }
+            }
+            _ => activities.push(JournalActivity::new(entry, position)),
+        }
+    }
+
+    activities.sort_by_key(|activity| std::cmp::Reverse(activity.latest_position));
+    activities
 }
 
 fn event_type_label(entry: &EventJournalEntry) -> &'static str {
@@ -146,14 +264,14 @@ fn source_label(entry: &EventJournalEntry, anonymize: bool) -> String {
     }
 
     entry
-        .source_watch_folder
+        .source_path
         .as_ref()
-        .map(|path| compact_path_label(path, 2))
+        .map(|path| compact_path_label(path, 1))
         .or_else(|| {
             entry
-                .source_path
+                .source_watch_folder
                 .as_ref()
-                .map(|path| compact_path_label(path, 2))
+                .map(|path| compact_path_label(path, 1))
         })
         .unwrap_or_else(|| "-".to_string())
 }
@@ -215,9 +333,15 @@ fn preferred_source_text(entry: &EventJournalEntry) -> Option<String> {
 
 fn pretty_timestamp(ts_iso: &str) -> String {
     DateTime::parse_from_rfc3339(ts_iso)
+        .map(|dt| dt.with_timezone(&Local).format("%b %d %H:%M").to_string())
+        .unwrap_or_else(|_| ts_iso.to_string())
+}
+
+fn detailed_timestamp(ts_iso: &str) -> String {
+    DateTime::parse_from_rfc3339(ts_iso)
         .map(|dt| {
             dt.with_timezone(&Local)
-                .format("%b %d %I:%M %p")
+                .format("%b %d %I:%M:%S %p")
                 .to_string()
         })
         .unwrap_or_else(|_| ts_iso.to_string())
@@ -255,7 +379,7 @@ fn detail_text(entry: Option<&EventJournalEntry>, anonymize: bool) -> String {
     let mut text = entry
         .message
         .clone()
-        .unwrap_or_else(|| "No journal entries yet.".to_string());
+        .unwrap_or_else(|| "No details recorded.".to_string());
 
     if anonymize {
         if let Some(torrent_name) = &entry.torrent_name {
@@ -273,23 +397,6 @@ fn detail_text(entry: Option<&EventJournalEntry>, anonymize: bool) -> String {
     }
 
     sanitize_text(&text)
-}
-
-fn selected_detail_text(app_state: &AppState, entry: Option<&EventJournalEntry>) -> String {
-    let Some(entry) = entry else {
-        return "No journal entries yet.".to_string();
-    };
-
-    let source_text = preferred_source_text(entry);
-
-    if let Some(source_text) = source_text {
-        if app_state.anonymize_torrent_names {
-            return "/path/to/source".to_string();
-        }
-        return sanitize_text(&source_text);
-    }
-
-    detail_text(Some(entry), app_state.anonymize_torrent_names)
 }
 
 fn replay_command_for_path(path: &Path) -> Option<AppCommand> {
@@ -312,13 +419,23 @@ fn replay_selected_entry(
     app_command_tx: &mpsc::Sender<AppCommand>,
     shutdown_tx: Option<&broadcast::Sender<()>>,
 ) {
-    let entries = filtered_entries(app_state);
-    let Some(entry) = entries.get(app_state.ui.journal.selected_index).copied() else {
+    let activities = journal_activities(app_state);
+    let selected_index = app_state
+        .ui
+        .journal
+        .selected_index
+        .min(activities.len().saturating_sub(1));
+    let Some(activity) = activities.get(selected_index) else {
         app_state.ui.journal.status_message = Some("No journal entry selected".to_string());
         return;
     };
 
-    let Some(source_path) = entry.source_path.as_ref() else {
+    let Some(source_path) = activity
+        .entries
+        .iter()
+        .rev()
+        .find_map(|entry| entry.source_path.as_ref())
+    else {
         app_state.ui.journal.status_message =
             Some("Selected entry has no replayable source file".to_string());
         return;
@@ -357,9 +474,9 @@ fn replay_selected_entry(
 #[derive(Clone, Copy)]
 enum JournalColumn {
     Time,
-    Event,
+    Status,
+    Subject,
     Done,
-    Torrent,
     Source,
 }
 
@@ -367,108 +484,262 @@ fn columns_for_filter(filter: JournalFilter) -> Vec<JournalColumn> {
     match filter {
         JournalFilter::All => vec![
             JournalColumn::Time,
-            JournalColumn::Event,
+            JournalColumn::Status,
+            JournalColumn::Subject,
             JournalColumn::Done,
-            JournalColumn::Torrent,
             JournalColumn::Source,
         ],
         JournalFilter::Queue => vec![
             JournalColumn::Time,
-            JournalColumn::Event,
+            JournalColumn::Status,
+            JournalColumn::Subject,
             JournalColumn::Done,
-            JournalColumn::Torrent,
             JournalColumn::Source,
         ],
         JournalFilter::Commands => {
             vec![
                 JournalColumn::Time,
-                JournalColumn::Event,
+                JournalColumn::Status,
+                JournalColumn::Subject,
                 JournalColumn::Source,
             ]
         }
         JournalFilter::Health => vec![
             JournalColumn::Time,
-            JournalColumn::Event,
-            JournalColumn::Torrent,
+            JournalColumn::Status,
+            JournalColumn::Subject,
         ],
     }
 }
 
-fn column_header(column: JournalColumn) -> &'static str {
-    match column {
-        JournalColumn::Time => "Time",
-        JournalColumn::Event => "Event",
-        JournalColumn::Done => "Done",
-        JournalColumn::Torrent => "Torrent",
-        JournalColumn::Source => "Source",
+fn column_header(column: JournalColumn, filter: JournalFilter) -> &'static str {
+    match (column, filter) {
+        (JournalColumn::Subject, JournalFilter::Commands) => "Action",
+        (JournalColumn::Subject, _) => "Torrent",
+        (JournalColumn::Time, _) => "Time",
+        (JournalColumn::Status, _) => "Status",
+        (JournalColumn::Done, _) => "Done",
+        (JournalColumn::Source, _) => "Source",
     }
+}
+
+fn visible_columns(filter: JournalFilter, width: u16) -> Vec<JournalColumn> {
+    columns_for_filter(filter)
+        .into_iter()
+        .filter(|column| match column {
+            JournalColumn::Source => width >= 96,
+            JournalColumn::Done => width >= 76,
+            _ => true,
+        })
+        .collect()
+}
+
+fn column_header_style(column: JournalColumn, ctx: &ThemeContext) -> Style {
+    let color = match column {
+        JournalColumn::Time => ctx.theme.semantic.subtext0,
+        JournalColumn::Status => ctx.state_warning(),
+        JournalColumn::Subject => ctx.accent_sky(),
+        JournalColumn::Done => ctx.state_success(),
+        JournalColumn::Source => ctx.accent_sapphire(),
+    };
+    ctx.apply(Style::default().fg(color).bold())
 }
 
 fn column_constraint(column: JournalColumn, filter: JournalFilter) -> Constraint {
     match (filter, column) {
-        (_, JournalColumn::Time) => Constraint::Length(17),
-        (JournalFilter::Commands, JournalColumn::Event) => Constraint::Percentage(34),
-        (JournalFilter::Health, JournalColumn::Event) => Constraint::Length(10),
-        (_, JournalColumn::Event) => Constraint::Length(10),
-        (_, JournalColumn::Done) => Constraint::Length(8),
-        (JournalFilter::Health, JournalColumn::Torrent) => Constraint::Min(10),
-        (_, JournalColumn::Torrent) => Constraint::Percentage(41),
-        (JournalFilter::Commands, JournalColumn::Source) => Constraint::Percentage(46),
-        (_, JournalColumn::Source) => Constraint::Percentage(24),
+        (_, JournalColumn::Time) => Constraint::Length(13),
+        (_, JournalColumn::Status) => Constraint::Length(22),
+        (_, JournalColumn::Subject) => Constraint::Fill(1),
+        (_, JournalColumn::Done) => Constraint::Length(7),
+        (_, JournalColumn::Source) => Constraint::Length(22),
     }
+}
+
+fn event_status_color(entry: &EventJournalEntry, ctx: &ThemeContext) -> ratatui::style::Color {
+    match entry.event_type {
+        EventType::IngestQueued | EventType::ControlQueued => ctx.state_warning(),
+        EventType::IngestAdded | EventType::DataRecovered | EventType::ControlApplied => {
+            ctx.state_success()
+        }
+        EventType::TorrentCompleted => ctx.state_complete(),
+        EventType::IngestDuplicate => ctx.state_info(),
+        EventType::IngestInvalid
+        | EventType::IngestFailed
+        | EventType::DataUnavailable
+        | EventType::ControlFailed => ctx.state_error(),
+    }
+}
+
+fn event_status_style(entry: &EventJournalEntry, ctx: &ThemeContext) -> Style {
+    let style = Style::default().fg(event_status_color(entry, ctx));
+    if matches!(activity_phase(entry), ActivityPhase::Terminal)
+        || matches!(
+            entry.event_type,
+            EventType::TorrentCompleted | EventType::DataUnavailable | EventType::DataRecovered
+        )
+    {
+        ctx.apply(style.bold())
+    } else {
+        ctx.apply(style)
+    }
+}
+
+fn activity_status_cell(activity: &JournalActivity<'_>, ctx: &ThemeContext) -> Cell<'static> {
+    let mut spans = Vec::new();
+    for (index, entry) in activity.entries.iter().enumerate() {
+        if index > 0 {
+            spans.push(Span::styled(
+                " → ",
+                ctx.apply(Style::default().fg(ctx.theme.semantic.overlay0)),
+            ));
+        }
+        spans.push(Span::styled("● ", event_status_style(entry, ctx)));
+        spans.push(Span::styled(
+            event_type_label(entry).to_string(),
+            event_status_style(entry, ctx),
+        ));
+    }
+    Cell::from(Line::from(spans))
+}
+
+fn activity_subject_label(activity: &JournalActivity<'_>, anonymize: bool) -> String {
+    let entry = activity.latest();
+    if matches!(entry.category, EventCategory::Control) {
+        command_action_label(entry)
+    } else {
+        torrent_label(activity.torrent_entry(), anonymize)
+    }
+}
+
+fn activity_progress_label(activity: &JournalActivity<'_>, app_state: &AppState) -> String {
+    activity
+        .entries
+        .iter()
+        .rev()
+        .find(|entry| live_completion_percent(entry, app_state).is_some())
+        .map(|entry| progress_label(entry, app_state))
+        .unwrap_or_else(|| "-".to_string())
 }
 
 fn column_cell(
     column: JournalColumn,
-    entry: &EventJournalEntry,
+    activity: &JournalActivity<'_>,
     app_state: &AppState,
+    ctx: &ThemeContext,
 ) -> Cell<'static> {
     match column {
-        JournalColumn::Time => Cell::from(pretty_timestamp(&entry.ts_iso)),
-        JournalColumn::Event => {
-            let label = if matches!(app_state.ui.journal.filter, JournalFilter::Commands) {
-                command_action_label(entry)
-            } else {
-                event_type_label(entry).to_string()
-            };
-            Cell::from(label)
-        }
-        JournalColumn::Done => Cell::from(progress_label(entry, app_state)),
-        JournalColumn::Torrent => {
-            Cell::from(torrent_label(entry, app_state.anonymize_torrent_names))
-        }
-        JournalColumn::Source => Cell::from(source_label(entry, app_state.anonymize_torrent_names)),
+        JournalColumn::Time => Cell::from(pretty_timestamp(&activity.latest().ts_iso))
+            .style(ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0))),
+        JournalColumn::Status => activity_status_cell(activity, ctx),
+        JournalColumn::Subject => Cell::from(activity_subject_label(
+            activity,
+            app_state.anonymize_torrent_names,
+        ))
+        .style(ctx.apply(Style::default().fg(ctx.theme.semantic.text))),
+        JournalColumn::Done => Cell::from(activity_progress_label(activity, app_state))
+            .style(ctx.apply(Style::default().fg(ctx.state_success()).bold())),
+        JournalColumn::Source => Cell::from(source_label(
+            activity.source_entry(),
+            app_state.anonymize_torrent_names,
+        ))
+        .style(ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1))),
     }
+}
+
+fn activity_detail_lines(
+    activity: Option<&JournalActivity<'_>>,
+    app_state: &AppState,
+    ctx: &ThemeContext,
+    width: u16,
+) -> Vec<Line<'static>> {
+    let Some(activity) = activity else {
+        return vec![Line::from(Span::styled(
+            "No journal activities yet.",
+            ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1)),
+        ))];
+    };
+
+    let record_message_width = usize::from(width.saturating_sub(35));
+    let mut lines = activity
+        .entries
+        .iter()
+        .map(|entry| {
+            let message = detail_text(Some(entry), app_state.anonymize_torrent_names);
+            Line::from(vec![
+                Span::styled("● ", event_status_style(entry, ctx)),
+                Span::styled(
+                    format!("{:<10}", event_type_label(entry)),
+                    event_status_style(entry, ctx),
+                ),
+                Span::styled(
+                    format!("{}  ", detailed_timestamp(&entry.ts_iso)),
+                    ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0)),
+                ),
+                Span::styled(
+                    truncate_with_ellipsis(&message, record_message_width),
+                    ctx.apply(Style::default().fg(ctx.theme.semantic.text)),
+                ),
+            ])
+        })
+        .collect::<Vec<_>>();
+
+    if let Some(source) = preferred_source_text(activity.source_entry()) {
+        let source = if app_state.anonymize_torrent_names {
+            "/path/to/source".to_string()
+        } else {
+            sanitize_text(&source)
+        };
+        let source = truncate_with_ellipsis(&source, usize::from(width.saturating_sub(10)));
+        lines.push(Line::from(vec![
+            Span::styled(
+                "  Source  ",
+                ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0)),
+            ),
+            Span::styled(
+                source,
+                ctx.apply(Style::default().fg(ctx.accent_sapphire())),
+            ),
+        ]));
+    }
+
+    lines
 }
 
 pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
     let app_state = screen.app.state;
     let ctx = screen.theme;
     let area = f.area();
-    let popup = crate::tui::formatters::centered_rect(92, 84, area);
-    let popup_layout =
-        ratatui::layout::Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(popup);
-    let body_area = popup_layout[0];
-    let footer_area = popup_layout[1];
+    let popup = crate::tui::formatters::centered_rect(94, 94, area);
+    let popup_layout = ratatui::layout::Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Min(0),
+        Constraint::Length(1),
+    ])
+    .split(popup);
+    let filter_area = popup_layout[0];
+    let panel_area = popup_layout[1];
+    let footer_area = popup_layout[2];
     f.render_widget(Clear, popup);
 
-    let outer = Block::default()
-        .title(Span::styled(
-            " Event Journal ",
-            ctx.apply(Style::default().fg(ctx.accent_sapphire()).bold()),
-        ))
-        .borders(Borders::ALL)
-        .border_style(ctx.apply(Style::default().fg(ctx.theme.semantic.border)));
-    let inner = outer.inner(body_area);
-    f.render_widget(outer, body_area);
-
-    let rows = ratatui::layout::Layout::vertical([
-        Constraint::Length(1),
-        Constraint::Length(1),
-        Constraint::Min(8),
-        Constraint::Length(4),
-    ])
-    .split(inner);
+    let activities = journal_activities(app_state);
+    let entry_count = activities
+        .iter()
+        .map(|activity| activity.entries.len())
+        .sum::<usize>();
+    let activity_label = if activities.len() == 1 {
+        "1 activity".to_string()
+    } else {
+        format!("{} activities", activities.len())
+    };
+    let count_label = if activities.len() == entry_count {
+        activity_label
+    } else {
+        format!("{activity_label} · {entry_count} records")
+    };
+    let count_width = u16::try_from(count_label.chars().count()).unwrap_or(u16::MAX);
+    let header_areas =
+        ratatui::layout::Layout::horizontal([Constraint::Min(0), Constraint::Length(count_width)])
+            .split(filter_area);
 
     let filter_spans = [
         JournalFilter::All,
@@ -478,135 +749,146 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
     ]
     .iter()
     .enumerate()
-    .flat_map(|(idx, filter)| {
+    .flat_map(|(index, filter)| {
         let style = if *filter == app_state.ui.journal.filter {
             ctx.apply(
                 Style::default()
-                    .fg(ctx.state_selected())
-                    .add_modifier(Modifier::BOLD),
+                    .fg(ctx.state_warning())
+                    .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
             )
         } else {
-            ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1))
+            ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0))
         };
-        let mut spans = vec![Span::styled(filter.label().to_string(), style)];
-        if idx < 3 {
-            spans.push(Span::styled(
-                "  ",
-                ctx.apply(Style::default().fg(ctx.theme.semantic.surface2)),
-            ));
+        let mut spans = vec![Span::styled(filter.label(), style)];
+        if index < 3 {
+            spans.push(Span::raw("   "));
         }
         spans
     })
     .collect::<Vec<_>>();
-    f.render_widget(Paragraph::new(Line::from(filter_spans)), rows[0]);
-
-    let entries = filtered_entries(app_state);
-    let status_line = app_state
-        .ui
-        .journal
-        .status_message
-        .as_ref()
-        .map(|message| format!("{} entries  |  {}", entries.len(), sanitize_text(message)))
-        .unwrap_or_else(|| format!("{} entries", entries.len()));
     f.render_widget(
-        Paragraph::new(status_line)
+        Paragraph::new(Line::from(filter_spans)).alignment(Alignment::Center),
+        header_areas[0],
+    );
+    f.render_widget(
+        Paragraph::new(count_label)
+            .alignment(Alignment::Right)
             .style(ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1))),
-        rows[1],
+        header_areas[1],
     );
 
-    let body_rows = entries
+    let panel = Block::default()
+        .title(Span::styled(
+            " Event Journal ",
+            ctx.apply(Style::default().fg(ctx.state_selected()).bold()),
+        ))
+        .borders(Borders::ALL)
+        .border_style(ctx.apply(Style::default().fg(ctx.theme.semantic.border)))
+        .padding(Padding::new(2, 2, 0, 0));
+    let inner = panel.inner(panel_area);
+    f.render_widget(panel, panel_area);
+
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+
+    let rows = ratatui::layout::Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Min(5),
+        Constraint::Length(1),
+        Constraint::Length(4),
+    ])
+    .split(inner);
+
+    if let Some(message) = &app_state.ui.journal.status_message {
+        f.render_widget(
+            Paragraph::new(sanitize_text(message))
+                .style(ctx.apply(Style::default().fg(ctx.state_warning()))),
+            rows[0],
+        );
+    }
+
+    let columns = visible_columns(app_state.ui.journal.filter, rows[1].width);
+    let body_rows = activities
         .iter()
-        .map(|entry| {
+        .map(|activity| {
             Row::new(
-                columns_for_filter(app_state.ui.journal.filter)
-                    .into_iter()
-                    .map(|column| column_cell(column, entry, app_state))
+                columns
+                    .iter()
+                    .copied()
+                    .map(|column| column_cell(column, activity, app_state, ctx))
                     .collect::<Vec<_>>(),
             )
+            .bottom_margin(1)
         })
         .collect::<Vec<_>>();
 
-    let columns = columns_for_filter(app_state.ui.journal.filter);
     let constraints = columns
         .iter()
         .map(|column| column_constraint(*column, app_state.ui.journal.filter))
         .collect::<Vec<_>>();
     let header_cells = columns
         .iter()
-        .map(|column| column_header(*column))
+        .map(|column| {
+            Cell::from(column_header(*column, app_state.ui.journal.filter))
+                .style(column_header_style(*column, ctx))
+        })
         .collect::<Vec<_>>();
 
     let table = Table::new(body_rows, constraints)
-        .header(
-            Row::new(header_cells).style(
-                ctx.apply(
-                    Style::default()
-                        .fg(ctx.theme.semantic.subtext0)
-                        .add_modifier(Modifier::BOLD),
-                ),
-            ),
-        )
+        .header(Row::new(header_cells).bottom_margin(1))
+        .column_spacing(2)
         .row_highlight_style(
             ctx.apply(
                 Style::default()
-                    .fg(ctx.theme.semantic.text)
-                    .bg(ctx.theme.semantic.surface0),
+                    .fg(ctx.state_warning())
+                    .add_modifier(Modifier::BOLD),
             ),
         )
-        .block(
-            Block::default()
-                .borders(Borders::TOP | Borders::BOTTOM)
-                .border_style(ctx.apply(Style::default().fg(ctx.theme.semantic.surface2))),
-        );
+        .highlight_symbol("▌ ");
 
+    let selected_index = app_state
+        .ui
+        .journal
+        .selected_index
+        .min(activities.len().saturating_sub(1));
     let mut table_state = TableState::default();
-    if !entries.is_empty() {
-        table_state.select(Some(
-            app_state.ui.journal.selected_index.min(entries.len() - 1),
-        ));
+    if !activities.is_empty() {
+        table_state.select(Some(selected_index));
     }
-    f.render_stateful_widget(table, rows[2], &mut table_state);
+    f.render_stateful_widget(table, rows[1], &mut table_state);
 
-    let details_text = selected_detail_text(
-        app_state,
-        entries.get(app_state.ui.journal.selected_index).copied(),
-    );
+    let selected_activity = activities.get(selected_index);
     f.render_widget(
-        Paragraph::new(details_text)
-            .wrap(Wrap { trim: true })
-            .alignment(Alignment::Left)
-            .style(ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1))),
+        Paragraph::new(activity_detail_lines(
+            selected_activity,
+            app_state,
+            ctx,
+            rows[3].width,
+        ))
+        .alignment(Alignment::Left),
         rows[3],
     );
 
-    let footer_hint = Paragraph::new(Line::from(vec![
-        Span::styled("[Tab]", footer_key_style(ctx, ActionTone::Mode)),
-        Span::styled(
-            " Filter  ",
-            ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1)),
-        ),
-        Span::styled("[Shift+Tab]", footer_key_style(ctx, ActionTone::Mode)),
-        Span::styled(
-            " Back  ",
-            ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1)),
-        ),
-        Span::styled("[j/k]", footer_key_style(ctx, ActionTone::Navigate)),
-        Span::styled(
-            " Move  ",
-            ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1)),
-        ),
-        Span::styled("[Shift+Y]", footer_key_style(ctx, ActionTone::Replay)),
-        Span::styled(
-            " Replay  ",
-            ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1)),
-        ),
-        Span::styled("[q]", footer_key_style(ctx, ActionTone::Cancel)),
-        Span::styled(
-            " Close",
-            ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1)),
-        ),
-    ]))
-    .alignment(Alignment::Center);
+    let mut footer_spans = Vec::new();
+    let mut push_action = |key: &str, label: &str, tone: ActionTone| {
+        if !footer_spans.is_empty() {
+            footer_spans.push(Span::raw("   "));
+        }
+        footer_spans.push(Span::styled(
+            format!("[{key}]"),
+            footer_key_style(ctx, tone),
+        ));
+        footer_spans.push(Span::styled(
+            format!(" {label}"),
+            ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0)),
+        ));
+    };
+    push_action("↑/↓", "nav", ActionTone::Navigate);
+    push_action("Tab", "filter", ActionTone::Mode);
+    push_action("Shift+Y", "replay", ActionTone::Replay);
+    push_action("Esc", "back", ActionTone::Cancel);
+    let footer_hint = Paragraph::new(Line::from(footer_spans)).alignment(Alignment::Center);
     f.render_widget(footer_hint, footer_area);
 }
 
@@ -614,8 +896,14 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
 mod tests {
     use super::*;
     use crate::app::{TorrentDisplayState, TorrentMetrics};
-    use crate::persistence::event_journal::{EventCategory, EventJournalState};
+    use crate::config::Settings;
+    use crate::dht_service::{DhtStatus, DhtWaveTelemetry};
+    use crate::persistence::event_journal::{EventCategory, EventJournalState, EventScope};
+    use crate::theme::ThemeContext;
+    use crate::tui::screen_context::ScreenContext;
+    use ratatui::backend::TestBackend;
     use ratatui::crossterm::event::{KeyEvent, KeyModifiers};
+    use ratatui::Terminal;
     use std::fs;
     use std::path::Path;
     use tokio::sync::mpsc;
@@ -662,6 +950,40 @@ mod tests {
         handle_event_inner(event, app_state, app_command_tx, None);
     }
 
+    fn render_journal_text(app_state: &AppState, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("create journal test terminal");
+        let dht_status = DhtStatus::default();
+        let dht_wave_telemetry = DhtWaveTelemetry::default();
+        let settings = Settings::default();
+        let theme = ThemeContext::new(app_state.theme, 0.0);
+
+        terminal
+            .draw(|frame| {
+                let screen = ScreenContext::new(
+                    app_state,
+                    &dht_status,
+                    &dht_wave_telemetry,
+                    &settings,
+                    &theme,
+                );
+                draw(frame, &screen);
+            })
+            .expect("draw journal test frame");
+
+        let buffer = terminal.backend().buffer();
+        (0..height)
+            .map(|y| {
+                (0..width)
+                    .filter_map(|x| buffer.cell((x, y)).map(|cell| cell.symbol()))
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     #[test]
     fn tab_cycles_filters() {
         let mut app_state = base_state();
@@ -687,19 +1009,324 @@ mod tests {
         let mut app_state = base_state();
 
         app_state.ui.journal.filter = JournalFilter::Queue;
-        let added = filtered_entries(&app_state);
+        let added = journal_activities(&app_state);
         assert_eq!(added.len(), 1);
-        assert_eq!(added[0].event_type, EventType::IngestAdded);
+        assert_eq!(added[0].latest().event_type, EventType::IngestAdded);
 
         app_state.ui.journal.filter = JournalFilter::Commands;
-        let commands = filtered_entries(&app_state);
+        let commands = journal_activities(&app_state);
         assert_eq!(commands.len(), 1);
-        assert_eq!(commands[0].event_type, EventType::ControlApplied);
+        assert_eq!(commands[0].latest().event_type, EventType::ControlApplied);
 
         app_state.ui.journal.filter = JournalFilter::Health;
-        let health = filtered_entries(&app_state);
+        let health = journal_activities(&app_state);
         assert_eq!(health.len(), 1);
-        assert_eq!(health[0].event_type, EventType::DataUnavailable);
+        assert_eq!(health[0].latest().event_type, EventType::DataUnavailable);
+    }
+
+    #[test]
+    fn correlated_ingest_stages_form_one_activity() {
+        let mut app_state = base_state();
+        app_state.ui.journal.filter = JournalFilter::Queue;
+        app_state.event_journal_state.entries = vec![
+            EventJournalEntry {
+                id: 10,
+                ts_iso: "2026-03-15T14:26:27Z".to_string(),
+                category: EventCategory::Ingest,
+                event_type: EventType::IngestQueued,
+                correlation_id: Some("activity-alpha".to_string()),
+                message: Some("Queued ingest item".to_string()),
+                ..Default::default()
+            },
+            EventJournalEntry {
+                id: 11,
+                ts_iso: "2026-03-15T14:26:28Z".to_string(),
+                category: EventCategory::Ingest,
+                event_type: EventType::IngestAdded,
+                correlation_id: Some("activity-alpha".to_string()),
+                torrent_name: Some("Sample Delta".to_string()),
+                message: Some("Added ingest item".to_string()),
+                ..Default::default()
+            },
+        ];
+
+        let activities = journal_activities(&app_state);
+
+        assert_eq!(activities.len(), 1);
+        assert_eq!(activities[0].entries.len(), 2);
+        assert_eq!(activities[0].entries[0].id, 10);
+        assert_eq!(activities[0].latest().id, 11);
+        assert_eq!(
+            activity_subject_label(&activities[0], false),
+            "Sample Delta"
+        );
+    }
+
+    #[test]
+    fn reused_correlation_starts_a_new_activity() {
+        let mut app_state = base_state();
+        app_state.ui.journal.filter = JournalFilter::Queue;
+        app_state.event_journal_state.entries = [
+            (20, EventType::IngestQueued),
+            (21, EventType::IngestAdded),
+            (22, EventType::IngestQueued),
+            (23, EventType::IngestFailed),
+        ]
+        .into_iter()
+        .map(|(id, event_type)| EventJournalEntry {
+            id,
+            category: EventCategory::Ingest,
+            event_type,
+            correlation_id: Some("reused-path".to_string()),
+            ..Default::default()
+        })
+        .collect();
+
+        let activities = journal_activities(&app_state);
+
+        assert_eq!(activities.len(), 2);
+        assert_eq!(activities[0].entries.len(), 2);
+        assert_eq!(activities[0].latest().id, 23);
+        assert_eq!(activities[1].entries.len(), 2);
+        assert_eq!(activities[1].latest().id, 21);
+    }
+
+    #[test]
+    fn reused_correlation_terminal_pairs_with_newest_open_queue() {
+        let mut app_state = base_state();
+        app_state.ui.journal.filter = JournalFilter::Queue;
+        app_state.event_journal_state.entries = [
+            (24, EventType::IngestQueued),
+            (25, EventType::IngestQueued),
+            (26, EventType::IngestAdded),
+        ]
+        .into_iter()
+        .map(|(id, event_type)| EventJournalEntry {
+            id,
+            category: EventCategory::Ingest,
+            event_type,
+            correlation_id: Some("reused-open-path".to_string()),
+            ..Default::default()
+        })
+        .collect();
+
+        let activities = journal_activities(&app_state);
+
+        assert_eq!(activities.len(), 2);
+        assert_eq!(activities[0].entries[0].id, 25);
+        assert_eq!(activities[0].latest().id, 26);
+        assert_eq!(activities[1].entries.len(), 1);
+        assert_eq!(activities[1].latest().id, 24);
+    }
+
+    #[test]
+    fn identical_correlations_do_not_cross_host_or_scope_boundaries() {
+        let mut app_state = base_state();
+        app_state.ui.journal.filter = JournalFilter::Queue;
+        app_state.event_journal_state.entries = vec![
+            EventJournalEntry {
+                id: 27,
+                category: EventCategory::Ingest,
+                event_type: EventType::IngestQueued,
+                host_id: Some("host-alpha".to_string()),
+                correlation_id: Some("shared-correlation".to_string()),
+                ..Default::default()
+            },
+            EventJournalEntry {
+                id: 28,
+                category: EventCategory::Ingest,
+                event_type: EventType::IngestQueued,
+                host_id: Some("host-beta".to_string()),
+                correlation_id: Some("shared-correlation".to_string()),
+                ..Default::default()
+            },
+            EventJournalEntry {
+                id: 29,
+                scope: EventScope::Shared,
+                category: EventCategory::Ingest,
+                event_type: EventType::IngestAdded,
+                host_id: Some("host-alpha".to_string()),
+                correlation_id: Some("shared-correlation".to_string()),
+                ..Default::default()
+            },
+            EventJournalEntry {
+                id: 30,
+                category: EventCategory::Ingest,
+                event_type: EventType::IngestAdded,
+                host_id: Some("host-beta".to_string()),
+                correlation_id: Some("shared-correlation".to_string()),
+                ..Default::default()
+            },
+        ];
+
+        let activities = journal_activities(&app_state);
+
+        assert_eq!(activities.len(), 3);
+        assert_eq!(activities[0].entries.len(), 2);
+        assert_eq!(
+            activities[0].entries[0].host_id.as_deref(),
+            Some("host-beta")
+        );
+        assert_eq!(activities[0].latest().id, 30);
+        assert!(activities[1..]
+            .iter()
+            .all(|activity| activity.entries.len() == 1));
+    }
+
+    #[test]
+    fn interleaved_correlations_pair_with_their_own_terminal_stage() {
+        let mut app_state = base_state();
+        app_state.ui.journal.filter = JournalFilter::Queue;
+        app_state.event_journal_state.entries = vec![
+            EventJournalEntry {
+                id: 30,
+                category: EventCategory::Ingest,
+                event_type: EventType::IngestQueued,
+                correlation_id: Some("activity-alpha".to_string()),
+                ..Default::default()
+            },
+            EventJournalEntry {
+                id: 31,
+                category: EventCategory::Ingest,
+                event_type: EventType::IngestQueued,
+                correlation_id: Some("activity-beta".to_string()),
+                ..Default::default()
+            },
+            EventJournalEntry {
+                id: 32,
+                category: EventCategory::Ingest,
+                event_type: EventType::IngestAdded,
+                correlation_id: Some("activity-alpha".to_string()),
+                ..Default::default()
+            },
+            EventJournalEntry {
+                id: 33,
+                category: EventCategory::Ingest,
+                event_type: EventType::IngestFailed,
+                correlation_id: Some("activity-beta".to_string()),
+                ..Default::default()
+            },
+        ];
+
+        let activities = journal_activities(&app_state);
+
+        assert_eq!(activities.len(), 2);
+        assert_eq!(activities[0].entries[0].id, 31);
+        assert_eq!(activities[0].latest().id, 33);
+        assert_eq!(activities[1].entries[0].id, 30);
+        assert_eq!(activities[1].latest().id, 32);
+    }
+
+    #[test]
+    fn navigation_clamps_to_grouped_activity_count() {
+        let mut app_state = base_state();
+        app_state.ui.journal.filter = JournalFilter::Queue;
+        app_state.event_journal_state.entries = [
+            (40, EventType::IngestQueued, Some("activity-alpha")),
+            (41, EventType::IngestAdded, Some("activity-alpha")),
+            (42, EventType::IngestAdded, None),
+        ]
+        .into_iter()
+        .map(|(id, event_type, correlation_id)| EventJournalEntry {
+            id,
+            category: EventCategory::Ingest,
+            event_type,
+            correlation_id: correlation_id.map(str::to_string),
+            ..Default::default()
+        })
+        .collect();
+        let (tx, _rx) = mpsc::channel(1);
+
+        for _ in 0..4 {
+            handle_event(
+                CrosstermEvent::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)),
+                &mut app_state,
+                &tx,
+            );
+        }
+
+        assert_eq!(journal_activities(&app_state).len(), 2);
+        assert_eq!(app_state.ui.journal.selected_index, 1);
+    }
+
+    #[test]
+    fn grouped_activity_renders_once_and_keeps_both_stage_details() {
+        let mut app_state = base_state();
+        app_state.ui.journal.filter = JournalFilter::Queue;
+        app_state.ui.journal.selected_index = 99;
+        app_state.event_journal_state.entries = vec![
+            EventJournalEntry {
+                id: 50,
+                ts_iso: "2026-03-15T14:26:27Z".to_string(),
+                category: EventCategory::Ingest,
+                event_type: EventType::IngestQueued,
+                correlation_id: Some("activity-render".to_string()),
+                source_path: Some(Path::new("/watch/sample-delta.magnet").to_path_buf()),
+                message: Some("Queued ingest item".to_string()),
+                ..Default::default()
+            },
+            EventJournalEntry {
+                id: 51,
+                ts_iso: "2026-03-15T14:26:28Z".to_string(),
+                category: EventCategory::Ingest,
+                event_type: EventType::IngestAdded,
+                correlation_id: Some("activity-render".to_string()),
+                torrent_name: Some("Sample Delta".to_string()),
+                source_path: Some(Path::new("/watch/sample-delta.magnet").to_path_buf()),
+                message: Some("Added ingest item".to_string()),
+                ..Default::default()
+            },
+        ];
+
+        let rendered = render_journal_text(&app_state, 120, 40);
+
+        assert!(rendered.contains("1 activity"), "{rendered}");
+        assert!(rendered.contains("2 records"), "{rendered}");
+        assert_eq!(rendered.matches("Sample Delta").count(), 1, "{rendered}");
+        assert!(rendered.contains("Queued ingest item"), "{rendered}");
+        assert!(rendered.contains("Added ingest item"), "{rendered}");
+        assert!(
+            rendered.contains("/watch/sample-delta.magnet"),
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    fn narrow_render_keeps_each_stage_and_source_on_separate_rows() {
+        let mut app_state = base_state();
+        app_state.ui.journal.filter = JournalFilter::Queue;
+        app_state.event_journal_state.entries = vec![
+            EventJournalEntry {
+                id: 52,
+                ts_iso: "2026-03-15T14:26:27Z".to_string(),
+                category: EventCategory::Ingest,
+                event_type: EventType::IngestQueued,
+                correlation_id: Some("activity-narrow".to_string()),
+                source_path: Some(Path::new("/watch/sample-epsilon.magnet").to_path_buf()),
+                message: Some("Queue detail ".repeat(20)),
+                ..Default::default()
+            },
+            EventJournalEntry {
+                id: 53,
+                ts_iso: "2026-03-15T14:26:28Z".to_string(),
+                category: EventCategory::Ingest,
+                event_type: EventType::IngestAdded,
+                correlation_id: Some("activity-narrow".to_string()),
+                torrent_name: Some("Sample Epsilon".to_string()),
+                source_path: Some(Path::new("/watch/sample-epsilon.magnet").to_path_buf()),
+                message: Some("Result detail ".repeat(20)),
+                ..Default::default()
+            },
+        ];
+
+        let rendered = render_journal_text(&app_state, 80, 24);
+
+        assert!(rendered.contains("Queue detail"), "{rendered}");
+        assert!(rendered.contains("Result detail"), "{rendered}");
+        assert!(
+            rendered.contains("/watch/sample-epsilon.magnet"),
+            "{rendered}"
+        );
     }
 
     #[test]
@@ -759,31 +1386,6 @@ mod tests {
     }
 
     #[test]
-    fn selected_detail_text_prefers_recorded_source_path_over_live_magnet() {
-        let mut app_state = base_state();
-        let info_hash = vec![0x22; 20];
-        app_state.event_journal_state.entries[0].info_hash_hex = Some(hex::encode(&info_hash));
-        app_state.event_journal_state.entries[0].source_path =
-            Some(Path::new("/alpha/archive/sample.magnet").to_path_buf());
-        app_state.torrents.insert(
-            info_hash,
-            TorrentDisplayState {
-                latest_state: TorrentMetrics {
-                    torrent_name: "Sample Alpha".to_string(),
-                    torrent_or_magnet:
-                        "magnet:?xt=urn:btih:2222222222222222222222222222222222222222".to_string(),
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-        );
-
-        let details =
-            selected_detail_text(&app_state, Some(&app_state.event_journal_state.entries[0]));
-        assert_eq!(details, "/alpha/archive/sample.magnet");
-    }
-
-    #[test]
     fn command_filter_uses_action_label_and_reduced_columns() {
         let entry = EventJournalEntry {
             details: EventDetails::Control {
@@ -798,13 +1400,26 @@ mod tests {
         };
 
         assert_eq!(command_action_label(&entry), "pause");
-        assert_eq!(columns_for_filter(JournalFilter::Commands).len(), 3);
+        assert_eq!(columns_for_filter(JournalFilter::Commands).len(), 4);
         assert_eq!(
-            column_header(columns_for_filter(JournalFilter::Commands)[1]),
-            "Event"
+            column_header(
+                columns_for_filter(JournalFilter::Commands)[1],
+                JournalFilter::Commands
+            ),
+            "Status"
         );
         assert_eq!(
-            column_header(columns_for_filter(JournalFilter::Commands)[2]),
+            column_header(
+                columns_for_filter(JournalFilter::Commands)[2],
+                JournalFilter::Commands
+            ),
+            "Action"
+        );
+        assert_eq!(
+            column_header(
+                columns_for_filter(JournalFilter::Commands)[3],
+                JournalFilter::Commands
+            ),
             "Source"
         );
         assert_eq!(command_action_label(&entry), "pause");
@@ -823,6 +1438,7 @@ mod tests {
     fn shift_y_replays_selected_magnet_source() {
         let mut app_state = base_state();
         app_state.ui.journal.filter = JournalFilter::Queue;
+        app_state.ui.journal.selected_index = 99;
         let replay_path = std::env::temp_dir().join(format!(
             "superseedr-journal-replay-{}.magnet",
             std::process::id()
@@ -832,7 +1448,20 @@ mod tests {
             "magnet:?xt=urn:btih:4444444444444444444444444444444444444444",
         )
         .expect("write replay file");
-        app_state.event_journal_state.entries[0].source_path = Some(replay_path.clone());
+        app_state.event_journal_state.entries.insert(
+            0,
+            EventJournalEntry {
+                id: 0,
+                category: EventCategory::Ingest,
+                event_type: EventType::IngestQueued,
+                correlation_id: Some("activity-replay".to_string()),
+                source_path: Some(replay_path.clone()),
+                ..Default::default()
+            },
+        );
+        app_state.event_journal_state.entries[1].correlation_id =
+            Some("activity-replay".to_string());
+        app_state.event_journal_state.entries[1].source_path = Some(replay_path.clone());
         let (tx, mut rx) = mpsc::channel(1);
 
         handle_event(

--- a/src/tui/screens/journal.rs
+++ b/src/tui/screens/journal.rs
@@ -138,6 +138,11 @@ fn handle_event_inner(
             let len = journal_activities(app_state).len();
             if len > 0 {
                 let page_rows = journal_page_rows(app_state);
+                app_state.ui.journal.scroll_offset = app_state
+                    .ui
+                    .journal
+                    .scroll_offset
+                    .min(app_state.ui.journal.selected_index);
                 app_state.ui.journal.selected_index =
                     (app_state.ui.journal.selected_index + 1).min(len - 1);
                 if app_state.ui.journal.selected_index
@@ -404,17 +409,20 @@ fn activity_search_haystack(activity: &JournalActivity<'_>) -> String {
         append_search_field(&mut haystack, event_type_label(entry));
         append_event_detail_search_fields(&mut haystack, &entry.details);
         append_search_field(&mut haystack, entry.torrent_name.as_deref().unwrap_or("-"));
-        if let Some(path) = entry
-            .source_path
-            .as_deref()
-            .or(entry.source_watch_folder.as_deref())
+        if entry.source_path.is_none() && entry.source_watch_folder.is_none() {
+            append_search_field(&mut haystack, "-");
+        }
+        for path in [
+            entry.source_path.as_deref(),
+            entry.source_watch_folder.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
         {
             if !haystack.is_empty() {
                 haystack.push(' ');
             }
             let _ = write!(haystack, "{}", path.display());
-        } else {
-            append_search_field(&mut haystack, "-");
         }
         append_search_field(
             &mut haystack,
@@ -449,6 +457,19 @@ fn append_search_number(haystack: &mut String, number: usize) {
 
 fn append_event_detail_search_fields(haystack: &mut String, details: &EventDetails) {
     match details {
+        EventDetails::Ingest {
+            download_path,
+            container_name,
+            payload_path,
+            ..
+        } => {
+            for path in [download_path, payload_path].into_iter().flatten() {
+                append_search_field(haystack, &path.to_string_lossy());
+            }
+            if let Some(container_name) = container_name.as_deref() {
+                append_search_field(haystack, container_name);
+            }
+        }
         EventDetails::Control {
             action,
             target_info_hash_hex,
@@ -486,6 +507,20 @@ fn append_event_detail_search_fields(haystack: &mut String, details: &EventDetai
 
 fn event_details_match_regex(details: &EventDetails, regex: &regex::Regex) -> bool {
     match details {
+        EventDetails::Ingest {
+            download_path,
+            container_name,
+            payload_path,
+            ..
+        } => {
+            [download_path, payload_path]
+                .into_iter()
+                .flatten()
+                .any(|path| regex.is_match(&path.to_string_lossy()))
+                || container_name
+                    .as_deref()
+                    .is_some_and(|name| regex.is_match(name))
+        }
         EventDetails::Control {
             action,
             target_info_hash_hex,
@@ -530,11 +565,14 @@ fn activity_matches_regex(activity: &JournalActivity<'_>, regex: &regex::Regex) 
             || entry
                 .source_path
                 .as_deref()
-                .or(entry.source_watch_folder.as_deref())
-                .map_or_else(
-                    || regex.is_match("-"),
-                    |path| regex.is_match(&path.to_string_lossy()),
-                )
+                .is_some_and(|path| regex.is_match(&path.to_string_lossy()))
+            || entry
+                .source_watch_folder
+                .as_deref()
+                .is_some_and(|path| regex.is_match(&path.to_string_lossy()))
+            || (entry.source_path.is_none()
+                && entry.source_watch_folder.is_none()
+                && regex.is_match("-"))
             || regex.is_match(entry.message.as_deref().unwrap_or("No details recorded."))
             || entry
                 .host_id
@@ -1755,6 +1793,44 @@ mod tests {
     }
 
     #[test]
+    fn ingest_search_matches_detail_and_source_fields_in_both_modes() {
+        let mut app_state = base_state();
+        app_state.ui.journal.filter = JournalFilter::Queue;
+        app_state.event_journal_state.entries = vec![EventJournalEntry {
+            category: EventCategory::Ingest,
+            event_type: EventType::IngestAdded,
+            source_path: Some(Path::new("/staging/item-alpha.torrent").to_path_buf()),
+            source_watch_folder: Some(Path::new("/watch-root/incoming").to_path_buf()),
+            details: EventDetails::Ingest {
+                origin: crate::persistence::event_journal::IngestOrigin::WatchFolder,
+                ingest_kind: crate::persistence::event_journal::IngestKind::TorrentFile,
+                download_path: Some(Path::new("/library/collection-ember").to_path_buf()),
+                container_name: Some("archive-slate".to_string()),
+                payload_path: Some(Path::new("payload/segment-omega.bin").to_path_buf()),
+            },
+            ..Default::default()
+        }];
+
+        for mode in [SearchMode::Fuzzy, SearchMode::Regex] {
+            app_state.ui.journal.search_mode = mode;
+            for query in [
+                "collection-ember",
+                "archive-slate",
+                "segment-omega",
+                "item-alpha",
+                "watch-root",
+            ] {
+                app_state.ui.journal.search_query = query.to_string();
+                assert_eq!(
+                    journal_activities(&app_state).len(),
+                    1,
+                    "{mode:?} search should match {query}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn filter_selection_matches_requested_groups() {
         let mut app_state = base_state();
 
@@ -2041,6 +2117,33 @@ mod tests {
 
         assert_eq!(journal_activities(&app_state).len(), 2);
         assert_eq!(app_state.ui.journal.selected_index, 1);
+    }
+
+    #[test]
+    fn move_down_clamps_stale_scroll_offset_before_advancing() {
+        let mut app_state = base_state();
+        app_state.screen_area = Rect::new(0, 0, 120, 30);
+        app_state.event_journal_state.entries = (0..100)
+            .map(|id| EventJournalEntry {
+                id,
+                category: EventCategory::Ingest,
+                event_type: EventType::IngestAdded,
+                torrent_name: Some(format!("Sample Item {id}")),
+                ..Default::default()
+            })
+            .collect();
+        app_state.ui.journal.selected_index = 0;
+        app_state.ui.journal.scroll_offset = 50;
+        let (tx, _rx) = mpsc::channel(1);
+
+        handle_event(
+            CrosstermEvent::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)),
+            &mut app_state,
+            &tx,
+        );
+
+        assert_eq!(app_state.ui.journal.selected_index, 1);
+        assert_eq!(app_state.ui.journal.scroll_offset, 0);
     }
 
     #[test]

--- a/src/tui/screens/normal.rs
+++ b/src/tui/screens/normal.rs
@@ -7024,6 +7024,7 @@ async fn execute_ui_effect(app: &mut App, effect: UiEffect) {
         }
         UiEffect::OpenJournalScreen => {
             app.app_state.ui.journal.selected_index = 0;
+            app.app_state.ui.journal.scroll_offset = 0;
             app.app_state.mode = AppMode::Journal;
         }
         UiEffect::OpenTorrentManagementScreen => {
@@ -10055,11 +10056,13 @@ mod tests {
             .await
             .expect("build app");
         app.app_state.ui.journal.selected_index = 9;
+        app.app_state.ui.journal.scroll_offset = 7;
 
         execute_ui_effect(&mut app, UiEffect::OpenJournalScreen).await;
 
         assert!(matches!(app.app_state.mode, AppMode::Journal));
         assert_eq!(app.app_state.ui.journal.selected_index, 0);
+        assert_eq!(app.app_state.ui.journal.scroll_offset, 0);
         let _ = app.shutdown_tx.send(());
     }
 


### PR DESCRIPTION
## Summary

- redesign the Journal as a compact, responsive activity table with colored filters and headers
- add retained search, live relative timestamps, stable details, and PageUp/PageDown navigation
- align the Journal filter and Help search placement with the existing TUI screen structure
- reduce unnecessary Journal allocations, row construction, and redraw work

## Why

The previous Journal layout was overly spaced, shifted when detail content changed, and did more per-frame aggregation and formatting than necessary. This keeps the screen consistent with the rest of the TUI while making navigation and live updates stable.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- 51 Journal-focused tests passed
- full test suite passed: 1,781 tests
