### PR TITLE
Support randomized listen ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,10 +38,10 @@ IMAGE_NAME=jagatranvo/superseedr:latest    # Public build (default)
 
 # --- Port Parameters ---
 # Static port for providers that do not support programmatic port forwarding.
-# Gluetun and superseedr will both use this port.
+# The VPN/firewall container and the client will both use this port.
 # CLIENT_PORT=6881
 # Native launches can instead use SUPERSEEDR_CLIENT_PORT=RANDOM or PORT=RANDOM.
-# Do not use RANDOM for CLIENT_PORT here: Gluetun requires a numeric firewall port.
+# Do not use RANDOM for CLIENT_PORT here: the VPN/firewall container requires a numeric firewall port.
 
 # -----------------------------------------------------------------
 # --- Developer Configuration ---

--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,8 @@ IMAGE_NAME=jagatranvo/superseedr:latest    # Public build (default)
 # Static port for providers that do not support programmatic port forwarding.
 # Gluetun and superseedr will both use this port.
 # CLIENT_PORT=6881
+# Native launches can instead use SUPERSEEDR_CLIENT_PORT=RANDOM or PORT=RANDOM.
+# Do not use RANDOM for CLIENT_PORT here: Gluetun requires a numeric firewall port.
 
 # -----------------------------------------------------------------
 # --- Developer Configuration ---

--- a/README.md
+++ b/README.md
@@ -265,6 +265,11 @@ See [`docs/cli.md`](docs/cli.md) for full CLI command behavior, and
 [`docs/shared-config.md`](docs/shared-config.md) for shared leader/follower
 routing.
 
+To choose a new available peer-listening port on every start, set
+`client_port = "RANDOM"` in `settings.toml`. You can also launch with
+`SUPERSEEDR_CLIENT_PORT=RANDOM` or the shorter `PORT=RANDOM`. A numeric
+`SUPERSEEDR_CLIENT_PORT` takes precedence and selects a fixed port.
+
 ### 3. Status API & Monitoring
 For external dashboards, health checks, and lightweight automation, Superseedr
 periodically dumps runtime state to JSON.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -67,6 +67,34 @@ cargo run --release --features synthetic-load -- benchmark --max-torrents 1000 -
 See [`docs/synthetic-benchmark.md`](synthetic-benchmark.md) for deeper
 synthetic load testing, disk-budget behavior, and per-scenario examples.
 
+## Runtime Listen Port
+
+To select a new available peer-listening port each time Superseedr starts, use
+either environment form:
+
+```bash
+PORT=RANDOM superseedr
+SUPERSEEDR_CLIENT_PORT=RANDOM superseedr
+```
+
+The namespaced variable takes precedence. It also accepts a numeric fixed port:
+
+```bash
+SUPERSEEDR_CLIENT_PORT=6681 superseedr
+```
+
+The equivalent persisted setting, including in a shared host config, is:
+
+```toml
+client_port = "RANDOM"
+```
+
+Runtime status reports the numeric port that was actually selected.
+
+The same mode is available in the TUI configuration screen: select **Listen
+Port**, press `Space`, enter `RANDOM`, and press `Enter`. Entering a numeric port
+switches the setting back to a fixed port.
+
 ## Runtime Peer Transport
 
 Production peer transport enables TCP and uTP by default. When both transports

--- a/docs/shared-config.md
+++ b/docs/shared-config.md
@@ -362,9 +362,14 @@ Convergence includes:
 Each host can still define its own local ingress folder:
 
 ```toml
-client_port = 6681
+client_port = "RANDOM"
 watch_folder = "/srv/local-watch"
 ```
+
+With randomization enabled, each host asks the OS for a new available port when
+it starts. The host config retains the randomization choice while runtime status
+reports the port that was actually bound. `client_port = "RANDOM"` is also
+accepted in standalone and shared host configs.
 
 Behavior:
 
@@ -573,7 +578,7 @@ Host config:
 
 ```toml
 # hosts/seedbox-a/config.toml
-client_port = 6681
+client_port = "RANDOM"
 watch_folder = "/srv/local-watch"
 ```
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3111,8 +3111,13 @@ impl App {
         runtime_mode: AppRuntimeMode,
         app_lock_handle: Option<File>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let listener = bind_peer_listener(client_configs.client_port).await?;
-        if client_configs.client_port == 0 {
+        let requested_port = if client_configs.randomize_client_port {
+            0
+        } else {
+            client_configs.client_port
+        };
+        let listener = bind_peer_listener(requested_port).await?;
+        if requested_port == 0 {
             if let Some(bound_port) = listener.as_ref().and_then(ListenerSet::local_port) {
                 client_configs.client_port = bound_port;
             }
@@ -5767,21 +5772,38 @@ impl App {
             }
         }
 
-        let port_changed = new_settings.client_port != old_settings.client_port;
+        let port_changed = new_settings.randomize_client_port != old_settings.randomize_client_port
+            || (!new_settings.randomize_client_port
+                && new_settings.client_port != old_settings.client_port);
         let bootstrap_changed = new_settings.bootstrap_nodes != old_settings.bootstrap_nodes;
         let mut config_error = None;
 
         if port_changed {
+            let requested_port = if new_settings.randomize_client_port {
+                0
+            } else {
+                new_settings.client_port
+            };
             tracing::info!(
                 "Config update: Port changed to {}",
-                new_settings.client_port
+                if requested_port == 0 {
+                    "RANDOM".to_string()
+                } else {
+                    requested_port.to_string()
+                }
             );
-            if !self.rebind_listener(new_settings.client_port).await {
+            if !self.rebind_listener(requested_port).await {
                 config_error = Some(format!(
                     "Could not activate listen port {}. Port {} remains active.",
-                    new_settings.client_port, old_settings.client_port
+                    if requested_port == 0 {
+                        "RANDOM".to_string()
+                    } else {
+                        requested_port.to_string()
+                    },
+                    old_settings.client_port
                 ));
                 self.client_configs.client_port = old_settings.client_port;
+                self.client_configs.randomize_client_port = old_settings.randomize_client_port;
                 let _ = self.rss_settings_tx.send(self.client_configs.clone());
                 if bootstrap_changed {
                     tracing::info!("Config update: DHT bootstrap nodes changed.");
@@ -12077,6 +12099,23 @@ mod tests {
             .app_state
             .externally_accessable_port_v6_highlight_until
             .is_none());
+
+        let _ = app.shutdown_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn randomized_client_port_binds_an_ephemeral_port_and_preserves_the_mode() {
+        let settings = crate::config::Settings {
+            client_port: 6681,
+            randomize_client_port: true,
+            ..Default::default()
+        };
+        let app = App::new(settings, AppRuntimeMode::Normal)
+            .await
+            .expect("create app");
+
+        assert_ne!(app.client_configs.client_port, 0);
+        assert!(app.client_configs.randomize_client_port);
 
         let _ = app.shutdown_tx.send(());
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -5776,10 +5776,21 @@ impl App {
         let port_changed = new_settings.randomize_client_port != old_settings.randomize_client_port
             || (!new_settings.randomize_client_port
                 && new_settings.client_port != old_settings.client_port);
+        let pinning_current_random_port = old_settings.randomize_client_port
+            && !new_settings.randomize_client_port
+            && self.listener.as_ref().and_then(ListenerSet::local_port)
+                == Some(new_settings.client_port);
         let bootstrap_changed = new_settings.bootstrap_nodes != old_settings.bootstrap_nodes;
         let mut config_error = None;
 
-        if port_changed {
+        if pinning_current_random_port {
+            tracing::info!(
+                "Config update: Pinned current random listen port {} without rebinding",
+                new_settings.client_port
+            );
+        }
+
+        if port_changed && !pinning_current_random_port {
             let requested_port = if new_settings.randomize_client_port {
                 0
             } else {
@@ -12169,6 +12180,46 @@ mod tests {
         );
 
         let _ = app.shutdown_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn pinning_current_random_port_preserves_listener_and_persists_fixed_mode() {
+        let _guard = lock_shared_env();
+        let _temp_paths = configure_temp_app_paths_for_test();
+        let settings = crate::config::Settings {
+            client_port: 6681,
+            randomize_client_port: true,
+            ..Default::default()
+        };
+        let mut app = App::new(settings, AppRuntimeMode::Normal)
+            .await
+            .expect("create app");
+        let bound_port = app
+            .listener
+            .as_ref()
+            .and_then(ListenerSet::local_port)
+            .expect("random listener should expose its bound port");
+        let mut fixed_settings = app.client_configs.clone();
+        fixed_settings.client_port = bound_port;
+        fixed_settings.randomize_client_port = false;
+
+        app.apply_settings_update(fixed_settings, true).await;
+        app.flush_persistence_writer().await;
+
+        assert_eq!(
+            app.listener.as_ref().and_then(ListenerSet::local_port),
+            Some(bound_port)
+        );
+        assert_eq!(app.client_configs.client_port, bound_port);
+        assert!(!app.client_configs.randomize_client_port);
+        assert!(app.app_state.system_error.is_none());
+
+        let persisted = crate::config::load_settings().expect("reload persisted settings");
+        assert_eq!(persisted.client_port, bound_port);
+        assert!(!persisted.randomize_client_port);
+
+        let _ = app.shutdown_tx.send(());
+        set_app_paths_override_for_tests(None);
     }
 
     #[tokio::test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -5744,8 +5744,9 @@ impl App {
         }
     }
 
-    async fn apply_settings_update(&mut self, new_settings: Settings, persist: bool) {
+    async fn apply_settings_update(&mut self, mut new_settings: Settings, persist: bool) {
         let old_settings = self.client_configs.clone();
+        preserve_bound_random_client_port(&old_settings, &mut new_settings);
         self.client_configs = new_settings.clone();
         let _ = self.rss_settings_tx.send(self.client_configs.clone());
         let rss_changed = rss_settings_changed(&old_settings, &new_settings);
@@ -9027,6 +9028,12 @@ impl App {
     }
 }
 
+fn preserve_bound_random_client_port(old_settings: &Settings, new_settings: &mut Settings) {
+    if old_settings.randomize_client_port && new_settings.randomize_client_port {
+        new_settings.client_port = old_settings.client_port;
+    }
+}
+
 fn is_valid_incoming_bittorrent_handshake(buffer: &[u8]) -> bool {
     buffer.len() >= 48
         && buffer[0] as usize == BITTORRENT_PROTOCOL_STR.len()
@@ -12116,6 +12123,49 @@ mod tests {
 
         assert_ne!(app.client_configs.client_port, 0);
         assert!(app.client_configs.randomize_client_port);
+
+        let _ = app.shutdown_tx.send(());
+    }
+
+    #[test]
+    fn random_client_port_reload_normalization_preserves_the_bound_port() {
+        let current_settings = crate::config::Settings {
+            client_port: 49152,
+            randomize_client_port: true,
+            ..Default::default()
+        };
+        let mut reloaded_settings = current_settings.clone();
+        reloaded_settings.client_port = 0;
+
+        super::preserve_bound_random_client_port(&current_settings, &mut reloaded_settings);
+
+        assert_eq!(reloaded_settings.client_port, current_settings.client_port);
+        assert!(reloaded_settings.randomize_client_port);
+    }
+
+    #[tokio::test]
+    async fn random_client_port_reload_preserves_the_bound_port() {
+        let settings = crate::config::Settings {
+            client_port: 6681,
+            randomize_client_port: true,
+            ..Default::default()
+        };
+        let mut app = App::new(settings, AppRuntimeMode::Normal)
+            .await
+            .expect("create app");
+        let bound_port = app.client_configs.client_port;
+        let mut reloaded_settings = app.client_configs.clone();
+        reloaded_settings.client_port = 0;
+        reloaded_settings.output_status_interval += 1;
+
+        app.apply_settings_update(reloaded_settings, false).await;
+
+        assert_eq!(app.client_configs.client_port, bound_port);
+        assert!(app.client_configs.randomize_client_port);
+        assert_eq!(
+            app.listener.as_ref().and_then(ListenerSet::local_port),
+            Some(bound_port)
+        );
 
         let _ = app.shutdown_tx.send(());
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -6885,6 +6885,7 @@ impl App {
                                 .and_then(ListenerSet::local_port)
                                 .unwrap_or(new_port);
                             self.client_configs.client_port = bound_port;
+                            self.client_configs.randomize_client_port = false;
 
                             tracing_event!(
                                 Level::INFO,
@@ -12168,6 +12169,47 @@ mod tests {
         );
 
         let _ = app.shutdown_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn forwarded_port_hot_reload_clears_random_mode_and_persists_fixed_port() {
+        let _guard = lock_shared_env();
+        let _temp_paths = configure_temp_app_paths_for_test();
+        let settings = crate::config::Settings {
+            client_port: 6681,
+            randomize_client_port: true,
+            ..Default::default()
+        };
+        let mut app = App::new(settings, AppRuntimeMode::Normal)
+            .await
+            .expect("create app");
+        let probe_listener = super::bind_peer_listener(0)
+            .await
+            .expect("reserve forwarded port");
+        let forwarded_port = probe_listener
+            .as_ref()
+            .and_then(ListenerSet::local_port)
+            .expect("forwarded listener should expose its port");
+        drop(probe_listener);
+        let port_file = _temp_paths.path().join("forwarded-port");
+        std::fs::write(&port_file, forwarded_port.to_string()).expect("write forwarded port file");
+
+        app.handle_port_change(port_file).await;
+        app.flush_persistence_writer().await;
+
+        assert_eq!(app.client_configs.client_port, forwarded_port);
+        assert!(!app.client_configs.randomize_client_port);
+        assert_eq!(
+            app.listener.as_ref().and_then(ListenerSet::local_port),
+            Some(forwarded_port)
+        );
+
+        let persisted = crate::config::load_settings().expect("reload persisted settings");
+        assert_eq!(persisted.client_port, forwarded_port);
+        assert!(!persisted.randomize_client_port);
+
+        let _ = app.shutdown_tx.send(());
+        set_app_paths_override_for_tests(None);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1051,6 +1051,7 @@ impl HostConfig {
             settings.client_id = client_id.clone();
         }
         settings.client_port = self.client_port;
+        settings.randomize_client_port = self.client_port == 0;
         settings.watch_folder = self.watch_folder.clone();
         settings.always_show_add_location_prompt = self.always_show_add_location_prompt;
     }
@@ -6002,6 +6003,24 @@ mod tests {
         host_only.always_show_add_location_prompt = true;
         assert_eq!(
             classify_shared_mode_settings_change(&current, &host_only),
+            SettingsChangeScope::HostOnly
+        );
+
+        let mut random_port = current.clone();
+        random_port.randomize_client_port = true;
+        assert_eq!(
+            classify_shared_mode_settings_change(&current, &random_port),
+            SettingsChangeScope::HostOnly
+        );
+
+        let mut current_random_port = current.clone();
+        current_random_port.client_port = 49152;
+        current_random_port.randomize_client_port = true;
+        let mut fixed_port = current_random_port.clone();
+        fixed_port.client_port = 4300;
+        fixed_port.randomize_client_port = false;
+        assert_eq!(
+            classify_shared_mode_settings_change(&current_random_port, &fixed_port),
             SettingsChangeScope::HostOnly
         );
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -217,7 +217,13 @@ impl UiLayoutMode {
 #[serde(default)]
 pub struct Settings {
     pub client_id: String,
+    #[serde(
+        deserialize_with = "deserialize_client_port",
+        serialize_with = "serialize_client_port"
+    )]
     pub client_port: u16,
+    #[serde(skip)]
+    pub randomize_client_port: bool,
     pub torrents: Vec<TorrentSettings>,
     pub lifetime_downloaded: u64,
     pub lifetime_uploaded: u64,
@@ -255,6 +261,7 @@ impl Default for Settings {
         Self {
             client_id: String::new(),
             client_port: 6681,
+            randomize_client_port: false,
             torrents: Vec::new(),
             watch_folder: None,
             default_download_folder: None,
@@ -370,6 +377,7 @@ const SHARED_CONFIG_DIR_ENV: &str = "SUPERSEEDR_SHARED_CONFIG_DIR";
 const SHARED_HOST_ID_ENV: &str = "SUPERSEEDR_SHARED_HOST_ID";
 const LEGACY_SHARED_HOST_ID_ENV: &str = "SUPERSEEDR_HOST_ID";
 const CLIENT_PORT_ENV: &str = "SUPERSEEDR_CLIENT_PORT";
+const PORT_ENV: &str = "PORT";
 const DEFAULT_DOWNLOAD_FOLDER_ENV: &str = "SUPERSEEDR_DEFAULT_DOWNLOAD_FOLDER";
 const OUTPUT_STATUS_INTERVAL_ENV: &str = "SUPERSEEDR_OUTPUT_STATUS_INTERVAL";
 const EXTRA_WATCH_PATH_PREFIX: &str = "SUPERSEEDR_WATCH_PATH_";
@@ -520,6 +528,10 @@ struct LayeredConfig {
 #[serde(default)]
 struct HostConfig {
     pub client_id: Option<String>,
+    #[serde(
+        deserialize_with = "deserialize_client_port",
+        serialize_with = "serialize_client_port"
+    )]
     pub client_port: u16,
     pub watch_folder: Option<PathBuf>,
     pub always_show_add_location_prompt: bool,
@@ -1019,7 +1031,7 @@ impl HostConfig {
     fn from_flat_settings(settings: &Settings) -> Self {
         Self {
             client_id: None,
-            client_port: settings.client_port,
+            client_port: configured_client_port(settings),
             watch_folder: settings.watch_folder.clone(),
             always_show_add_location_prompt: settings.always_show_add_location_prompt,
         }
@@ -1028,7 +1040,7 @@ impl HostConfig {
     fn from_settings(settings: &Settings, shared_client_id: &str) -> Self {
         Self {
             client_id: (settings.client_id != shared_client_id).then(|| settings.client_id.clone()),
-            client_port: settings.client_port,
+            client_port: configured_client_port(settings),
             watch_folder: settings.watch_folder.clone(),
             always_show_add_location_prompt: settings.always_show_add_location_prompt,
         }
@@ -1041,6 +1053,14 @@ impl HostConfig {
         settings.client_port = self.client_port;
         settings.watch_folder = self.watch_folder.clone();
         settings.always_show_add_location_prompt = self.always_show_add_location_prompt;
+    }
+}
+
+fn configured_client_port(settings: &Settings) -> u16 {
+    if settings.randomize_client_port {
+        0
+    } else {
+        settings.client_port
     }
 }
 fn sanitize_host_id(raw: &str) -> String {
@@ -1498,8 +1518,17 @@ fn decode_catalog_torrent_source(source: &str, shared_root: Option<&Path>) -> St
 fn apply_env_overrides(settings: &Settings) -> io::Result<Settings> {
     let mut resolved = settings.clone();
 
-    if let Some(client_port) = parse_env_override(CLIENT_PORT_ENV)? {
-        resolved.client_port = client_port;
+    if resolved.client_port == 0 {
+        resolved.randomize_client_port = true;
+    }
+    if let Some(client_port) = parse_client_port_env_override()? {
+        match client_port {
+            Some(client_port) => {
+                resolved.client_port = client_port;
+                resolved.randomize_client_port = false;
+            }
+            None => resolved.randomize_client_port = true,
+        }
     }
     if let Some(default_download_folder) = parse_path_env_override(DEFAULT_DOWNLOAD_FOLDER_ENV)? {
         resolved.default_download_folder = Some(default_download_folder);
@@ -1509,6 +1538,73 @@ fn apply_env_overrides(settings: &Settings) -> io::Result<Settings> {
     }
 
     Ok(resolved)
+}
+
+fn parse_client_port_env_override() -> io::Result<Option<Option<u16>>> {
+    if let Some(value) = env_var_case_insensitive(CLIENT_PORT_ENV)? {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("{CLIENT_PORT_ENV} must not be empty"),
+            ));
+        }
+        if trimmed.eq_ignore_ascii_case("random") {
+            return Ok(Some(None));
+        }
+        return trimmed
+            .parse::<u16>()
+            .map(|port| Some(Some(port)))
+            .map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "Invalid {CLIENT_PORT_ENV}={value:?}: expected a port number or RANDOM: {error}"
+                    ),
+                )
+            });
+    }
+
+    if env_var_case_insensitive(PORT_ENV)?
+        .is_some_and(|value| value.trim().eq_ignore_ascii_case("random"))
+    {
+        return Ok(Some(None));
+    }
+
+    Ok(None)
+}
+
+fn deserialize_client_port<'de, D>(deserializer: D) -> Result<u16, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum ClientPortValue {
+        Number(u16),
+        Text(String),
+    }
+
+    match ClientPortValue::deserialize(deserializer)? {
+        ClientPortValue::Number(port) => Ok(port),
+        ClientPortValue::Text(value) if value.trim().eq_ignore_ascii_case("random") => Ok(0),
+        ClientPortValue::Text(value) => value.trim().parse::<u16>().map_err(|error| {
+            serde::de::Error::custom(format!(
+                "invalid client_port {value:?}: expected a port number or RANDOM: {error}"
+            ))
+        }),
+    }
+}
+
+fn serialize_client_port<S>(port: &u16, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    if *port == 0 {
+        serializer.serialize_str("RANDOM")
+    } else {
+        serializer.serialize_u16(*port)
+    }
 }
 
 fn parse_env_override<T>(key: &str) -> io::Result<Option<T>>
@@ -3287,6 +3383,21 @@ mod tests {
     }
 
     #[test]
+    fn test_random_client_port_config_forms_enable_randomization() {
+        let _guard = watch_env_guard().lock().unwrap();
+        let _client_port = EnvVarRestore::capture(CLIENT_PORT_ENV);
+        let _port = EnvVarRestore::capture(PORT_ENV);
+        env::remove_var(CLIENT_PORT_ENV);
+        env::remove_var(PORT_ENV);
+
+        let string_port: Settings = deserialize_versioned_toml(r#"client_port = "RANDOM""#)
+            .expect("parse RANDOM client port");
+        let string_port = apply_env_overrides(&string_port).expect("normalize RANDOM client port");
+        assert_eq!(string_port.client_port, 0);
+        assert!(string_port.randomize_client_port);
+    }
+
+    #[test]
     fn test_default_settings() {
         let toml_str = "";
 
@@ -3453,6 +3564,32 @@ mod tests {
         let resolved = apply_env_overrides(&settings).expect("apply env overrides");
 
         assert_eq!(resolved.client_port, 61235);
+    }
+
+    #[test]
+    fn test_apply_env_overrides_accepts_random_port_values() {
+        let _guard = watch_env_guard().lock().unwrap();
+        let _client_port = EnvVarRestore::capture(CLIENT_PORT_ENV);
+        let _port = EnvVarRestore::capture(PORT_ENV);
+        env::remove_var(CLIENT_PORT_ENV);
+        env::set_var(PORT_ENV, "RANDOM");
+
+        let settings = Settings {
+            client_port: 7777,
+            ..Settings::default()
+        };
+        let resolved = apply_env_overrides(&settings).expect("apply PORT=RANDOM");
+        assert_eq!(resolved.client_port, 7777);
+        assert!(resolved.randomize_client_port);
+
+        env::set_var(CLIENT_PORT_ENV, "61234");
+        let resolved = apply_env_overrides(&settings).expect("apply explicit numeric port");
+        assert_eq!(resolved.client_port, 61234);
+        assert!(!resolved.randomize_client_port);
+
+        env::set_var(CLIENT_PORT_ENV, " random ");
+        let resolved = apply_env_overrides(&settings).expect("apply namespaced RANDOM port");
+        assert!(resolved.randomize_client_port);
     }
 
     #[test]
@@ -3940,6 +4077,23 @@ mod tests {
     }
 
     #[test]
+    fn test_host_config_round_trips_random_client_port() {
+        let dir = tempdir().expect("create tempdir");
+        let path = dir.path().join("host.toml");
+        let host = HostConfig {
+            client_port: 0,
+            ..HostConfig::default()
+        };
+
+        write_toml_atomically_with_fingerprint(&path, &host).expect("write host config");
+        let persisted = fs::read_to_string(&path).expect("read host config");
+        let loaded: HostConfig = read_toml_or_default(&path).expect("load host config");
+
+        assert!(persisted.contains("client_port = \"RANDOM\""));
+        assert_eq!(loaded.client_port, 0);
+    }
+
+    #[test]
     fn test_write_shared_cluster_revision_marker_writes_file_atomically() {
         let dir = tempdir().expect("create tempdir");
         let revision_path = dir.path().join("cluster.revision");
@@ -3999,6 +4153,39 @@ mod tests {
         assert_eq!(loaded.global_download_limit_bps, 1234);
         assert!(backend.paths.settings_path.exists());
         assert!(backend.paths.metadata_path.exists());
+    }
+
+    #[test]
+    fn test_normal_backend_preserves_random_client_port_across_save() {
+        let _guard = watch_env_guard().lock().unwrap();
+        let _client_port = EnvVarRestore::capture(CLIENT_PORT_ENV);
+        let _port = EnvVarRestore::capture(PORT_ENV);
+        env::remove_var(CLIENT_PORT_ENV);
+        env::remove_var(PORT_ENV);
+
+        let dir = tempdir().expect("create tempdir");
+        let backend = NormalConfigBackend {
+            paths: NormalConfigPaths {
+                settings_path: dir.path().join("settings.toml"),
+                metadata_path: dir.path().join("torrent_metadata.toml"),
+                backup_dir: dir.path().join("backups_settings_files"),
+                data_dir: dir.path().join("data"),
+            },
+        };
+        let settings = Settings {
+            client_port: 54321,
+            randomize_client_port: true,
+            ..Settings::default()
+        };
+
+        backend.save_settings(&settings).expect("save settings");
+        let persisted =
+            fs::read_to_string(&backend.paths.settings_path).expect("read persisted settings");
+        let loaded = backend.load_settings().expect("load settings");
+
+        assert!(persisted.contains("client_port = \"RANDOM\""));
+        assert_eq!(loaded.client_port, 0);
+        assert!(loaded.randomize_client_port);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -959,6 +959,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         dynamic_port
                     );
                     client_configs.client_port = dynamic_port;
+                    client_configs.randomize_client_port = false;
                 } else {
                     tracing::warn!("Dynamic port file was empty or zero. Using config port.");
                 }

--- a/src/tui/screens/config.rs
+++ b/src/tui/screens/config.rs
@@ -189,6 +189,9 @@ fn selected_item(items: &[ConfigItem], selected_index: usize) -> ConfigItem {
 
 fn value_for_item(item: ConfigItem, settings: &Settings) -> String {
     match item {
+        ConfigItem::ClientPort if settings.randomize_client_port => {
+            format!("Random ({})", settings.client_port)
+        }
         ConfigItem::ClientPort => settings.client_port.to_string(),
         ConfigItem::DefaultDownloadFolder => {
             path_to_string(settings.default_download_folder.as_deref())
@@ -209,7 +212,10 @@ fn value_for_item(item: ConfigItem, settings: &Settings) -> String {
 
 fn config_item_is_dirty(item: ConfigItem, draft: &Settings, applied: &Settings) -> bool {
     match item {
-        ConfigItem::ClientPort => draft.client_port != applied.client_port,
+        ConfigItem::ClientPort => {
+            draft.client_port != applied.client_port
+                || draft.randomize_client_port != applied.randomize_client_port
+        }
         ConfigItem::DefaultDownloadFolder => {
             draft.default_download_folder != applied.default_download_folder
         }
@@ -254,7 +260,10 @@ pub(crate) fn merge_config_item_into_current(
         return update;
     }
     match item {
-        ConfigItem::ClientPort => update.client_port = draft.client_port,
+        ConfigItem::ClientPort => {
+            update.client_port = draft.client_port;
+            update.randomize_client_port = draft.randomize_client_port;
+        }
         ConfigItem::DefaultDownloadFolder => {
             update.default_download_folder = draft.default_download_folder.clone();
         }
@@ -322,7 +331,9 @@ fn parse_rate_limit_input(input: &str) -> Option<u64> {
 
 fn edit_character_allowed(item: ConfigItem, character: char) -> bool {
     match item {
-        ConfigItem::ClientPort => character.is_ascii_digit(),
+        ConfigItem::ClientPort => {
+            character.is_ascii_digit() || "random".contains(character.to_ascii_lowercase())
+        }
         ConfigItem::GlobalDownloadLimit | ConfigItem::GlobalUploadLimit => {
             character.is_ascii_alphanumeric() || matches!(character, '.' | ' ' | '/')
         }
@@ -441,7 +452,11 @@ pub fn reduce_config_action(
                     }
                 }
                 ConfigItem::ClientPort => {
-                    let buffer = settings_edit.client_port.to_string();
+                    let buffer = if settings_edit.randomize_client_port {
+                        "RANDOM".to_string()
+                    } else {
+                        settings_edit.client_port.to_string()
+                    };
                     *editing = Some(ConfigEditState {
                         cursor: buffer.len(),
                         buffer,
@@ -503,6 +518,7 @@ pub fn reduce_config_action(
             match selected_item {
                 ConfigItem::ClientPort => {
                     settings_edit.client_port = default_settings.client_port;
+                    settings_edit.randomize_client_port = false;
                 }
                 ConfigItem::DefaultDownloadFolder => {
                     if !shared_path_is_manual(selected_item) {
@@ -645,10 +661,16 @@ pub fn reduce_config_action(
                 let mut changed = false;
                 match editor.item {
                     ConfigItem::ClientPort => {
-                        if let Ok(new_port) = editor.buffer.parse::<u16>() {
+                        if is_random_port_input(&editor.buffer) {
+                            changed = !settings_edit.randomize_client_port;
+                            settings_edit.randomize_client_port = true;
+                            committed = true;
+                        } else if let Ok(new_port) = editor.buffer.parse::<u16>() {
                             if new_port > 0 {
-                                changed = settings_edit.client_port != new_port;
+                                changed = settings_edit.client_port != new_port
+                                    || settings_edit.randomize_client_port;
                                 settings_edit.client_port = new_port;
+                                settings_edit.randomize_client_port = false;
                                 committed = true;
                             }
                         }
@@ -1049,7 +1071,9 @@ fn build_port_detail_lines(
     let ctx = render_ctx.screen.theme;
     let draft = render_ctx.settings.client_port;
     let active = render_ctx.screen.settings.client_port;
-    let dirty = draft != active;
+    let draft_random = render_ctx.settings.randomize_client_port;
+    let active_random = render_ctx.screen.settings.randomize_client_port;
+    let dirty = draft != active || draft_random != active_random;
     let value_style = ctx.apply(
         Style::default()
             .fg(if dirty {
@@ -1059,7 +1083,12 @@ fn build_port_detail_lines(
             })
             .bold(),
     );
-    let mut configured = detail_row("Configured", draft.to_string(), value_style, ctx);
+    let configured_value = if draft_random {
+        "Random each start".to_string()
+    } else {
+        draft.to_string()
+    };
+    let mut configured = detail_row("Configured", configured_value, value_style, ctx);
     if dirty {
         configured.spans.push(Span::styled(
             "  UPDATING",
@@ -1456,7 +1485,7 @@ fn build_edit_detail_lines(
     let (status, valid) = match item {
         ConfigItem::ClientPort => (
             port_edit_status_message(buffer),
-            buffer.parse::<u16>().is_ok_and(|port| port > 0),
+            is_random_port_input(buffer) || buffer.parse::<u16>().is_ok_and(|port| port > 0),
         ),
         ConfigItem::GlobalDownloadLimit | ConfigItem::GlobalUploadLimit => {
             let parsed = parse_rate_limit_input(buffer);
@@ -1741,14 +1770,21 @@ fn rate_gauge_line(
 
 fn port_edit_status_message(buffer: &str) -> String {
     if buffer.is_empty() {
-        return "Type the new listen port.".to_string();
+        return "Type a listen port or RANDOM.".to_string();
+    }
+    if is_random_port_input(buffer) {
+        return "Ready to select a new port on each start.".to_string();
     }
 
     match buffer.parse::<u16>() {
-        Ok(0) => "Port 0 is reserved for startup auto-bind.".to_string(),
+        Ok(0) => "Use RANDOM to select an available port at startup.".to_string(),
         Ok(port) => format!("Ready to apply port {port}."),
-        Err(_) => "Invalid port range. Use 1-65535.".to_string(),
+        Err(_) => "Use RANDOM or a port from 1-65535.".to_string(),
     }
+}
+
+fn is_random_port_input(buffer: &str) -> bool {
+    buffer.eq_ignore_ascii_case("RANDOM")
 }
 
 fn render_config_footer(
@@ -2546,6 +2582,7 @@ mod tests {
         };
         let mut draft = current.clone();
         draft.client_port = draft.client_port.saturating_add(1);
+        draft.randomize_client_port = true;
         draft.watch_folder = Some(std::path::PathBuf::from("/tmp/superseedr-watch"));
         draft.always_show_add_location_prompt = !draft.always_show_add_location_prompt;
         draft.ui_layout_mode = crate::config::UiLayoutMode::Horizontal;
@@ -2556,6 +2593,7 @@ mod tests {
         let update = merge_config_item_into_current(&draft, &current, ConfigItem::ClientPort, true);
 
         assert_eq!(update.client_port, draft.client_port);
+        assert!(update.randomize_client_port);
         assert_eq!(update.watch_folder, current.watch_folder);
         assert_eq!(
             update.always_show_add_location_prompt,
@@ -2629,6 +2667,58 @@ mod tests {
         );
 
         assert_eq!(settings.global_download_limit_bps, 123);
+        assert_eq!(editing, None);
+        assert!(matches!(
+            out.effects.as_slice(),
+            [ConfigEffect::ApplySettings]
+        ));
+    }
+
+    #[test]
+    fn reducer_numeric_port_edit_disables_randomization() {
+        let mut settings = Box::new(Settings {
+            randomize_client_port: true,
+            ..Settings::default()
+        });
+        let mut idx = 0usize;
+        let mut items = config_items();
+        let mut editing = Some(editor(ConfigItem::ClientPort, "7123"));
+
+        let out = reduce_config_action(
+            ConfigAction::EditCommit,
+            &mut settings,
+            &mut idx,
+            items.as_mut_slice(),
+            &mut editing,
+        );
+
+        assert_eq!(settings.client_port, 7123);
+        assert!(!settings.randomize_client_port);
+        assert_eq!(editing, None);
+        assert!(matches!(
+            out.effects.as_slice(),
+            [ConfigEffect::ApplySettings]
+        ));
+    }
+
+    #[test]
+    fn reducer_random_port_edit_enables_randomization() {
+        let mut settings = Box::new(Settings::default());
+        let original_port = settings.client_port;
+        let mut idx = 0usize;
+        let mut items = config_items();
+        let mut editing = Some(editor(ConfigItem::ClientPort, "random"));
+
+        let out = reduce_config_action(
+            ConfigAction::EditCommit,
+            &mut settings,
+            &mut idx,
+            items.as_mut_slice(),
+            &mut editing,
+        );
+
+        assert_eq!(settings.client_port, original_port);
+        assert!(settings.randomize_client_port);
         assert_eq!(editing, None);
         assert!(matches!(
             out.effects.as_slice(),
@@ -3243,6 +3333,36 @@ mod tests {
     }
 
     #[test]
+    fn exact_editor_prefills_random_for_randomized_port_mode() {
+        let mut settings = Box::new(Settings {
+            randomize_client_port: true,
+            ..Settings::default()
+        });
+        let mut idx = 0usize;
+        let mut items = config_items();
+        let mut editing = None;
+
+        let out = reduce_config_action(
+            ConfigAction::ShiftSelected,
+            &mut settings,
+            &mut idx,
+            items.as_mut_slice(),
+            &mut editing,
+        );
+
+        assert!(out.effects.is_empty());
+        assert_eq!(
+            editing,
+            Some(ConfigEditState {
+                item: ConfigItem::ClientPort,
+                buffer: "RANDOM".to_string(),
+                cursor: 6,
+                select_all: true,
+            })
+        );
+    }
+
+    #[test]
     fn first_typed_character_replaces_selected_editor_value() {
         let mut settings = Box::new(Settings::default());
         let mut idx = 0usize;
@@ -3345,14 +3465,21 @@ mod tests {
 
     #[test]
     fn port_edit_validation_rejects_zero_and_out_of_range_values() {
-        assert_eq!(port_edit_status_message(""), "Type the new listen port.");
+        assert_eq!(
+            port_edit_status_message(""),
+            "Type a listen port or RANDOM."
+        );
         assert_eq!(
             port_edit_status_message("0"),
-            "Port 0 is reserved for startup auto-bind."
+            "Use RANDOM to select an available port at startup."
         );
         assert_eq!(
             port_edit_status_message("7123"),
             "Ready to apply port 7123."
+        );
+        assert_eq!(
+            port_edit_status_message("random"),
+            "Ready to select a new port on each start."
         );
     }
 


### PR DESCRIPTION
## Summary

- accept `client_port = "RANDOM"`, `SUPERSEEDR_CLIENT_PORT=RANDOM`, and `PORT=RANDOM`
- bind an available ephemeral TCP/uTP listen port while preserving random mode across autosaves
- allow `RANDOM` in the TUI Listen Port editor and show the selected runtime port
- document config, CLI, shared-host, and Docker/Gluetun behavior

## Why

Users running multiple clients or frequently changing environments need a collision-free listen port without manually choosing and persisting a number. The runtime already supported binding port zero internally, but configuration parsing, persistence, environment overrides, and the TUI did not expose that behavior as a durable user setting.

## User impact

Users can choose a new available port on each startup from the config file, environment, or config screen. Numeric port inputs continue to select a fixed port and take precedence through the namespaced environment variable.

## Validation

- `cargo fmt -- --check`
- `cargo test --locked config::tests` (130 passed)
- `cargo test --locked randomized_client_port_binds_an_ephemeral_port_and_preserves_the_mode`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `git diff --cached --check` before commit
