### PR TITLE
Add named library profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,15 @@ superseedr show-configs
 # Persist shared launcher config for installed/protocol launches
 superseedr set-shared-config "/path/to/seedbox"
 
+# Register and switch between named shared-config libraries
+superseedr library add primary "/path/to/primary"
+superseedr library add archive "/path/to/archive"
+superseedr library use primary
+superseedr library list
+
+# Use a library for one invocation without changing the active library
+superseedr --library archive torrents
+
 # Convert local config into layered shared config
 superseedr to-shared "/path/to/seedbox"
 
@@ -261,9 +270,23 @@ superseedr to-standalone
 superseedr stop-client
 ```
 
-See [`docs/cli.md`](docs/cli.md) for full CLI command behavior, and
-[`docs/shared-config.md`](docs/shared-config.md) for shared leader/follower
-routing.
+See [`docs/cli.md`](docs/cli.md) for full CLI command behavior,
+[`docs/libraries.md`](docs/libraries.md) for local and shared named-library
+behavior, and [`docs/shared-config.md`](docs/shared-config.md) for shared
+leader/follower routing.
+
+Press `c`, select **Libraries**, and press `Space` to manage libraries. Adding a
+library asks for its name and then opens the directory picker for its root. The
+simplified Libraries manager opens inside Config's existing detail panel. A
+library switch gracefully shuts down and flushes the current engine, releases
+its shared-config lock, selects the new root, and launches a fresh engine. Only
+one library runs at a time.
+The Libraries panel loads torrent counts and the highlighted library's
+scrollable torrent-name list asynchronously; previewing does not start an
+inactive torrent manager.
+Library roots may be ordinary local directories; they do not need to be network
+shares. They always use the layered `<library-root>/superseedr-config/` layout,
+not additional platform-default standalone config directories.
 
 To choose a new available peer-listening port on every start, set
 `client_port = "RANDOM"` in `settings.toml`. You can also launch with
@@ -469,6 +492,3 @@ Superseedr implements the following BitTorrent Enhancement Proposals (BEPs):
 * **BEP 52:** The BitTorrent Protocol v2
 
 </details>
-
-
-

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release v1.0.13
 ### 🚀 New Features
+- **Shared-Config Libraries**: Added an always-local named library registry, CLI management, one-shot `--library` selection, Config-integrated management, and asynchronous read-only torrent counts/name previews; switching occurs only after the current engine has flushed and shut down.
 - **Global Peer Management**: Added a dedicated `P` workspace for inspecting peers across all torrents, with activity and restriction filters, fuzzy or regex search, sortable columns, detailed evidence views, and optional privacy masking.
 - **Automatic Malicious-Peer Protection**: Added a global policy that detects excessive transfer activity and rapid reconnect churn, temporarily restricts offending addresses, and carries those protections across active torrents and restarts.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -228,9 +228,48 @@ source of that selection.
 
 Shared-config precedence is:
 
-1. `SUPERSEEDR_SHARED_CONFIG_DIR`
-2. persisted launcher shared-config sidecar
-3. normal standalone mode
+1. `--library <NAME>` for the current process
+2. `SUPERSEEDR_SHARED_CONFIG_DIR`
+3. active named library
+4. persisted launcher shared-config sidecar
+5. normal standalone mode
+
+### `library`
+
+```bash
+superseedr library list
+superseedr library add <NAME> <PATH> [--description <TEXT>]
+superseedr library rename <NAME> <NEW_NAME>
+superseedr library remove <NAME>
+superseedr library use <NAME>
+superseedr library show [NAME]
+superseedr library open [NAME]
+```
+
+Libraries are named shared-config roots stored in the always-local launcher
+configuration. Missing paths remain registered and are reported as unavailable.
+Removing a library only removes its registry entry; it never deletes the shared
+configuration or torrent data.
+
+The root may be an ordinary local directory or mounted shared storage, but every
+named library uses `<root>/superseedr-config/`. Platform-default standalone
+config directories cannot be registered directly; use `to-shared` to copy the
+current standalone configuration into a library root first. See
+[`libraries.md`](libraries.md) for setup, migration, switching, and download-path
+examples.
+
+`library use` changes the library used by future starts when the client is not
+running. While the client is running, press `c`, select **Libraries**, press
+`Space`, and switch there so the old engine can flush and shut down before
+selection changes.
+
+Use `--library <NAME>` to target one library for a single process without
+changing the active library:
+
+```bash
+superseedr --library archive torrents
+superseedr --library archive show-configs
+```
 
 ### `show-configs`
 

--- a/docs/configuration-and-backups.md
+++ b/docs/configuration-and-backups.md
@@ -29,6 +29,12 @@ directories.
 The exact `<config-dir>` and `<data-dir>` are platform-specific. Use
 `superseedr show-configs --all` to print them.
 
+There is one platform-default standalone configuration. Named libraries do not
+redirect to additional standalone config directories; each library instead uses
+the layered shared-config layout described below. The library root may still be
+an ordinary local directory. See [`libraries.md`](libraries.md) for conversion
+and switching examples.
+
 ## Launcher Sidecars
 
 These per-user files live in the normal `<config-dir>` even when shared mode is
@@ -39,6 +45,7 @@ shared mode without relying on shell environment variables.
 | --- | --- |
 | `<config-dir>/launcher_shared_config.toml` | Persisted shared mount root from `superseedr set-shared-config`. |
 | `<config-dir>/launcher_host_id.toml` | Persisted shared host id from `superseedr set-host-id`. |
+| `<config-dir>/libraries.toml` | Named shared-config roots, active library, descriptions, and last-used timestamps. |
 
 ## macOS Handler Diagnostics
 

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -1,0 +1,159 @@
+# Named Libraries
+
+Named libraries let one Superseedr installation switch between independent
+configurations. A library is a name associated with an absolute root directory.
+Only the selected library is loaded, and only its torrent manager runs.
+
+## Local and Shared Roots
+
+A library root does not need to be on a network share. It can be any existing,
+writable directory:
+
+| Root location | Supported | Behavior |
+| --- | --- | --- |
+| Local disk directory | Yes | Uses the shared/layered layout locally. |
+| Mounted network or removable directory | Yes | Can participate in shared leader/follower mode. |
+| Platform-default standalone config directory | No, not directly | Remains the single standalone configuration. Convert it into a library first. |
+
+Every named library uses this layout, even when its root is on a local disk:
+
+```text
+<library-root>/
+  superseedr-config/
+    settings.toml
+    catalog.toml
+    torrent_metadata.toml
+    hosts/
+```
+
+The word "shared" describes the configuration backend and directory layout; it
+does not require multiple computers or shared storage.
+
+The always-local library registry is stored in the normal Superseedr config
+directory as `libraries.toml`. It contains library names and paths, not the
+libraries' torrent catalogs.
+
+## Default Standalone Configuration
+
+When no named library, shared-config environment variable, or persisted shared
+root is selected, Superseedr continues to use its normal platform-default config
+and data directories. Named libraries do not change or delete that standalone
+configuration.
+
+Superseedr cannot currently register several standalone config directories and
+switch among them directly. To make the current standalone configuration a
+named library, convert it to a library root:
+
+```bash
+# Stop the running client before converting its persisted configuration.
+mkdir -p /absolute/path/to/primary
+superseedr to-shared /absolute/path/to/primary
+superseedr library add primary /absolute/path/to/primary
+superseedr library use primary
+```
+
+`to-shared` copies the current standalone configuration into the layered layout.
+It does not remove the standalone files or select the new root by itself.
+
+To create a new empty local library instead:
+
+```bash
+mkdir -p /absolute/path/to/archive
+superseedr library add archive /absolute/path/to/archive \
+  --description "Local archive configuration"
+superseedr library use archive
+```
+
+The registered path must be absolute and must exist before it can be selected.
+Superseedr initializes and validates the `superseedr-config` backend when the
+library is first loaded; configuration files are persisted as settings and
+catalog state are saved.
+
+## Managing Libraries
+
+```bash
+superseedr library list
+superseedr library add <NAME> <PATH> [--description <TEXT>]
+superseedr library rename <NAME> <NEW_NAME>
+superseedr library remove <NAME>
+superseedr library use <NAME>
+superseedr library show [NAME]
+superseedr library open [NAME]
+```
+
+Press `c` to open Config, select **Libraries**, and press `Space`. From there you
+can add, rename, remove, reveal, or switch libraries. Adding a library prompts
+for its name and then opens the directory picker to select the library root; the
+path does not need to be typed manually.
+
+Library management stays inside Config. On wider layouts the settings list
+remains visible and Libraries replaces the existing detail panel; on compact
+layouts it uses that same panel area and `Esc` returns to the settings list.
+
+When the Libraries panel opens, Superseedr reads registered catalogs in a
+background task. Each library row shows its torrent count, and the highlighted
+library shows an alphabetized list of torrent names. Use `Page Up`, `Page Down`,
+`Home`, and `End` to scroll that list. Loading an inactive preview is read-only:
+it does not acquire the library as active or start its torrent manager. Missing
+and unreadable catalogs are reported in the preview without blocking the TUI.
+
+Removing a library only removes its registry entry. It never deletes the root,
+configuration, downloaded data, or torrent files. A missing or unmounted path
+also remains registered but is shown as unavailable.
+
+## Switching and Runtime Behavior
+
+Only one named library runs in a Superseedr process. A live TUI switch:
+
+1. validates and preloads the destination configuration
+2. flushes and gracefully shuts down the current engine
+3. releases the current config lock and runtime resources
+4. records the new active library
+5. launches a fresh Superseedr process for that library
+
+The old library is not left seeding or downloading in the background. Running
+several libraries simultaneously requires separate Superseedr processes and is
+outside the named-library switching workflow.
+
+`superseedr library use <NAME>` is intended for switching while the client is
+stopped. If a client is running, switch from the TUI so its current state can be
+persisted safely.
+
+For a one-command override without changing the saved active library:
+
+```bash
+superseedr --library archive torrents
+superseedr --library archive show-configs
+```
+
+Selection precedence is:
+
+1. `--library <NAME>`
+2. `SUPERSEEDR_SHARED_CONFIG_DIR`
+3. active named library
+4. persisted `set-shared-config` root
+5. normal standalone paths
+
+Because the environment variable has higher precedence, a process started with
+`SUPERSEEDR_SHARED_CONFIG_DIR` cannot switch named libraries until that override
+is removed.
+
+## Libraries Versus Download Paths
+
+Use separate libraries when you want separate catalogs, settings, runtime state,
+and torrent-manager lifecycles. Use one configuration with different download
+paths when you only want to organize payload data into folders.
+
+For example, these torrents remain in one library and one running engine:
+
+```bash
+superseedr add --path /data/active /path/to/first.torrent
+superseedr add --path /data/archive /path/to/second.torrent
+```
+
+Changing a torrent's download path does not create another library or another
+torrent manager.
+
+For the underlying file layout and multi-host behavior, see
+[`configuration-and-backups.md`](configuration-and-backups.md) and
+[`shared-config.md`](shared-config.md).

--- a/docs/release-candidate-testing.md
+++ b/docs/release-candidate-testing.md
@@ -366,9 +366,9 @@ the event journal.
 
 ### `TUI-09` Config Screen
 
-Exercise every current setting: Listen Port, Default Download Folder, Torrent
-Watch Folder, Layout, Confirm Add Priority And Location, Global Download Limit,
-and Global Upload Limit.
+Exercise every current setting and route: Listen Port, Libraries, Default
+Download Folder, Torrent Watch Folder, Layout, Confirm Add Priority And
+Location, Global Download Limit, and Global Upload Limit.
 
 For each setting:
 
@@ -388,6 +388,15 @@ For each setting:
 8. Change the listen port while running. Confirm listener/status updates and the
    transport-seen matrix resets for the new listener.
 9. Press `q` or `Esc`; confirm Config closes without an extra save step.
+10. Select Libraries and press `Space`. Confirm management replaces Config's
+    detail panel instead of opening a separate screen. Add a disposable library
+    name, confirm the directory picker opens, cancel back to Libraries once,
+    then select a disposable root. Confirm `Esc` returns to Config's settings
+    list and no global `L` route opens Libraries from the dashboard.
+11. Register at least two disposable libraries with different neutral torrent
+    names. Confirm counts and the selected library's names load without input
+    lag, `Page Up`/`Page Down` scroll the preview, and highlighting an unavailable
+    library reports an error without starting another torrent manager.
 
 For rate editors, use a documented valid value such as `25 Mbps`; byte-oriented
 forms such as `MiB/s` are not valid unless Help explicitly says otherwise. An

--- a/docs/shared-config.md
+++ b/docs/shared-config.md
@@ -184,6 +184,27 @@ superseedr show-host-id
 superseedr clear-host-id
 ```
 
+Named libraries provide an always-local registry of shared-config roots:
+
+```bash
+superseedr library add primary /mnt/shared-drive/primary
+superseedr library add archive /mnt/archive-drive/archive
+superseedr library use primary
+superseedr library list
+```
+
+A named root may be on a local disk; it does not have to be shared by multiple
+hosts. Named libraries still use the layered `<root>/superseedr-config/` backend
+and do not directly wrap multiple platform-default standalone config
+directories. See [`libraries.md`](libraries.md) for the complete guide and
+standalone conversion steps.
+
+Press `c`, select **Libraries**, and press `Space` to switch safely. Adding a
+library opens the directory picker after its name is entered. The current engine
+is fully flushed and stopped before the active library changes, then a fresh
+process loads the new shared root and acquires its own leader/follower lock.
+Inactive libraries do not run torrent managers.
+
 Rules:
 
 - `set-shared-config` requires an absolute path
@@ -194,6 +215,8 @@ Rules:
 - `show-host-id` reports the effective host id and its source
 - `clear-shared-config` disables persisted shared mode unless the env var is set
 - `clear-host-id` removes the persisted host id unless the env var is set
+- unavailable library paths remain registered rather than being removed
+- an environment-selected shared root cannot be changed from Config's Libraries panel
 
 ## Conversion Commands
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -506,6 +506,9 @@ pub enum FileBrowserMode {
         selected_index: usize,
         items: Vec<ConfigItem>,
     },
+    LibraryPathSelection {
+        name: String,
+    },
 }
 
 fn merge_file_browser_mode_for_fetch(
@@ -914,6 +917,11 @@ pub enum AppCommand {
         request: ControlRequest,
     },
     ClientShutdown(PathBuf),
+    SwitchLibrary(String),
+    LibraryPreviewsLoaded {
+        request_id: u64,
+        previews: Vec<crate::library::LibraryPreview>,
+    },
     PortFileChanged(PathBuf),
     FetchFileTree {
         browser_generation: u64,
@@ -979,6 +987,42 @@ pub enum AppRuntimeMode {
     Normal,
     SharedLeader,
     SharedFollower,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AppExit {
+    Quit,
+    SwitchLibrary(String),
+}
+
+fn validate_library_switch_request(name: &str) -> io::Result<()> {
+    if crate::config::effective_shared_config_selection()?
+        .is_some_and(|selection| selection.source == crate::config::SharedConfigSource::Env)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Cannot switch libraries while SUPERSEEDR_SHARED_CONFIG_DIR overrides the active library.",
+        ));
+    }
+    let library = crate::library::validate_switch_target(name)?;
+    crate::config::preflight_shared_library(&library.shared_config_path).map(|_| ())
+}
+
+fn apply_library_previews(
+    libraries: &mut LibrariesUiState,
+    request_id: u64,
+    previews: Vec<crate::library::LibraryPreview>,
+) -> bool {
+    if request_id != libraries.preview_request_id {
+        return false;
+    }
+    libraries.previews = previews
+        .into_iter()
+        .map(|preview| (preview.name.clone(), preview))
+        .collect();
+    libraries.previews_loading = false;
+    libraries.preview_scroll = 0;
+    true
 }
 
 impl AppRuntimeMode {
@@ -1066,6 +1110,7 @@ pub enum ConfigItem {
     AlwaysShowAddLocationPrompt,
     GlobalDownloadLimit,
     GlobalUploadLimit,
+    Libraries,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -1073,6 +1118,7 @@ pub enum ConfigPane {
     #[default]
     Settings,
     Details,
+    Libraries,
 }
 
 #[derive(Default)]
@@ -1664,9 +1710,35 @@ pub struct UiState {
     pub journal: JournalUiState,
     pub peer_management: PeerManagementUiState,
     pub torrent_management: TorrentManagementUiState,
+    pub libraries: LibrariesUiState,
     pub normal_paste_burst: PasteBurst,
     #[allow(dead_code)]
     pub rss: RssUiState,
+}
+
+#[derive(Default)]
+pub struct LibrariesUiState {
+    pub entries: Vec<crate::library::LibraryStatus>,
+    pub selected_index: usize,
+    pub input: Option<LibraryInputState>,
+    pub status_message: Option<String>,
+    pub previews: HashMap<String, crate::library::LibraryPreview>,
+    pub preview_request_id: u64,
+    pub previews_loading: bool,
+    pub preview_scroll: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LibraryInputState {
+    pub kind: LibraryInputKind,
+    pub buffer: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LibraryInputKind {
+    AddName,
+    Rename { current_name: String },
+    ConfirmRemove { name: String },
 }
 
 impl UiState {
@@ -2832,6 +2904,7 @@ pub struct App {
     pub current_cluster_role: Option<AppClusterRole>,
     pub watched_paths: Vec<PathBuf>,
     pub base_system_warning: Option<String>,
+    pending_library_switch: Option<String>,
 
     pub listener: Option<ListenerSet>,
 
@@ -3474,6 +3547,7 @@ impl App {
             current_cluster_role,
             watched_paths,
             base_system_warning: system_warning,
+            pending_library_switch: None,
             listener,
             torrent_manager_incoming_peer_txs: HashMap::new(),
             torrent_manager_command_txs: HashMap::new(),
@@ -4890,7 +4964,7 @@ impl App {
     pub async fn run(
         &mut self,
         terminal: &mut Terminal<CrosstermBackend<Stdout>>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<AppExit, Box<dyn std::error::Error>> {
         if let Ok(size) = terminal.size() {
             self.app_state.screen_area = Rect::new(0, 0, size.width, size.height);
         }
@@ -5169,7 +5243,10 @@ impl App {
         self.flush_shared_recovery_backup_worker().await;
         self.flush_persistence_writer().await;
 
-        Ok(())
+        Ok(match self.pending_library_switch.take() {
+            Some(name) => AppExit::SwitchLibrary(name),
+            None => AppExit::Quit,
+        })
     }
 
     fn should_draw_this_frame(
@@ -6318,6 +6395,26 @@ impl App {
                         &path,
                         e
                     );
+                }
+            }
+            AppCommand::SwitchLibrary(name) => {
+                match validate_library_switch_request(&name) {
+                    Ok(()) => {
+                        self.pending_library_switch = Some(name);
+                        self.app_state.should_quit = true;
+                    }
+                    Err(error) => {
+                        self.app_state.system_error = Some(error.to_string());
+                    }
+                }
+                self.app_state.ui.needs_redraw = true;
+            }
+            AppCommand::LibraryPreviewsLoaded {
+                request_id,
+                previews,
+            } => {
+                if apply_library_previews(&mut self.app_state.ui.libraries, request_id, previews) {
+                    self.app_state.ui.needs_redraw = true;
                 }
             }
             AppCommand::PortFileChanged(path) => {
@@ -10131,7 +10228,7 @@ mod tests {
     #![allow(clippy::await_holding_lock)]
 
     use super::{
-        advance_dht_wave_state, align_unpinned_sort_with_visible_activity,
+        advance_dht_wave_state, align_unpinned_sort_with_visible_activity, apply_library_previews,
         apply_network_history_persist_result, build_persist_payload, build_torrent_preview_tree,
         bytes_per_sec_to_bps, clamp_selected_indices_in_state, compose_system_warning,
         configured_download_bucket_rate, configured_download_ceiling_bytes_per_sec,
@@ -10145,17 +10242,17 @@ mod tests {
         resolve_magnet_torrent_name, rss_settings_changed, should_load_persisted_torrent,
         should_persist_network_history_on_interval, sort_and_filter_torrent_list_state,
         swarm_availability_counts, tcp_peer_listener_enabled, torrent_completion_percent,
-        torrent_is_effectively_incomplete, App, AppClusterRole, AppCommand, AppMode,
-        AppRuntimeMode, AppState, BrowserPane, BrowserSearchState, ColumnId, CommandIngestResult,
-        DataRate, DhtWaveTargets, DhtWaveUiState, DiskBackpressureDecision,
+        torrent_is_effectively_incomplete, validate_library_switch_request, App, AppClusterRole,
+        AppCommand, AppMode, AppRuntimeMode, AppState, BrowserPane, BrowserSearchState, ColumnId,
+        CommandIngestResult, DataRate, DhtWaveTargets, DhtWaveUiState, DiskBackpressureDecision,
         DiskBackpressureDownloadThrottle, DiskBackpressureSample, DownloadSelectionTarget,
         FileBrowserMode, FileMetadata, FilePriority, InboundPeerTransportStatus, IngestSource,
-        ListenerSet, LogCooldown, PeerInfo, PeerListenerTransportMode, PeerSortColumn,
-        PendingManualIngest, PersistPayload, ResolvedAddPayload, SearchMode, SelectedHeader,
-        SortDirection, SwarmAvailabilityFlashState, TorrentControlState, TorrentDisplayState,
-        TorrentIntegritySnapshot, TorrentMetrics, TorrentPreviewPayload, TorrentSortColumn,
-        UiState, WakeLagPeerThrottle, AWAITING_MAGNET_METADATA_LABEL, BITTORRENT_PROTOCOL_STR,
-        DHT_WAVE_PHASE_WRAP_PERIOD, DISK_WRITE_THROTTLE_MIN_BYTES_PER_SEC,
+        LibrariesUiState, ListenerSet, LogCooldown, PeerInfo, PeerListenerTransportMode,
+        PeerSortColumn, PendingManualIngest, PersistPayload, ResolvedAddPayload, SearchMode,
+        SelectedHeader, SortDirection, SwarmAvailabilityFlashState, TorrentControlState,
+        TorrentDisplayState, TorrentIntegritySnapshot, TorrentMetrics, TorrentPreviewPayload,
+        TorrentSortColumn, UiState, WakeLagPeerThrottle, AWAITING_MAGNET_METADATA_LABEL,
+        BITTORRENT_PROTOCOL_STR, DHT_WAVE_PHASE_WRAP_PERIOD, DISK_WRITE_THROTTLE_MIN_BYTES_PER_SEC,
         DISK_WRITE_THROTTLE_START_BYTES_PER_SEC, DISK_WRITE_THROTTLE_STEP_MAX,
         DISK_WRITE_THROTTLE_STEP_MIN, DISK_WRITE_THROTTLE_TARGET_LATENCY_SECS,
         DISK_WRITE_THROTTLE_WINDOW_TICKS, SWARM_AVAILABILITY_FLASH_DURATION,
@@ -10657,6 +10754,62 @@ mod tests {
         let data_dir = dir.path().join("data");
         set_app_paths_override_for_tests(Some((config_dir, data_dir)));
         TempAppPaths { dir }
+    }
+
+    #[test]
+    fn library_switch_plan_does_not_change_config_before_engine_shutdown() {
+        let _guard = lock_shared_env();
+        let temp_paths = configure_temp_app_paths_for_test();
+        let library_a = temp_paths.path().join("library-a");
+        let library_b = temp_paths.path().join("library-b");
+        std::fs::create_dir_all(&library_a).expect("create library A");
+        std::fs::create_dir_all(&library_b).expect("create library B");
+        crate::library::add_library("library-a", &library_a, None).expect("add library A");
+        crate::library::add_library("library-b", &library_b, None).expect("add library B");
+        crate::library::activate_library("library-a").expect("activate library A");
+
+        validate_library_switch_request("library-b").expect("validate switch target");
+        assert_eq!(
+            crate::library::active_library()
+                .expect("load active library")
+                .expect("active library")
+                .0,
+            "library-a",
+            "the old library must stay active until App::run flushes and shuts down"
+        );
+    }
+
+    #[test]
+    fn stale_library_preview_results_do_not_replace_the_current_request() {
+        let mut libraries = LibrariesUiState {
+            preview_request_id: 2,
+            previews_loading: true,
+            preview_scroll: 12,
+            ..Default::default()
+        };
+        let stale = crate::library::LibraryPreview {
+            name: "archive".to_string(),
+            torrent_names: vec!["Stale Entry".to_string()],
+            error: None,
+        };
+
+        assert!(!apply_library_previews(&mut libraries, 1, vec![stale]));
+        assert!(libraries.previews.is_empty());
+        assert!(libraries.previews_loading);
+        assert_eq!(libraries.preview_scroll, 12);
+
+        let current = crate::library::LibraryPreview {
+            name: "archive".to_string(),
+            torrent_names: vec!["Current Entry".to_string()],
+            error: None,
+        };
+        assert!(apply_library_previews(&mut libraries, 2, vec![current]));
+        assert_eq!(
+            libraries.previews["archive"].torrent_names,
+            ["Current Entry"]
+        );
+        assert!(!libraries.previews_loading);
+        assert_eq!(libraries.preview_scroll, 0);
     }
 
     fn mark_startup_roll_in_responsiveness_ready(app: &mut App) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -402,6 +402,7 @@ struct LauncherHostId {
 #[serde(rename_all = "snake_case")]
 pub enum SharedConfigSource {
     Env,
+    Library,
     Launcher,
 }
 
@@ -599,6 +600,7 @@ enum ConfigBackend {
 
 static LOGGED_SHARED_CONFIG_REVISION: OnceLock<Mutex<Option<LoggedSharedConfigRevision>>> =
     OnceLock::new();
+static PROCESS_SHARED_CONFIG_OVERRIDE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
 
 #[cfg(test)]
 static APP_PATHS_OVERRIDE: OnceLock<Mutex<Option<(PathBuf, PathBuf)>>> = OnceLock::new();
@@ -629,6 +631,22 @@ pub(crate) fn shared_env_guard_for_tests() -> &'static Mutex<()> {
 
 fn logged_shared_config_revision() -> &'static Mutex<Option<LoggedSharedConfigRevision>> {
     LOGGED_SHARED_CONFIG_REVISION.get_or_init(|| Mutex::new(None))
+}
+
+fn process_shared_config_override() -> &'static Mutex<Option<PathBuf>> {
+    PROCESS_SHARED_CONFIG_OVERRIDE.get_or_init(|| Mutex::new(None))
+}
+
+pub fn set_process_library_override(name: Option<&str>) -> io::Result<()> {
+    let path = match name {
+        Some(name) => Some(crate::library::validate_switch_target(name)?.shared_config_path),
+        None => None,
+    };
+    *process_shared_config_override()
+        .lock()
+        .expect("process shared-config override lock poisoned") = path;
+    clear_shared_config_state();
+    Ok(())
 }
 
 impl LayeredConfig {
@@ -1144,6 +1162,19 @@ fn load_launcher_host_id() -> io::Result<Option<String>> {
 }
 
 fn resolve_shared_config_selection() -> io::Result<Option<SharedConfigSelection>> {
+    if let Some(path) = process_shared_config_override()
+        .lock()
+        .expect("process shared-config override lock poisoned")
+        .clone()
+    {
+        let (mount_root, config_root) = resolve_shared_mount_and_config_root(path);
+        return Ok(Some(SharedConfigSelection {
+            source: SharedConfigSource::Library,
+            mount_root,
+            config_root,
+        }));
+    }
+
     if let Some(path) = env_var_os_case_insensitive(SHARED_CONFIG_DIR_ENV)
         .filter(|value| !value.is_empty())
         .map(expand_home_path)
@@ -1152,6 +1183,16 @@ fn resolve_shared_config_selection() -> io::Result<Option<SharedConfigSelection>
         let (mount_root, config_root) = resolve_shared_mount_and_config_root(path);
         return Ok(Some(SharedConfigSelection {
             source: SharedConfigSource::Env,
+            mount_root,
+            config_root,
+        }));
+    }
+
+    if let Some((_name, library)) = crate::library::active_library()? {
+        let (mount_root, config_root) =
+            resolve_shared_mount_and_config_root(library.shared_config_path);
+        return Ok(Some(SharedConfigSelection {
+            source: SharedConfigSource::Library,
             mount_root,
             config_root,
         }));
@@ -3160,6 +3201,35 @@ pub fn load_settings() -> io::Result<Settings> {
 
 pub fn load_settings_for_cli() -> io::Result<Settings> {
     resolve_config_backend()?.load_settings_for_cli()
+}
+
+pub fn preflight_shared_library(path: &Path) -> io::Result<Settings> {
+    shared_backend_for_mount_root(path)?.load_settings()
+}
+
+pub fn load_shared_library_torrent_names(path: &Path) -> io::Result<Vec<String>> {
+    if !path.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("Library is unavailable at {}", path.display()),
+        ));
+    }
+    let (_, config_root) = resolve_shared_mount_and_config_root(path.to_path_buf());
+    let catalog: CatalogConfig = read_toml_or_default(&config_root.join("catalog.toml"))?;
+    let mut names = catalog
+        .torrents
+        .into_iter()
+        .map(|torrent| {
+            let name = torrent.name.trim();
+            if name.is_empty() {
+                "Unnamed torrent".to_string()
+            } else {
+                name.to_string()
+            }
+        })
+        .collect::<Vec<_>>();
+    names.sort_by_key(|name| name.to_lowercase());
+    Ok(names)
 }
 
 pub fn save_settings(settings: &Settings) -> io::Result<()> {
@@ -6146,5 +6216,31 @@ mod tests {
             env::remove_var(LEGACY_SHARED_HOST_ID_ENV);
         }
         clear_shared_config_state();
+    }
+
+    #[test]
+    fn shared_library_torrent_names_are_read_without_starting_a_client() {
+        let root = tempdir().expect("create library root");
+        let config_root = root.path().join(SHARED_CONFIG_SUBDIR);
+        fs::create_dir_all(&config_root).expect("create shared config root");
+        let catalog = CatalogConfig {
+            torrents: vec![
+                CatalogTorrentSettings {
+                    name: "Zeta Archive".to_string(),
+                    ..Default::default()
+                },
+                CatalogTorrentSettings {
+                    name: "Amber Seed".to_string(),
+                    ..Default::default()
+                },
+                CatalogTorrentSettings::default(),
+            ],
+        };
+        write_toml_atomically(&config_root.join("catalog.toml"), &catalog).expect("write catalog");
+
+        let names = load_shared_library_torrent_names(root.path()).expect("read names");
+
+        assert_eq!(names, ["Amber Seed", "Unnamed torrent", "Zeta Archive"]);
+        assert!(!config_root.join("hosts").exists());
     }
 }

--- a/src/integrations/cli.rs
+++ b/src/integrations/cli.rs
@@ -26,6 +26,14 @@ pub struct Cli {
     #[arg(long, global = true, help = "Return structured JSON output")]
     pub json: bool,
 
+    #[arg(
+        long,
+        global = true,
+        value_name = "NAME",
+        help = "Use a named library for this process without changing the active library"
+    )]
+    pub library: Option<String>,
+
     #[arg(help = "Add a torrent file path or magnet link without using a subcommand")]
     pub input: Option<String>,
 
@@ -78,6 +86,11 @@ pub enum Commands {
     ClearSharedConfig,
     #[command(about = "Show the effective shared root selection and its source")]
     ShowSharedConfig,
+    #[command(about = "Manage named shared-config libraries")]
+    Library {
+        #[command(subcommand)]
+        command: LibraryCommands,
+    },
     #[command(about = "Show resolved config, log, status, journal, and watch paths")]
     ShowConfigs {
         #[arg(long, help = "Include launcher, local, and shared layer details")]
@@ -207,6 +220,48 @@ pub enum Commands {
         about = "Run a local synthetic BitTorrent load harness"
     )]
     SyntheticLoad(SyntheticLoadArgs),
+}
+
+#[derive(Subcommand, Debug)]
+pub enum LibraryCommands {
+    #[command(about = "List registered libraries")]
+    List,
+    #[command(about = "Register a named shared-config library")]
+    Add {
+        #[arg(value_name = "NAME")]
+        name: String,
+        #[arg(value_name = "PATH")]
+        path: PathBuf,
+        #[arg(long, value_name = "TEXT")]
+        description: Option<String>,
+    },
+    #[command(about = "Rename a registered library")]
+    Rename {
+        #[arg(value_name = "NAME")]
+        name: String,
+        #[arg(value_name = "NEW_NAME")]
+        new_name: String,
+    },
+    #[command(about = "Remove a library from the registry without deleting its files")]
+    Remove {
+        #[arg(value_name = "NAME")]
+        name: String,
+    },
+    #[command(about = "Select the library used by future application starts")]
+    Use {
+        #[arg(value_name = "NAME")]
+        name: String,
+    },
+    #[command(about = "Show the active library or one named library")]
+    Show {
+        #[arg(value_name = "NAME")]
+        name: Option<String>,
+    },
+    #[command(about = "Print the active library path or one named library path")]
+    Open {
+        #[arg(value_name = "NAME")]
+        name: Option<String>,
+    },
 }
 
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
@@ -667,6 +722,7 @@ where
         | Commands::SetSharedConfig { .. }
         | Commands::ClearSharedConfig
         | Commands::ShowSharedConfig
+        | Commands::Library { .. }
         | Commands::ShowConfigs { .. }
         | Commands::SetHostId { .. }
         | Commands::ClearHostId
@@ -861,6 +917,30 @@ mod tests {
     use clap::CommandFactory;
     use std::fs::{self, File};
     use std::io::Write;
+
+    #[test]
+    fn parses_library_commands_and_process_override() {
+        let parsed = Cli::try_parse_from([
+            "superseedr",
+            "--library",
+            "library-a",
+            "library",
+            "add",
+            "library-b",
+            "/srv/library-b",
+            "--description",
+            "Detached archive",
+        ])
+        .expect("parse library command");
+
+        assert_eq!(parsed.library.as_deref(), Some("library-a"));
+        assert!(matches!(
+            parsed.command,
+            Some(Commands::Library {
+                command: LibraryCommands::Add { name, path, .. }
+            }) if name == "library-b" && path == Path::new("/srv/library-b")
+        ));
+    }
 
     // Helper to setup a temp directory if tempfile crate is missing
     fn setup_temp_dir() -> (PathBuf, impl Drop) {

--- a/src/library.rs
+++ b/src/library.rs
@@ -1,0 +1,406 @@
+// SPDX-FileCopyrightText: 2026 The superseedr Contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::config::app_config_dir;
+use crate::fs_atomic::{deserialize_versioned_toml, write_toml_atomically};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const LIBRARY_REGISTRY_FILE: &str = "libraries.toml";
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct LibraryRegistry {
+    pub active: Option<String>,
+    pub libraries: BTreeMap<String, LibraryDefinition>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct LibraryDefinition {
+    pub shared_config_path: PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_used_unix_secs: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct LibraryStatus {
+    pub name: String,
+    pub shared_config_path: PathBuf,
+    pub description: Option<String>,
+    pub last_used_unix_secs: Option<u64>,
+    pub active: bool,
+    pub available: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LibraryPreview {
+    pub name: String,
+    pub torrent_names: Vec<String>,
+    pub error: Option<String>,
+}
+
+pub fn load_previews(libraries: Vec<LibraryStatus>) -> Vec<LibraryPreview> {
+    libraries
+        .into_iter()
+        .map(|library| {
+            match crate::config::load_shared_library_torrent_names(&library.shared_config_path) {
+                Ok(torrent_names) => LibraryPreview {
+                    name: library.name,
+                    torrent_names,
+                    error: None,
+                },
+                Err(error) => LibraryPreview {
+                    name: library.name,
+                    torrent_names: Vec::new(),
+                    error: Some(error.to_string()),
+                },
+            }
+        })
+        .collect()
+}
+
+pub fn registry_path() -> io::Result<PathBuf> {
+    app_config_dir()
+        .map(|path| path.join(LIBRARY_REGISTRY_FILE))
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "Could not resolve application config directory",
+            )
+        })
+}
+
+pub fn load_registry() -> io::Result<LibraryRegistry> {
+    let path = registry_path()?;
+    if !path.exists() {
+        return Ok(LibraryRegistry::default());
+    }
+    let content = fs::read_to_string(path)?;
+    deserialize_versioned_toml(&content)
+}
+
+pub fn save_registry(registry: &LibraryRegistry) -> io::Result<()> {
+    validate_registry(registry)?;
+    write_toml_atomically(&registry_path()?, registry)
+}
+
+pub fn list_libraries() -> io::Result<Vec<LibraryStatus>> {
+    let registry = load_registry()?;
+    Ok(registry
+        .libraries
+        .iter()
+        .map(|(name, library)| LibraryStatus {
+            name: name.clone(),
+            shared_config_path: library.shared_config_path.clone(),
+            description: library.description.clone(),
+            last_used_unix_secs: library.last_used_unix_secs,
+            active: registry.active.as_deref() == Some(name.as_str()),
+            available: library.shared_config_path.is_dir(),
+        })
+        .collect())
+}
+
+pub fn active_library() -> io::Result<Option<(String, LibraryDefinition)>> {
+    let registry = load_registry()?;
+    let Some(name) = registry.active else {
+        return Ok(None);
+    };
+    let library = registry.libraries.get(&name).cloned().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Active library '{name}' is missing from the library registry"),
+        )
+    })?;
+    Ok(Some((name, library)))
+}
+
+pub fn get_library(name: &str) -> io::Result<LibraryDefinition> {
+    let registry = load_registry()?;
+    registry.libraries.get(name).cloned().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("Library '{name}' does not exist"),
+        )
+    })
+}
+
+pub fn add_library(
+    name: &str,
+    shared_config_path: &Path,
+    description: Option<&str>,
+) -> io::Result<LibraryStatus> {
+    let name = validate_name(name)?;
+    if !shared_config_path.is_absolute() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Library shared-config path must be absolute",
+        ));
+    }
+    let mut registry = load_registry()?;
+    if registry.libraries.contains_key(&name) {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("Library '{name}' already exists"),
+        ));
+    }
+    let description = description
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    registry.libraries.insert(
+        name.clone(),
+        LibraryDefinition {
+            shared_config_path: shared_config_path.to_path_buf(),
+            description: description.clone(),
+            last_used_unix_secs: None,
+        },
+    );
+    save_registry(&registry)?;
+    Ok(LibraryStatus {
+        name,
+        shared_config_path: shared_config_path.to_path_buf(),
+        description,
+        last_used_unix_secs: None,
+        active: false,
+        available: shared_config_path.is_dir(),
+    })
+}
+
+pub fn rename_library(current_name: &str, new_name: &str) -> io::Result<()> {
+    let new_name = validate_name(new_name)?;
+    let mut registry = load_registry()?;
+    if registry.libraries.contains_key(&new_name) {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("Library '{new_name}' already exists"),
+        ));
+    }
+    let library = registry.libraries.remove(current_name).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("Library '{current_name}' does not exist"),
+        )
+    })?;
+    if registry.active.as_deref() == Some(current_name) {
+        registry.active = Some(new_name.clone());
+    }
+    registry.libraries.insert(new_name, library);
+    save_registry(&registry)
+}
+
+pub fn remove_library(name: &str) -> io::Result<LibraryDefinition> {
+    let mut registry = load_registry()?;
+    if registry.active.as_deref() == Some(name) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "The active library cannot be removed; switch libraries first",
+        ));
+    }
+    let removed = registry.libraries.remove(name).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("Library '{name}' does not exist"),
+        )
+    })?;
+    save_registry(&registry)?;
+    Ok(removed)
+}
+
+pub fn validate_switch_target(name: &str) -> io::Result<LibraryDefinition> {
+    let library = get_library(name)?;
+    if !library.shared_config_path.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!(
+                "Library '{name}' is unavailable at {}",
+                library.shared_config_path.display()
+            ),
+        ));
+    }
+    Ok(library)
+}
+
+pub fn activate_library(name: &str) -> io::Result<LibraryDefinition> {
+    validate_switch_target(name)?;
+    let mut registry = load_registry()?;
+    let library = registry.libraries.get_mut(name).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("Library '{name}' does not exist"),
+        )
+    })?;
+    library.last_used_unix_secs = Some(now_unix_secs());
+    let activated = library.clone();
+    registry.active = Some(name.to_string());
+    save_registry(&registry)?;
+    Ok(activated)
+}
+
+pub fn restore_active_library(name: Option<&str>) -> io::Result<()> {
+    let mut registry = load_registry()?;
+    if let Some(name) = name {
+        if !registry.libraries.contains_key(name) {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("Library '{name}' does not exist"),
+            ));
+        }
+        registry.active = Some(name.to_string());
+    } else {
+        registry.active = None;
+    }
+    save_registry(&registry)
+}
+
+pub fn reveal_directory(path: &Path) -> io::Result<()> {
+    if !path.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("Library is unavailable at {}", path.display()),
+        ));
+    }
+    #[cfg(target_os = "windows")]
+    let status = std::process::Command::new("explorer").arg(path).status()?;
+    #[cfg(target_os = "macos")]
+    let status = std::process::Command::new("open").arg(path).status()?;
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let status = std::process::Command::new("xdg-open").arg(path).status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "System file browser exited with status {status}"
+        )))
+    }
+}
+
+fn validate_registry(registry: &LibraryRegistry) -> io::Result<()> {
+    if let Some(active) = &registry.active {
+        if !registry.libraries.contains_key(active) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Active library '{active}' is missing from the registry"),
+            ));
+        }
+    }
+    for (name, library) in &registry.libraries {
+        validate_name(name)?;
+        if !library.shared_config_path.is_absolute() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Library '{name}' has a non-absolute shared-config path"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_name(name: &str) -> io::Result<String> {
+    let name = name.trim();
+    if name.is_empty() || name.len() > 64 || name.chars().any(char::is_control) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Library name must contain 1-64 printable characters",
+        ));
+    }
+    Ok(name.to_string())
+}
+
+fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{set_app_paths_override_for_tests, shared_env_guard_for_tests};
+    use tempfile::tempdir;
+
+    #[test]
+    fn registry_switches_between_two_specific_shared_configs() {
+        let _guard = shared_env_guard_for_tests().lock().expect("lock test env");
+        let root = tempdir().expect("create registry root");
+        let config_dir = root.path().join("launcher");
+        let data_dir = root.path().join("runtime");
+        let library_a = root.path().join("library-a");
+        let library_b = root.path().join("library-b");
+        fs::create_dir_all(&library_a).expect("create library A");
+        fs::create_dir_all(&library_b).expect("create library B");
+        set_app_paths_override_for_tests(Some((config_dir, data_dir)));
+
+        add_library("library-a", &library_a, Some("Primary test library")).expect("add library A");
+        add_library("library-b", &library_b, None).expect("add library B");
+        activate_library("library-a").expect("activate library A");
+        let mut settings_a = crate::config::load_settings().expect("load library A settings");
+        settings_a.client_port = 41_001;
+        crate::config::save_settings(&settings_a).expect("save library A settings");
+        assert_eq!(
+            active_library().expect("load active").unwrap().0,
+            "library-a"
+        );
+        activate_library("library-b").expect("activate library B");
+        let mut settings_b = crate::config::load_settings().expect("load library B settings");
+        settings_b.client_port = 41_002;
+        crate::config::save_settings(&settings_b).expect("save library B settings");
+        assert_eq!(
+            active_library().expect("load active").unwrap().0,
+            "library-b"
+        );
+        activate_library("library-a").expect("switch back to library A");
+        assert_eq!(
+            crate::config::load_settings()
+                .expect("reload library A settings")
+                .client_port,
+            41_001
+        );
+        activate_library("library-b").expect("switch back to library B");
+        assert_eq!(
+            crate::config::load_settings()
+                .expect("reload library B settings")
+                .client_port,
+            41_002
+        );
+
+        let statuses = list_libraries().expect("list libraries");
+        assert_eq!(statuses.len(), 2);
+        assert!(statuses.iter().all(|library| library.available));
+        assert!(statuses
+            .iter()
+            .find(|library| library.name == "library-b")
+            .is_some_and(|library| library.active && library.last_used_unix_secs.is_some()));
+
+        set_app_paths_override_for_tests(None);
+    }
+
+    #[test]
+    fn missing_library_remains_registered_but_cannot_be_activated() {
+        let _guard = shared_env_guard_for_tests().lock().expect("lock test env");
+        let root = tempdir().expect("create registry root");
+        set_app_paths_override_for_tests(Some((
+            root.path().join("launcher"),
+            root.path().join("runtime"),
+        )));
+        let missing = root.path().join("detached-library");
+        add_library("detached", &missing, None).expect("register missing library");
+
+        let status = list_libraries().expect("list libraries").remove(0);
+        assert!(!status.available);
+        assert_eq!(
+            activate_library("detached")
+                .expect_err("activation must fail")
+                .kind(),
+            io::ErrorKind::NotFound
+        );
+
+        set_app_paths_override_for_tests(None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod errors;
 mod fs_atomic;
 mod integrations;
 mod integrity_scheduler;
+mod library;
 mod logging;
 mod networking;
 mod peer_manager;
@@ -34,7 +35,7 @@ mod tui;
 mod tuning;
 mod watch_inbox;
 
-use app::{App, AppRuntimeMode};
+use app::{App, AppExit, AppRuntimeMode};
 use rand::{Rng, RngExt};
 
 use std::fs;
@@ -65,7 +66,8 @@ use crate::integrations::cli::{
     command_to_control_requests_with_resolver, expand_add_inputs, require_cli_targets,
     status_command_mode, status_control_request, status_file_modified_at,
     wait_for_status_json_after, write_control_command, write_input_command,
-    write_path_command_payload, write_stop_command, Cli, Commands, StatusCommandMode,
+    write_path_command_payload, write_stop_command, Cli, Commands, LibraryCommands,
+    StatusCommandMode,
 };
 #[cfg(test)]
 use crate::integrations::control::ControlPriorityTarget;
@@ -743,6 +745,7 @@ fn private_client_leak_guard_message(config_path: &str) -> String {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
+    config::set_process_library_override(cli.library.as_deref())?;
     let output_mode = if cli.json {
         OutputMode::Json
     } else {
@@ -1025,12 +1028,48 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_result = app.run(&mut terminal).await;
     cleanup_terminal()?;
 
-    if let Err(error) = app_result {
-        tracing::error!("Application failed: {}", error);
-        return Err(error);
+    let app_exit = match app_result {
+        Ok(app_exit) => app_exit,
+        Err(error) => {
+            tracing::error!("Application failed: {}", error);
+            return Err(error);
+        }
+    };
+    drop(app);
+
+    if let AppExit::SwitchLibrary(name) = app_exit {
+        restart_with_library(&name)?;
     }
 
     Ok(())
+}
+
+fn restart_with_library(name: &str) -> io::Result<()> {
+    let previous_active = crate::library::active_library()?.map(|(name, _)| name);
+    let library = crate::library::activate_library(name)?;
+    tracing::info!(
+        library = name,
+        path = %library.shared_config_path.display(),
+        "Restarting with selected library"
+    );
+
+    let executable = env::current_exe()?;
+    match std::process::Command::new(executable).spawn() {
+        Ok(_) => Ok(()),
+        Err(error) => {
+            if let Err(rollback_error) =
+                crate::library::restore_active_library(previous_active.as_deref())
+            {
+                return Err(io::Error::other(format!(
+                    "Failed to restart for library '{name}': {error}; also failed to restore the previous library: {rollback_error}"
+                )));
+            }
+            Err(io::Error::new(
+                error.kind(),
+                format!("Failed to restart for library '{name}': {error}"),
+            ))
+        }
+    }
 }
 
 fn get_lock_path() -> Option<PathBuf> {
@@ -1059,6 +1098,17 @@ fn try_acquire_app_lock() -> io::Result<Option<File>> {
     }
 }
 
+fn app_lock_is_held() -> io::Result<bool> {
+    let Some(lock_path) = get_lock_path() else {
+        return Ok(false);
+    };
+    if !lock_path.exists() {
+        return Ok(false);
+    }
+    let file = File::options().read(true).write(true).open(lock_path)?;
+    Ok(file.try_lock().is_err())
+}
+
 fn process_launcher_setup_command(cli: &Cli, output_mode: OutputMode) -> Option<io::Result<()>> {
     let command = cli.command.as_ref()?;
     match command {
@@ -1067,6 +1117,7 @@ fn process_launcher_setup_command(cli: &Cli, output_mode: OutputMode) -> Option<
         }
         Commands::ClearSharedConfig => Some(process_clear_shared_config_command(output_mode)),
         Commands::ShowSharedConfig => Some(process_show_shared_config_command(output_mode)),
+        Commands::Library { command } => Some(process_library_command(command, output_mode)),
         Commands::SetHostId { host_id } => Some(process_set_host_id_command(host_id, output_mode)),
         Commands::ClearHostId => Some(process_clear_host_id_command(output_mode)),
         Commands::ShowHostId => Some(process_show_host_id_command(output_mode)),
@@ -1103,6 +1154,7 @@ fn process_set_shared_config_command(
     output_mode: OutputMode,
 ) -> io::Result<()> {
     let selection = set_persisted_shared_config(path)?;
+    crate::library::restore_active_library(None)?;
     let sidecar_path = persisted_shared_config_path()?;
     print_success(
         output_mode,
@@ -1122,6 +1174,7 @@ fn process_set_shared_config_command(
 
 fn process_clear_shared_config_command(output_mode: OutputMode) -> io::Result<()> {
     let cleared = clear_persisted_shared_config()?;
+    crate::library::restore_active_library(None)?;
     let sidecar_path = persisted_shared_config_path()?;
     let message = if cleared {
         "Cleared persisted shared config."
@@ -1139,6 +1192,163 @@ fn process_clear_shared_config_command(output_mode: OutputMode) -> io::Result<()
         }),
     );
     Ok(())
+}
+
+fn process_library_command(command: &LibraryCommands, output_mode: OutputMode) -> io::Result<()> {
+    match command {
+        LibraryCommands::List => {
+            let libraries = crate::library::list_libraries()?;
+            if output_mode == OutputMode::Json {
+                print_success(
+                    output_mode,
+                    "library list",
+                    "Listed registered libraries.",
+                    json!({ "libraries": libraries }),
+                );
+            } else if libraries.is_empty() {
+                println!("No libraries are registered.");
+            } else {
+                for library in libraries {
+                    let active = if library.active { "*" } else { " " };
+                    let available = if library.available {
+                        "available"
+                    } else {
+                        "unavailable"
+                    };
+                    println!(
+                        "{} {}\t{}\t{}",
+                        active,
+                        library.name,
+                        available,
+                        library.shared_config_path.display()
+                    );
+                    if let Some(description) = library.description {
+                        println!("    {description}");
+                    }
+                }
+            }
+            Ok(())
+        }
+        LibraryCommands::Add {
+            name,
+            path,
+            description,
+        } => {
+            let status = crate::library::add_library(name, path, description.as_deref())?;
+            print_success(
+                output_mode,
+                "library add",
+                &format!("Registered library '{}'.", status.name),
+                json!({ "library": status }),
+            );
+            Ok(())
+        }
+        LibraryCommands::Rename { name, new_name } => {
+            crate::library::rename_library(name, new_name)?;
+            print_success(
+                output_mode,
+                "library rename",
+                &format!("Renamed library '{name}' to '{new_name}'."),
+                json!({ "old_name": name, "name": new_name }),
+            );
+            Ok(())
+        }
+        LibraryCommands::Remove { name } => {
+            let removed = crate::library::remove_library(name)?;
+            print_success(
+                output_mode,
+                "library remove",
+                &format!("Removed library '{name}' from the registry; no files were deleted."),
+                json!({
+                    "name": name,
+                    "shared_config_path": removed.shared_config_path,
+                    "files_deleted": false,
+                }),
+            );
+            Ok(())
+        }
+        LibraryCommands::Use { name } => {
+            let target = crate::library::validate_switch_target(name)?;
+            config::preflight_shared_library(&target.shared_config_path)?;
+            if effective_shared_config_selection()?
+                .is_some_and(|selection| selection.source == SharedConfigSource::Env)
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "Cannot switch libraries while SUPERSEEDR_SHARED_CONFIG_DIR overrides the active library",
+                ));
+            }
+            if app_lock_is_held()? {
+                return Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "Superseedr is running; switch from the Libraries screen so the current engine can shut down safely",
+                ));
+            }
+            let library = crate::library::activate_library(name)?;
+            print_success(
+                output_mode,
+                "library use",
+                &format!("Selected library '{name}'."),
+                json!({
+                    "name": name,
+                    "shared_config_path": library.shared_config_path,
+                }),
+            );
+            Ok(())
+        }
+        LibraryCommands::Show { name } => {
+            let (name, library) = match name {
+                Some(name) => (name.clone(), crate::library::get_library(name)?),
+                None => crate::library::active_library()?.ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, "No active library is selected")
+                })?,
+            };
+            let available = library.shared_config_path.is_dir();
+            print_success(
+                output_mode,
+                "library show",
+                &format!(
+                    "Library '{name}' is {} at {}.",
+                    if available {
+                        "available"
+                    } else {
+                        "unavailable"
+                    },
+                    library.shared_config_path.display()
+                ),
+                json!({
+                    "name": name,
+                    "shared_config_path": library.shared_config_path,
+                    "description": library.description,
+                    "last_used_unix_secs": library.last_used_unix_secs,
+                    "available": available,
+                }),
+            );
+            Ok(())
+        }
+        LibraryCommands::Open { name } => {
+            let (name, library) = match name {
+                Some(name) => (name.clone(), crate::library::get_library(name)?),
+                None => crate::library::active_library()?.ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, "No active library is selected")
+                })?,
+            };
+            if !library.shared_config_path.is_dir() {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("Library '{name}' is unavailable"),
+                ));
+            }
+            crate::library::reveal_directory(&library.shared_config_path)?;
+            print_success(
+                output_mode,
+                "library open",
+                &format!("Opened library '{name}'."),
+                json!({ "name": name, "shared_config_path": library.shared_config_path }),
+            );
+            Ok(())
+        }
+    }
 }
 
 fn process_show_shared_config_command(output_mode: OutputMode) -> io::Result<()> {
@@ -1176,6 +1386,7 @@ fn process_show_shared_config_command(output_mode: OutputMode) -> io::Result<()>
                 "Source: {}",
                 match selection.source {
                     SharedConfigSource::Env => "env",
+                    SharedConfigSource::Library => "library",
                     SharedConfigSource::Launcher => "launcher",
                 }
             );
@@ -2064,6 +2275,7 @@ fn print_show_configs_settings(snapshot: &ShowConfigsSnapshot) {
 fn shared_config_source_label(source: SharedConfigSource) -> &'static str {
     match source {
         SharedConfigSource::Env => "env",
+        SharedConfigSource::Library => "library",
         SharedConfigSource::Launcher => "launcher",
     }
 }
@@ -3394,6 +3606,7 @@ fn cli_command_name(command: Option<&Commands>) -> Option<&'static str> {
         Some(Commands::SetSharedConfig { .. }) => Some("set-shared-config"),
         Some(Commands::ClearSharedConfig) => Some("clear-shared-config"),
         Some(Commands::ShowSharedConfig) => Some("show-shared-config"),
+        Some(Commands::Library { .. }) => Some("library"),
         Some(Commands::ShowConfigs { .. }) => Some("show-configs"),
         Some(Commands::SetHostId { .. }) => Some("set-host-id"),
         Some(Commands::ClearHostId) => Some("clear-host-id"),
@@ -3865,6 +4078,7 @@ mod tests {
         let destination = tempdir().expect("create destination");
         let cli = Cli {
             json: false,
+            library: None,
             input: None,
             command: Some(Commands::Move {
                 info_hash_hex: "1111111111111111111111111111111111111111".to_string(),
@@ -4255,6 +4469,7 @@ mod tests {
         let loaded = crate::config::load_settings().expect("reload shared settings");
         let cli = Cli {
             json: false,
+            library: None,
             input: None,
             command: Some(Commands::Pause {
                 targets: vec!["1111111111111111111111111111111111111111".to_string()],
@@ -4341,6 +4556,7 @@ mod tests {
         .to_string();
         let cli = Cli {
             json: false,
+            library: None,
             input: None,
             command: Some(Commands::Add {
                 validated: true,

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: 2025 The superseedr Contributors
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use crate::app::{App, AppMode};
+use crate::app::{App, AppMode, ConfigPane};
 use crate::tui::paste_burst::FlushResult as PasteBurstFlushResult;
 use crate::tui::screens::{
-    browser, config, delete_confirm, help, journal, normal, peers, power, rss, torrents, welcome,
+    browser, config, delete_confirm, help, journal, libraries, normal, peers, power, rss, torrents,
+    welcome,
 };
 
 use ratatui::crossterm::event::{
@@ -211,6 +212,10 @@ async fn dispatch_mode_event(event: CrosstermEvent, app: &mut App) {
         AppMode::Normal => normal::handle_event(event, app).await,
         AppMode::PowerSaving => power::handle_event(event, &mut app.app_state),
         AppMode::Config => {
+            if app.app_state.ui.config.active_pane == ConfigPane::Libraries {
+                libraries::handle_event(event, app);
+                return;
+            }
             if app.app_state.ui.config.editing.is_none() {
                 *app.app_state.ui.config.settings_edit = app.client_configs.clone();
             }
@@ -242,6 +247,11 @@ async fn dispatch_mode_event(event: CrosstermEvent, app: &mut App) {
             if let Some(settings) = settings_update {
                 app.apply_config_update_from_ui(settings).await;
                 *app.app_state.ui.config.settings_edit = app.client_configs.clone();
+            }
+            if app.app_state.ui.config.active_pane == ConfigPane::Libraries {
+                app.app_state.ui.libraries.status_message = None;
+                app.app_state.ui.libraries.input = None;
+                libraries::refresh(app);
             }
         }
         AppMode::DeleteConfirm => {

--- a/src/tui/screens/browser.rs
+++ b/src/tui/screens/browser.rs
@@ -149,7 +149,9 @@ pub fn draw(
         footer_spans.push(Span::raw(" Discard Changes"));
     } else {
         match browser_mode {
-            FileBrowserMode::ConfigPathSelection { .. } | FileBrowserMode::Directory => {
+            FileBrowserMode::ConfigPathSelection { .. }
+            | FileBrowserMode::LibraryPathSelection { .. }
+            | FileBrowserMode::Directory => {
                 footer_spans.push(Span::styled(
                     "[Arrows/Vim]",
                     footer_key_style(ctx, ActionTone::Navigate),
@@ -284,6 +286,7 @@ pub fn draw(
         FileBrowserMode::Directory => " Select Directory ".to_string(),
         FileBrowserMode::DownloadLocSelection { .. } => String::new(),
         FileBrowserMode::ConfigPathSelection { .. } => " Select Config Path ".to_string(),
+        FileBrowserMode::LibraryPathSelection { .. } => " Select Library Root ".to_string(),
         FileBrowserMode::File(exts) => format!(" Select File [{}] ", exts.join(", ")),
     };
 
@@ -1220,6 +1223,7 @@ async fn handle_browser_common_key(key_code: KeyCode, app: &mut App) -> bool {
 
 pub enum ConfirmDecision {
     ToConfig(ConfigUiState),
+    LibraryPath { name: String, path: PathBuf },
     Download(DownloadConfirmPayload),
     File(PathBuf),
     None,
@@ -1270,6 +1274,7 @@ pub enum BrowserDialogAction {
 pub enum BrowserDialogEffect {
     ExecuteConfirmDecision(ConfirmDecision),
     ToConfig(ConfigUiState),
+    ToLibraries,
     CleanupPendingLink,
     ToNormalAndClearPending,
     ClearSearch,
@@ -1279,6 +1284,7 @@ pub enum BrowserDialogEffect {
 pub enum BrowserTransition {
     ToNormal,
     ToConfig,
+    ToLibraries,
     Close,
 }
 
@@ -1948,7 +1954,8 @@ pub fn build_filesystem_filter(
             }
             FileBrowserMode::Directory
             | FileBrowserMode::DownloadLocSelection { .. }
-            | FileBrowserMode::ConfigPathSelection { .. } => TreeFilter::default(),
+            | FileBrowserMode::ConfigPathSelection { .. }
+            | FileBrowserMode::LibraryPathSelection { .. } => TreeFilter::default(),
         };
     }
 
@@ -1956,7 +1963,8 @@ pub fn build_filesystem_filter(
         FileBrowserMode::File(extensions) => Some(extensions.clone()),
         FileBrowserMode::Directory
         | FileBrowserMode::DownloadLocSelection { .. }
-        | FileBrowserMode::ConfigPathSelection { .. } => None,
+        | FileBrowserMode::ConfigPathSelection { .. }
+        | FileBrowserMode::LibraryPathSelection { .. } => None,
     };
 
     match search_mode {
@@ -2116,6 +2124,11 @@ pub fn reduce_browser_dialog_action(
                     .push(BrowserDialogEffect::ToConfig(config_ui));
                 return result;
             }
+            if matches!(browser_mode, FileBrowserMode::LibraryPathSelection { .. }) {
+                result.effects.push(BrowserDialogEffect::ClearSearch);
+                result.effects.push(BrowserDialogEffect::ToLibraries);
+                return result;
+            }
 
             if matches!(browser_mode, FileBrowserMode::DownloadLocSelection { .. })
                 && has_pending_torrent_link
@@ -2153,6 +2166,10 @@ pub async fn execute_browser_dialog_effects(app: &mut App, effects: Vec<BrowserD
             BrowserDialogEffect::ToConfig(config_ui) => {
                 app.app_state.ui.config = config_ui;
                 apply_browser_transition(app, BrowserTransition::ToConfig);
+            }
+            BrowserDialogEffect::ToLibraries => {
+                crate::tui::screens::libraries::refresh(app);
+                apply_browser_transition(app, BrowserTransition::ToLibraries);
             }
             BrowserDialogEffect::CleanupPendingLink => {
                 app.cleanup_pending_magnet_preview_runtime();
@@ -2198,6 +2215,18 @@ fn apply_browser_transition(app: &mut App, transition: BrowserTransition) {
                 .ui
                 .file_browser
                 .return_to_torrent_management_on_close = false;
+            app.app_state.mode = AppMode::Config;
+        }
+        BrowserTransition::ToLibraries => {
+            app.app_state
+                .ui
+                .file_browser
+                .invalidate_browser_generation();
+            app.app_state
+                .ui
+                .file_browser
+                .return_to_torrent_management_on_close = false;
+            app.app_state.ui.config.active_pane = crate::app::ConfigPane::Libraries;
             app.app_state.mode = AppMode::Config;
         }
         BrowserTransition::Close => apply_browser_close_transition(app),
@@ -2301,6 +2330,12 @@ pub fn resolve_confirm_decision(
     if let Some(config_ui) = confirm_config_path_selection(state, browser_mode) {
         return ConfirmDecision::ToConfig(config_ui);
     }
+    if let FileBrowserMode::LibraryPathSelection { name } = browser_mode {
+        return ConfirmDecision::LibraryPath {
+            name: name.clone(),
+            path: state.current_path.clone(),
+        };
+    }
     if let Some(payload) = build_download_confirm_payload(state, browser_mode) {
         return ConfirmDecision::Download(payload);
     }
@@ -2354,6 +2389,15 @@ pub async fn execute_confirm_decision(
             }
             app.app_state.ui.config = config_ui;
             Some(BrowserTransition::ToConfig)
+        }
+        ConfirmDecision::LibraryPath { name, path } => {
+            app.app_state.ui.libraries.status_message =
+                match crate::library::add_library(&name, &path, None) {
+                    Ok(_) => Some(format!("Registered '{name}'.")),
+                    Err(error) => Some(error.to_string()),
+                };
+            crate::tui::screens::libraries::refresh(app);
+            Some(BrowserTransition::ToLibraries)
         }
         ConfirmDecision::Download(payload) => match payload.target {
             DownloadSelectionTarget::PendingAdd => {
@@ -4155,6 +4199,41 @@ mod tests {
             decision,
             ConfirmDecision::ToConfig(ConfigUiState { .. })
         ));
+    }
+
+    #[test]
+    fn library_path_selection_confirms_current_directory() {
+        let mode = FileBrowserMode::LibraryPathSelection {
+            name: "archive".to_string(),
+        };
+        let state = TreeViewState {
+            current_path: PathBuf::from("/tmp/archive"),
+            ..Default::default()
+        };
+
+        assert!(matches!(
+            resolve_confirm_decision(&state, &mode),
+            ConfirmDecision::LibraryPath { name, path }
+                if name == "archive" && path == Path::new("/tmp/archive")
+        ));
+    }
+
+    #[test]
+    fn library_path_selection_escape_returns_to_libraries() {
+        let mode = FileBrowserMode::LibraryPathSelection {
+            name: "archive".to_string(),
+        };
+        let result = reduce_browser_dialog_action(
+            BrowserDialogAction::Escape,
+            &TreeViewState::default(),
+            &mode,
+            false,
+        );
+
+        assert!(result
+            .effects
+            .iter()
+            .any(|effect| matches!(effect, BrowserDialogEffect::ToLibraries)));
     }
 
     #[test]

--- a/src/tui/screens/config.rs
+++ b/src/tui/screens/config.rs
@@ -10,6 +10,7 @@ use crate::tui::formatters::{
 };
 use crate::tui::layout::config::{calculate_config_layout, ConfigLayoutKind};
 use crate::tui::screen_context::ScreenContext;
+use crate::tui::screens::libraries;
 use directories::UserDirs;
 use ratatui::crossterm::event::{Event as CrosstermEvent, KeyCode, KeyEventKind};
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
@@ -44,6 +45,7 @@ pub enum ConfigAction {
 pub enum ConfigEffect {
     AppCommand(Box<AppCommand>),
     ApplySettings,
+    OpenLibraries,
 }
 
 pub struct ConfigHandleContext<'a> {
@@ -95,6 +97,7 @@ impl ConfigCategory {
 enum ConfigControlKind {
     Bool,
     Enum,
+    Navigation,
     Number,
     RateLimit,
     Path,
@@ -122,6 +125,13 @@ fn config_setting_descriptors() -> &'static [ConfigSettingDescriptor] {
             category: ConfigCategory::Network,
             label: "Listen Port",
             control: ConfigControlKind::Number,
+            scope: ConfigScope::Host,
+        },
+        ConfigSettingDescriptor {
+            item: ConfigItem::Libraries,
+            category: ConfigCategory::Paths,
+            label: "Libraries",
+            control: ConfigControlKind::Navigation,
             scope: ConfigScope::Host,
         },
         ConfigSettingDescriptor {
@@ -189,6 +199,11 @@ fn selected_item(items: &[ConfigItem], selected_index: usize) -> ConfigItem {
 
 fn value_for_item(item: ConfigItem, settings: &Settings) -> String {
     match item {
+        ConfigItem::Libraries => crate::library::active_library()
+            .ok()
+            .flatten()
+            .map(|(name, _)| name)
+            .unwrap_or_else(|| "No named library".to_string()),
         ConfigItem::ClientPort if settings.randomize_client_port => {
             format!("Random ({})", settings.client_port)
         }
@@ -212,6 +227,7 @@ fn value_for_item(item: ConfigItem, settings: &Settings) -> String {
 
 fn config_item_is_dirty(item: ConfigItem, draft: &Settings, applied: &Settings) -> bool {
     match item {
+        ConfigItem::Libraries => false,
         ConfigItem::ClientPort => {
             draft.client_port != applied.client_port
                 || draft.randomize_client_port != applied.randomize_client_port
@@ -260,6 +276,7 @@ pub(crate) fn merge_config_item_into_current(
         return update;
     }
     match item {
+        ConfigItem::Libraries => {}
         ConfigItem::ClientPort => {
             update.client_port = draft.client_port;
             update.randomize_client_port = draft.randomize_client_port;
@@ -443,6 +460,9 @@ pub fn reduce_config_action(
         ConfigAction::ShiftSelected => {
             result.consumed = true;
             match items[*selected_index] {
+                ConfigItem::Libraries => {
+                    result.effects.push(ConfigEffect::OpenLibraries);
+                }
                 ConfigItem::DefaultDownloadFolder | ConfigItem::WatchFolder => {
                     let selected_item = items[*selected_index];
                     if let Some(effect) =
@@ -516,6 +536,9 @@ pub fn reduce_config_action(
             let changed = config_item_is_dirty(selected_item, settings_edit, &default_settings);
             let mut can_apply = true;
             match selected_item {
+                ConfigItem::Libraries => {
+                    can_apply = false;
+                }
                 ConfigItem::ClientPort => {
                     settings_edit.client_port = default_settings.client_port;
                     settings_edit.randomize_client_port = false;
@@ -836,17 +859,31 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>, state: ConfigDrawState<'_
                 plan.content_area,
                 true,
             ),
+            ConfigPane::Libraries => {
+                libraries::draw_panel(f, screen, plan.content_area, true);
+            }
         }
     } else {
-        render_settings_pane(f, &render_ctx, items, selected_index, plan.list_pane, true);
-        render_details_pane(
+        render_settings_pane(
             f,
             &render_ctx,
-            active_item,
-            active_descriptor,
-            plan.details_pane,
-            false,
+            items,
+            selected_index,
+            plan.list_pane,
+            active_pane == ConfigPane::Settings,
         );
+        if active_pane == ConfigPane::Libraries {
+            libraries::draw_panel(f, screen, plan.details_pane, true);
+        } else {
+            render_details_pane(
+                f,
+                &render_ctx,
+                active_item,
+                active_descriptor,
+                plan.details_pane,
+                false,
+            );
+        }
     }
 
     render_config_footer(f, &render_ctx, active_item, active_pane, plan.footer_area);
@@ -1051,6 +1088,7 @@ fn build_setting_detail_lines(
     width: u16,
 ) -> Vec<Line<'static>> {
     match item {
+        ConfigItem::Libraries => build_libraries_detail_lines(render_ctx, width),
         ConfigItem::ClientPort => build_port_detail_lines(render_ctx, width),
         ConfigItem::DefaultDownloadFolder | ConfigItem::WatchFolder => {
             build_path_detail_lines(item, render_ctx, width)
@@ -1062,6 +1100,47 @@ fn build_setting_detail_lines(
         ConfigItem::GlobalDownloadLimit => build_rate_detail_lines(true, render_ctx, width),
         ConfigItem::GlobalUploadLimit => build_rate_detail_lines(false, render_ctx, width),
     }
+}
+
+fn build_libraries_detail_lines(
+    render_ctx: &ConfigRenderContext<'_, '_>,
+    width: u16,
+) -> Vec<Line<'static>> {
+    let ctx = render_ctx.screen.theme;
+    let libraries = crate::library::list_libraries().unwrap_or_default();
+    let active = libraries.iter().find(|library| library.active);
+    let active_name = active
+        .map(|library| library.name.clone())
+        .unwrap_or_else(|| "No named library".to_string());
+    let active_path = active
+        .map(|library| library.shared_config_path.display().to_string())
+        .unwrap_or_else(|| "Current config uses another selection source".to_string());
+    vec![
+        detail_row(
+            "Active",
+            active_name,
+            ctx.apply(Style::default().fg(ctx.state_selected()).bold()),
+            ctx,
+        ),
+        detail_row(
+            "Root",
+            truncate_with_ellipsis(&active_path, width.saturating_sub(10) as usize),
+            ctx.apply(Style::default().fg(ctx.theme.semantic.text)),
+            ctx,
+        ),
+        detail_row(
+            "Registered",
+            libraries.len().to_string(),
+            ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1)),
+            ctx,
+        ),
+        Line::from(""),
+        detail_divider(width, ctx),
+        info_note_line(
+            "Open Libraries to add, rename, remove, reveal, or safely switch configurations.",
+            ctx,
+        ),
+    ]
 }
 
 fn build_port_detail_lines(
@@ -1797,6 +1876,10 @@ fn render_config_footer(
     if area.height == 0 {
         return;
     }
+    if active_pane == ConfigPane::Libraries {
+        libraries::draw_footer(f, render_ctx.screen, area);
+        return;
+    }
     let locked = config_item_is_locked(active_item, render_ctx.shared_follower);
     let mut actions = Vec::new();
     if render_ctx.editing.is_some() {
@@ -1813,6 +1896,9 @@ fn render_config_footer(
                     actions.push(("Space", "next", ActionTone::Toggle));
                     actions.push(("←/→", "choice", ActionTone::Navigate));
                 }
+                ConfigControlKind::Navigation => {
+                    actions.push(("Space", "manage", ActionTone::Open));
+                }
                 ConfigControlKind::Number | ConfigControlKind::RateLimit => {
                     actions.push(("Space", "edit", ActionTone::Edit));
                 }
@@ -1827,7 +1913,7 @@ fn render_config_footer(
         } else {
             actions.push(("Esc", "close", ActionTone::Cancel));
         }
-        if !locked {
+        if !locked && descriptor_for_item(active_item).control != ConfigControlKind::Navigation {
             actions.push(("r", "reset", ActionTone::Clear));
         }
         actions.push(("↑/↓", "setting", ActionTone::Navigate));
@@ -1967,6 +2053,7 @@ fn action_supported_for_item(action: &ConfigAction, item: ConfigItem) -> bool {
                 control,
                 ConfigControlKind::Bool
                     | ConfigControlKind::Enum
+                    | ConfigControlKind::Navigation
                     | ConfigControlKind::Number
                     | ConfigControlKind::RateLimit
                     | ConfigControlKind::Path
@@ -1976,6 +2063,7 @@ fn action_supported_for_item(action: &ConfigAction, item: ConfigItem) -> bool {
         ConfigAction::IncreaseSelected | ConfigAction::DecreaseSelected => {
             control == ConfigControlKind::Enum
         }
+        ConfigAction::RequestReset => control != ConfigControlKind::Navigation,
         _ => true,
     }
 }
@@ -2091,6 +2179,9 @@ pub fn handle_event(event: CrosstermEvent, ctx: ConfigHandleContext<'_>) -> Opti
                             command,
                         );
                     }
+                    ConfigEffect::OpenLibraries => {
+                        *ctx.active_pane = ConfigPane::Libraries;
+                    }
                 }
             }
             return settings_update;
@@ -2118,6 +2209,7 @@ mod tests {
             ConfigItem::AlwaysShowAddLocationPrompt,
             ConfigItem::GlobalDownloadLimit,
             ConfigItem::GlobalUploadLimit,
+            ConfigItem::Libraries,
         ]
     }
 
@@ -2285,6 +2377,7 @@ mod tests {
 
         for item in [
             ConfigItem::ClientPort,
+            ConfigItem::Libraries,
             ConfigItem::WatchFolder,
             ConfigItem::AlwaysShowAddLocationPrompt,
         ] {
@@ -2313,6 +2406,10 @@ mod tests {
             }
         );
         assert!(rows.contains(&ConfigListRow::Category(ConfigCategory::Paths)));
+        assert!(rows.contains(&ConfigListRow::Setting {
+            global_index: 7,
+            item: ConfigItem::Libraries,
+        }));
         assert!(rows.contains(&ConfigListRow::Category(ConfigCategory::Downloads)));
         assert!(rows.contains(&ConfigListRow::Category(ConfigCategory::Ui)));
     }
@@ -2322,11 +2419,13 @@ mod tests {
         let items = config_items();
 
         assert_eq!(next_visible_setting_index(&items, 0), 1);
-        assert_eq!(next_visible_setting_index(&items, 2), 4);
+        assert_eq!(next_visible_setting_index(&items, 2), 7);
+        assert_eq!(next_visible_setting_index(&items, 7), 4);
         assert_eq!(next_visible_setting_index(&items, 6), 3);
         assert_eq!(next_visible_setting_index(&items, 3), 3);
         assert_eq!(previous_visible_setting_index(&items, 3), 6);
-        assert_eq!(previous_visible_setting_index(&items, 4), 2);
+        assert_eq!(previous_visible_setting_index(&items, 4), 7);
+        assert_eq!(previous_visible_setting_index(&items, 7), 2);
         assert_eq!(previous_visible_setting_index(&items, 0), 0);
     }
 
@@ -2344,6 +2443,39 @@ mod tests {
         assert!(!rendered.contains("Settings ·"));
         assert!(rendered.contains("Listen Port · Network"));
         assert!(rendered.contains("[Space] edit"));
+    }
+
+    #[test]
+    fn wide_library_management_stays_inside_the_config_panels() {
+        let rendered = rendered_config(
+            120,
+            34,
+            crate::config::UiLayoutMode::Horizontal,
+            ConfigPane::Libraries,
+            7,
+        );
+
+        assert!(rendered.contains("NETWORK"));
+        assert!(rendered.contains("Libraries"));
+        assert!(rendered.contains("One active configuration"));
+        assert!(rendered.contains("No libraries yet"));
+        assert!(rendered.contains("[Esc] settings"));
+    }
+
+    #[test]
+    fn compact_library_management_reuses_the_config_content_panel() {
+        let rendered = rendered_config(
+            52,
+            16,
+            crate::config::UiLayoutMode::Horizontal,
+            ConfigPane::Libraries,
+            7,
+        );
+
+        assert!(rendered.contains("Libraries"));
+        assert!(rendered.contains("One active configuration"));
+        assert!(rendered.contains("No libraries yet"));
+        assert!(rendered.contains("[Esc] settings"));
     }
 
     #[test]
@@ -3199,6 +3331,32 @@ mod tests {
             map_key_to_config_action(KeyCode::Enter, &editing),
             Some(ConfigAction::EditCommit)
         );
+    }
+
+    #[test]
+    fn reducer_library_row_opens_library_management() {
+        let mut settings = Box::new(Settings::default());
+        let mut selected_index = 0;
+        let mut items = [ConfigItem::Libraries];
+        let mut editing = None;
+
+        let result = reduce_config_action(
+            ConfigAction::ShiftSelected,
+            &mut settings,
+            &mut selected_index,
+            &mut items,
+            &mut editing,
+        );
+
+        assert!(result.consumed);
+        assert!(matches!(
+            result.effects.as_slice(),
+            [ConfigEffect::OpenLibraries]
+        ));
+        assert!(!action_supported_for_item(
+            &ConfigAction::RequestReset,
+            ConfigItem::Libraries
+        ));
     }
 
     #[test]

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -290,7 +290,7 @@ fn build_help_items(settings: &Settings, app_state: &AppState) -> Vec<HelpItem> 
         HelpSection::General,
         "Global Routes",
         "c",
-        "Open Config",
+        "Open Config, including library management",
         ActionTone::Open
     );
     action_item!(
@@ -657,6 +657,34 @@ fn build_help_items(settings: &Settings, app_state: &AppState) -> Vec<HelpItem> 
     );
     action_item!(
         HelpSection::Screens,
+        "Libraries",
+        "Up / Down / k / j",
+        "Move through registered shared-config libraries",
+        ActionTone::Navigate
+    );
+    action_item!(
+        HelpSection::Screens,
+        "Libraries",
+        "Enter / u",
+        "Gracefully stop the current engine and switch libraries",
+        ActionTone::Confirm
+    );
+    action_item!(
+        HelpSection::Screens,
+        "Libraries",
+        "a / r / d / o",
+        "Add with the directory picker, rename, remove, or open a library path",
+        ActionTone::Edit
+    );
+    action_item!(
+        HelpSection::Screens,
+        "Libraries",
+        "Page Up / Page Down / Home / End",
+        "Scroll the selected library's asynchronously loaded torrent names",
+        ActionTone::Navigate
+    );
+    action_item!(
+        HelpSection::Screens,
         "Journal",
         "Tab / Shift+Tab",
         "Cycle event journal filters",
@@ -689,6 +717,13 @@ fn build_help_items(settings: &Settings, app_state: &AppState) -> Vec<HelpItem> 
         "Space",
         "Shift or open the selected control",
         ActionTone::Navigate
+    );
+    action_item!(
+        HelpSection::Screens,
+        "Config",
+        "Libraries + Space",
+        "Open named-library management",
+        ActionTone::Open
     );
     action_item!(
         HelpSection::Screens,

--- a/src/tui/screens/libraries.rs
+++ b/src/tui/screens/libraries.rs
@@ -1,0 +1,512 @@
+// SPDX-FileCopyrightText: 2026 The superseedr Contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::app::{
+    App, AppCommand, ConfigPane, FileBrowserMode, LibraryInputKind, LibraryInputState,
+};
+use crate::tui::action_style::{footer_key_style, ActionTone};
+use crate::tui::app_command::spawn_app_command_sender;
+use crate::tui::formatters::{sanitize_text, truncate_with_ellipsis};
+use crate::tui::screen_context::ScreenContext;
+use ratatui::crossterm::event::{Event as CrosstermEvent, KeyCode, KeyEventKind};
+use ratatui::{prelude::*, widgets::*};
+use std::path::PathBuf;
+
+pub fn refresh(app: &mut App) {
+    match crate::library::list_libraries() {
+        Ok(entries) => {
+            app.app_state.ui.libraries.entries = entries;
+            let len = app.app_state.ui.libraries.entries.len();
+            app.app_state.ui.libraries.selected_index = app
+                .app_state
+                .ui
+                .libraries
+                .selected_index
+                .min(len.saturating_sub(1));
+            request_previews(app);
+        }
+        Err(error) => {
+            app.app_state.ui.libraries.status_message = Some(error.to_string());
+            app.app_state.ui.libraries.previews.clear();
+            app.app_state.ui.libraries.previews_loading = false;
+        }
+    }
+}
+
+fn request_previews(app: &mut App) {
+    let entries = app.app_state.ui.libraries.entries.clone();
+    let libraries = &mut app.app_state.ui.libraries;
+    libraries.preview_request_id = libraries.preview_request_id.wrapping_add(1);
+    libraries.preview_scroll = 0;
+    libraries.previews.clear();
+    libraries.previews_loading = !entries.is_empty();
+    if entries.is_empty() {
+        return;
+    }
+
+    let request_id = libraries.preview_request_id;
+    let app_command_tx = app.app_command_tx.clone();
+    tokio::spawn(async move {
+        let fallback_entries = entries.clone();
+        let previews =
+            match tokio::task::spawn_blocking(move || crate::library::load_previews(entries)).await
+            {
+                Ok(previews) => previews,
+                Err(error) => fallback_entries
+                    .into_iter()
+                    .map(|library| crate::library::LibraryPreview {
+                        name: library.name,
+                        torrent_names: Vec::new(),
+                        error: Some(format!("Metadata task failed: {error}")),
+                    })
+                    .collect(),
+            };
+        let _ = app_command_tx
+            .send(AppCommand::LibraryPreviewsLoaded {
+                request_id,
+                previews,
+            })
+            .await;
+    });
+}
+
+pub fn handle_event(event: CrosstermEvent, app: &mut App) {
+    let CrosstermEvent::Key(key) = event else {
+        return;
+    };
+    if key.kind != KeyEventKind::Press {
+        return;
+    }
+
+    if app.app_state.ui.libraries.input.is_some() {
+        handle_input_key(key.code, app);
+        return;
+    }
+
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('q') => {
+            app.app_state.ui.config.active_pane = ConfigPane::Settings;
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            app.app_state.ui.libraries.selected_index =
+                app.app_state.ui.libraries.selected_index.saturating_sub(1);
+            app.app_state.ui.libraries.preview_scroll = 0;
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            let last = app.app_state.ui.libraries.entries.len().saturating_sub(1);
+            app.app_state.ui.libraries.selected_index =
+                (app.app_state.ui.libraries.selected_index + 1).min(last);
+            app.app_state.ui.libraries.preview_scroll = 0;
+        }
+        KeyCode::PageUp => {
+            app.app_state.ui.libraries.preview_scroll =
+                app.app_state.ui.libraries.preview_scroll.saturating_sub(10);
+        }
+        KeyCode::PageDown => {
+            let last = selected_preview_len(app).saturating_sub(1);
+            app.app_state.ui.libraries.preview_scroll = app
+                .app_state
+                .ui
+                .libraries
+                .preview_scroll
+                .saturating_add(10)
+                .min(last);
+        }
+        KeyCode::Home => app.app_state.ui.libraries.preview_scroll = 0,
+        KeyCode::End => {
+            app.app_state.ui.libraries.preview_scroll = selected_preview_len(app).saturating_sub(1);
+        }
+        KeyCode::Enter | KeyCode::Char('u') => switch_selected(app),
+        KeyCode::Char('a') => {
+            app.app_state.ui.libraries.input = Some(LibraryInputState {
+                kind: LibraryInputKind::AddName,
+                buffer: String::new(),
+            });
+        }
+        KeyCode::Char('r') => {
+            if let Some(entry) = selected(app) {
+                app.app_state.ui.libraries.input = Some(LibraryInputState {
+                    kind: LibraryInputKind::Rename {
+                        current_name: entry.name.clone(),
+                    },
+                    buffer: entry.name.clone(),
+                });
+            }
+        }
+        KeyCode::Char('d') => {
+            if let Some(entry) = selected(app) {
+                app.app_state.ui.libraries.input = Some(LibraryInputState {
+                    kind: LibraryInputKind::ConfirmRemove {
+                        name: entry.name.clone(),
+                    },
+                    buffer: String::new(),
+                });
+            }
+        }
+        KeyCode::Char('o') => {
+            if let Some(entry) = selected(app) {
+                app.app_state.ui.libraries.status_message =
+                    match crate::library::reveal_directory(&entry.shared_config_path) {
+                        Ok(()) => Some(format!("Opened '{}'.", entry.name)),
+                        Err(error) => Some(error.to_string()),
+                    };
+            }
+        }
+        _ => {}
+    }
+}
+
+fn selected_preview_len(app: &App) -> usize {
+    selected(app)
+        .and_then(|entry| app.app_state.ui.libraries.previews.get(&entry.name))
+        .map(|preview| preview.torrent_names.len())
+        .unwrap_or(0)
+}
+
+fn selected(app: &App) -> Option<&crate::library::LibraryStatus> {
+    app.app_state
+        .ui
+        .libraries
+        .entries
+        .get(app.app_state.ui.libraries.selected_index)
+}
+
+fn switch_selected(app: &mut App) {
+    let Some(entry) = selected(app).cloned() else {
+        app.app_state.ui.libraries.status_message = Some("No library is selected.".to_string());
+        return;
+    };
+    if entry.active {
+        app.app_state.ui.libraries.status_message =
+            Some(format!("'{}' is already active.", entry.name));
+    } else if !entry.available {
+        app.app_state.ui.libraries.status_message = Some(format!(
+            "'{}' is unavailable at {}.",
+            entry.name,
+            entry.shared_config_path.display()
+        ));
+    } else if let Err(error) = app
+        .app_command_tx
+        .try_send(AppCommand::SwitchLibrary(entry.name))
+    {
+        app.app_state.ui.libraries.status_message =
+            Some(format!("Could not queue library switch: {error}"));
+    }
+}
+
+fn handle_input_key(code: KeyCode, app: &mut App) {
+    let Some(mut input) = app.app_state.ui.libraries.input.take() else {
+        return;
+    };
+    match (&input.kind, code) {
+        (_, KeyCode::Esc) => {}
+        (LibraryInputKind::ConfirmRemove { name }, KeyCode::Char('y')) => {
+            app.app_state.ui.libraries.status_message = match crate::library::remove_library(name) {
+                Ok(_) => Some(format!(
+                    "Removed '{name}' from the registry; no files were deleted."
+                )),
+                Err(error) => Some(error.to_string()),
+            };
+            refresh(app);
+        }
+        (LibraryInputKind::ConfirmRemove { .. }, KeyCode::Char('n')) => {}
+        (LibraryInputKind::ConfirmRemove { .. }, _) => {
+            app.app_state.ui.libraries.input = Some(input);
+        }
+        (LibraryInputKind::AddName, KeyCode::Enter) => {
+            let name = input.buffer.trim().to_string();
+            if name.is_empty() {
+                app.app_state.ui.libraries.status_message =
+                    Some("Library name must not be empty.".to_string());
+                app.app_state.ui.libraries.input = Some(input);
+            } else {
+                open_library_path_picker(name, app);
+            }
+        }
+        (LibraryInputKind::Rename { current_name }, KeyCode::Enter) => {
+            let new_name = input.buffer.trim();
+            app.app_state.ui.libraries.status_message =
+                match crate::library::rename_library(current_name, new_name) {
+                    Ok(()) => Some(format!("Renamed '{current_name}' to '{new_name}'.")),
+                    Err(error) => Some(error.to_string()),
+                };
+            refresh(app);
+        }
+        (_, KeyCode::Backspace) => {
+            input.buffer.pop();
+            app.app_state.ui.libraries.input = Some(input);
+        }
+        (_, KeyCode::Char(character)) => {
+            input.buffer.push(character);
+            app.app_state.ui.libraries.input = Some(input);
+        }
+        _ => {
+            app.app_state.ui.libraries.input = Some(input);
+        }
+    }
+}
+
+fn open_library_path_picker(name: String, app: &mut App) {
+    let initial_path = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    app.app_state.ui.file_browser.browser_generation = app
+        .app_state
+        .ui
+        .file_browser
+        .browser_generation
+        .wrapping_add(1);
+    spawn_app_command_sender(
+        app.app_command_tx.clone(),
+        app.shutdown_tx.subscribe(),
+        AppCommand::FetchFileTree {
+            browser_generation: app.app_state.ui.file_browser.browser_generation,
+            path: initial_path,
+            browser_mode: FileBrowserMode::LibraryPathSelection { name },
+            preserve_browser_mode: false,
+            highlight_path: None,
+        },
+    );
+}
+
+pub fn draw_panel(f: &mut Frame, screen: &ScreenContext<'_>, area: Rect, focused: bool) {
+    let state = &screen.ui.ui.libraries;
+    let ctx = screen.theme;
+    let block = Block::default()
+        .title(" Libraries ")
+        .borders(Borders::ALL)
+        .padding(Padding::horizontal(1))
+        .border_style(ctx.apply(Style::default().fg(if focused {
+            ctx.state_selected()
+        } else {
+            ctx.theme.semantic.border
+        })));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let list_height =
+        (state.entries.len() as u16 + 2).clamp(3, inner.height.saturating_div(2).max(3));
+    let chunks = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Length(list_height),
+        Constraint::Min(3),
+        Constraint::Length(2),
+    ])
+    .split(inner);
+    f.render_widget(
+        Paragraph::new("One active configuration · previews are read-only"),
+        chunks[0],
+    );
+
+    let libraries_block = Block::default()
+        .title(" Saved ")
+        .borders(Borders::ALL)
+        .border_style(ctx.apply(Style::default().fg(ctx.theme.semantic.border)));
+    let libraries_inner = libraries_block.inner(chunks[1]);
+    f.render_widget(libraries_block, chunks[1]);
+
+    let name_width = usize::from(libraries_inner.width.saturating_sub(10)).clamp(8, 24);
+    let items = state.entries.iter().map(|entry| {
+        let marker = if entry.active { "*" } else { " " };
+        let count = if !entry.available {
+            "!".to_string()
+        } else {
+            state
+                .previews
+                .get(&entry.name)
+                .map(|preview| {
+                    if preview.error.is_some() {
+                        "!".to_string()
+                    } else {
+                        preview.torrent_names.len().to_string()
+                    }
+                })
+                .unwrap_or_else(|| {
+                    if state.previews_loading {
+                        "…".to_string()
+                    } else {
+                        "—".to_string()
+                    }
+                })
+        };
+        ListItem::new(format!("{marker} {:<name_width$} {:>6}", entry.name, count,))
+    });
+    let mut list_state = ListState::default().with_selected(Some(state.selected_index));
+    f.render_stateful_widget(
+        List::new(items).highlight_symbol("> ").highlight_style(
+            ctx.apply(
+                Style::default()
+                    .fg(ctx.state_selected())
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ),
+        libraries_inner,
+        &mut list_state,
+    );
+
+    render_torrent_preview(f, screen, chunks[2]);
+
+    let detail = if let Some(input) = &state.input {
+        match &input.kind {
+            LibraryInputKind::AddName => format!("New library name: {}", input.buffer),
+            LibraryInputKind::Rename { current_name } => {
+                format!("Rename '{current_name}' to: {}", input.buffer)
+            }
+            LibraryInputKind::ConfirmRemove { name } => {
+                format!("Remove '{name}' from the registry? No files will be deleted. [y/N]")
+            }
+        }
+    } else if let Some(message) = &state.status_message {
+        message.clone()
+    } else if let Some(entry) = state.entries.get(state.selected_index) {
+        let path = entry.shared_config_path.display().to_string();
+        let max_width = chunks[3].width.saturating_sub(2) as usize;
+        let path = truncate_with_ellipsis(&path, max_width);
+        entry
+            .description
+            .as_ref()
+            .map(|description| format!("{description}\n{path}"))
+            .unwrap_or(path)
+    } else {
+        "No libraries yet. Press [a] to add one.".to_string()
+    };
+    f.render_widget(Paragraph::new(detail).wrap(Wrap { trim: true }), chunks[3]);
+}
+
+pub fn draw_footer(f: &mut Frame, screen: &ScreenContext<'_>, area: Rect) {
+    let ctx = screen.theme;
+    let input = screen.ui.ui.libraries.input.as_ref();
+    let actions = match input.map(|input| &input.kind) {
+        Some(LibraryInputKind::ConfirmRemove { .. }) => vec![
+            ("y", "remove", ActionTone::Destructive),
+            ("n/Esc", "cancel", ActionTone::Cancel),
+        ],
+        Some(LibraryInputKind::AddName) => vec![
+            ("Enter", "choose folder", ActionTone::Confirm),
+            ("Esc", "cancel", ActionTone::Cancel),
+        ],
+        Some(LibraryInputKind::Rename { .. }) => vec![
+            ("Enter", "rename", ActionTone::Confirm),
+            ("Esc", "cancel", ActionTone::Cancel),
+        ],
+        None => vec![
+            ("Enter", "switch", ActionTone::Confirm),
+            ("a", "add", ActionTone::Add),
+            ("Esc", "settings", ActionTone::Cancel),
+            ("r", "rename", ActionTone::Edit),
+            ("d", "remove", ActionTone::Destructive),
+            ("PgUp/PgDn", "names", ActionTone::Navigate),
+        ],
+    };
+    let mut spans = Vec::new();
+    let mut used = 0usize;
+    for (key, label, tone) in &actions {
+        let separator_width = usize::from(!spans.is_empty()) * 2;
+        let action_width = key.chars().count() + label.chars().count() + 3;
+        if used + separator_width + action_width > area.width as usize {
+            continue;
+        }
+        if !spans.is_empty() {
+            spans.push(Span::styled(
+                "  ",
+                ctx.apply(Style::default().fg(ctx.theme.semantic.overlay0)),
+            ));
+            used += 2;
+        }
+        spans.push(Span::styled(
+            format!("[{key}]"),
+            footer_key_style(ctx, *tone),
+        ));
+        spans.push(Span::styled(
+            format!(" {label}"),
+            ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0)),
+        ));
+        used += action_width;
+    }
+    f.render_widget(
+        Paragraph::new(Line::from(spans)).alignment(Alignment::Center),
+        area,
+    );
+}
+
+fn render_torrent_preview(f: &mut Frame, screen: &ScreenContext<'_>, area: Rect) {
+    let state = &screen.ui.ui.libraries;
+    let ctx = screen.theme;
+    let selected_entry = state.entries.get(state.selected_index);
+    let preview = selected_entry.and_then(|entry| state.previews.get(&entry.name));
+    let title = match (selected_entry, preview) {
+        (Some(entry), Some(preview)) if preview.error.is_none() => format!(
+            " Torrents · {} · {} ",
+            entry.name,
+            preview.torrent_names.len()
+        ),
+        (Some(entry), _) => format!(" Torrents · {} ", entry.name),
+        (None, _) => " Torrent names ".to_string(),
+    };
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(ctx.apply(Style::default().fg(ctx.theme.semantic.border)));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let Some(preview) = preview else {
+        let message = if state.previews_loading && selected_entry.is_some() {
+            "Loading torrent metadata…"
+        } else if selected_entry.is_some() {
+            "Torrent metadata is not loaded."
+        } else {
+            "Select or add a library."
+        };
+        f.render_widget(Paragraph::new(message).wrap(Wrap { trim: true }), inner);
+        return;
+    };
+    if let Some(error) = &preview.error {
+        f.render_widget(
+            Paragraph::new(format!("Could not read catalog: {error}")).wrap(Wrap { trim: true }),
+            inner,
+        );
+        return;
+    }
+    if preview.torrent_names.is_empty() {
+        f.render_widget(Paragraph::new("No torrents in this library."), inner);
+        return;
+    }
+
+    let visible_height = inner.height as usize;
+    let start = torrent_preview_start(
+        preview.torrent_names.len(),
+        state.preview_scroll,
+        visible_height,
+    );
+    let names = preview
+        .torrent_names
+        .iter()
+        .enumerate()
+        .skip(start)
+        .take(visible_height)
+        .map(|(index, name)| {
+            let name = if screen.ui.anonymize_torrent_names {
+                format!("torrent-{:05}", index + 1)
+            } else {
+                sanitize_text(name)
+            };
+            ListItem::new(format!("{:>5}. {name}", index + 1))
+        });
+    f.render_widget(List::new(names), inner);
+}
+
+fn torrent_preview_start(total: usize, requested_start: usize, visible_height: usize) -> usize {
+    requested_start.min(total.saturating_sub(visible_height))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::torrent_preview_start;
+
+    #[test]
+    fn torrent_preview_scroll_keeps_the_last_page_full() {
+        assert_eq!(torrent_preview_start(25, 0, 10), 0);
+        assert_eq!(torrent_preview_start(25, 10, 10), 10);
+        assert_eq!(torrent_preview_start(25, 24, 10), 15);
+        assert_eq!(torrent_preview_start(4, 20, 10), 0);
+    }
+}

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -7,6 +7,7 @@ pub mod delete_confirm;
 pub mod help;
 pub(crate) mod input_panel;
 pub mod journal;
+pub mod libraries;
 pub mod normal;
 pub mod peers;
 pub mod power;

--- a/src/tui/screens/normal.rs
+++ b/src/tui/screens/normal.rs
@@ -8581,6 +8581,10 @@ mod tests {
             map_key_to_ui_action(KeyEvent::new(KeyCode::Char('P'), KeyModifiers::NONE)),
             Some(UiAction::OpenPeerManagement)
         );
+        assert_eq!(
+            map_key_to_ui_action(KeyEvent::new(KeyCode::Char('L'), KeyModifiers::NONE)),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add named libraries backed by isolated shared-config roots
- integrate library management into **Config → Paths → Libraries**
- support adding, inspecting, switching, renaming, and removing libraries through the TUI and CLI
- load torrent counts and scrollable torrent-name previews asynchronously without starting inactive torrent managers
- preserve default standalone paths when no library is selected
- document setup, switching behavior, CLI commands, and release-candidate coverage

## Why

Users need a lightweight way to separate torrent collections while keeping each library's settings, catalog, metadata, and download location isolated. Switching the active shared-config root gives each library its own state while ensuring only the active library's torrent manager runs.

Closes #283

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets` — 1,961 passed, 1 ignored
