### PR TITLE
Add torrent tags and management screen

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release v1.0.13
 ### 🚀 New Features
+- **Torrent Tags**: Added persistent manual tags with stable IDs, shared-catalog assignments, a themed `L` tag-filter workspace with flowing pills and torrent/file results, an inline `t` tag picker shared with Torrent Management for bulk assignment and create-and-assign, and matching text/JSON CLI operations for creating, renaming, deleting, assigning, removing, listing, and inspecting tags.
 - **Global Peer Management**: Added a dedicated `P` workspace for inspecting peers across all torrents, with activity and restriction filters, fuzzy or regex search, sortable columns, detailed evidence views, and optional privacy masking.
 - **Automatic Malicious-Peer Protection**: Added a global policy that detects excessive transfer activity and rapid reconnect churn, temporarily restricts offending addresses, and carries those protections across active torrents and restarts.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,7 +18,7 @@ The roadmap now reflects features shipped through `v1.0.1`.
 ## Big Features
 - `[Shipped]` **RSS Feed Support**
 - `[Planned]` **Config Screen Redesign**: Modernize and refactor config management for more complex user inputs.
-- `[Planned]` **Advanced Torrent Management**: Add multi-select, bulk actions, and grouping in torrent management UI flows.
+- `[Partially Shipped]` **Advanced Torrent Management**: Multi-select, bulk actions, and persistent torrent tags are available; broader tag-driven filtering remains extensible.
 - `[Partially Shipped]` **User Adjustables**: Continue improving user control over visible columns and auto behaviors.
 - `[Partially Shipped]` **Alternative and Custom Themes**: Extend beyond built-ins with full user-defined theme packs.
 - `[Shipped]` **Internal TUI Architecture Refactor**
@@ -59,7 +59,7 @@ Longer-term work targets deeper networking and operational control:
 ### Advanced Torrent Management
 - **phase: 1.1 to v1.5** | Multi-select State - internal logic to track multiple selected rows | [Issue #____]
 - **phase: 1.1 to v1.5** | Bulk Actions - apply start, stop, and delete to selection context | [Issue #____]
-- **phase: 1.1 to v1.5** | Grouping/Tagging - associate torrents with tags/groups for management flows | [Issue #____]
+- **phase: 1.1 to v1.5** | Grouping/Tagging - associate torrents with persistent tags for management flows | [Issue #307]
 
 ### Config Screen Redesign
 - **phase: 1.1 to v1.5** | Input Field Refactor - support complex field types (dropdowns, toggles) | [Issue #____]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,6 +47,7 @@ Inspect current state:
 ```bash
 superseedr status
 superseedr torrents
+superseedr tags list
 superseedr journal
 superseedr show-configs
 ```
@@ -321,6 +322,23 @@ superseedr info <INFO_HASH_HEX_OR_PATH>
 ```
 
 Show a single torrent by info hash or unique file path.
+
+### `tags`
+
+```bash
+superseedr tags list
+superseedr tags show <TAG_ID_OR_NAME>
+superseedr tags create <NAME>
+superseedr tags rename <TAG_ID_OR_NAME> <NEW_NAME>
+superseedr tags delete <TAG_ID_OR_NAME>
+superseedr tags assign <TAG_ID_OR_NAME> <INFO_HASH_HEX_OR_PATH>...
+superseedr tags remove <TAG_ID_OR_NAME> <INFO_HASH_HEX_OR_PATH>...
+```
+
+Tag names are unique without regard to ASCII letter case. Tags keep a stable
+numeric ID across renames. Assignment commands accept the same torrent target
+forms as pause, resume, and other torrent controls. `--json` includes tag
+origin metadata and assigned torrent summaries.
 
 ### `status`
 

--- a/docs/shared-config.md
+++ b/docs/shared-config.md
@@ -433,6 +433,8 @@ Commands like these read shared state:
 - `torrents`
 - `info`
 - `files`
+- `tags list`
+- `tags show`
 
 `status` in shared mode follows the current leader snapshot rather than a purely
 local standalone-style node status view.
@@ -447,6 +449,8 @@ Mutating commands include:
 - `remove`
 - `purge`
 - `priority`
+- `tags create`, `tags rename`, and `tags delete`
+- `tags assign` and `tags remove`
 
 Behavior:
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1085,6 +1085,7 @@ pub enum AppMode {
     Journal,
     PeerManagement,
     TorrentManagement,
+    TagManagement,
     PowerSaving,
     DeleteConfirm,
     Config,
@@ -1664,6 +1665,8 @@ pub struct UiState {
     pub journal: JournalUiState,
     pub peer_management: PeerManagementUiState,
     pub torrent_management: TorrentManagementUiState,
+    pub tag_management: TagManagementUiState,
+    pub tag_picker: TagPickerUiState,
     pub normal_paste_burst: PasteBurst,
     #[allow(dead_code)]
     pub rss: RssUiState,
@@ -2162,6 +2165,43 @@ impl Default for TorrentManagementUiState {
             review_cache: None,
         }
     }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum TagManagementPane {
+    #[default]
+    Tags,
+    Torrents,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TagInputMode {
+    Search,
+    Create,
+    Rename(crate::tags::TagId),
+}
+
+#[derive(Default)]
+pub struct TagManagementUiState {
+    pub selected_tag_index: usize,
+    pub selected_torrent_index: usize,
+    pub active_pane: TagManagementPane,
+    pub assignment_mode: bool,
+    pub input_mode: Option<TagInputMode>,
+    pub input_buffer: String,
+    pub search_query: String,
+    pub delete_confirm_tag_id: Option<crate::tags::TagId>,
+    pub status_message: Option<String>,
+}
+
+#[derive(Default)]
+pub struct TagPickerUiState {
+    pub open: bool,
+    pub selected_index: usize,
+    pub creating: bool,
+    pub input_buffer: String,
+    pub target_hashes: Vec<Vec<u8>>,
+    pub status_message: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -9933,6 +9973,11 @@ fn build_persist_payload(
         .iter()
         .map(|cfg| (cfg.torrent_or_magnet.clone(), cfg.added_at_unix_secs))
         .collect();
+    let old_tag_ids: HashMap<String, Vec<crate::tags::TagId>> = client_configs
+        .torrents
+        .iter()
+        .map(|cfg| (cfg.torrent_or_magnet.clone(), cfg.tag_ids.clone()))
+        .collect();
     let previous_torrents = client_configs.torrents.clone();
     let deferred_hashes: HashSet<Vec<u8>> = startup_deferred_load_queue.iter().cloned().collect();
     let pending_preview_info_hash = app_state.pending_magnet_preview_info_hash.clone();
@@ -9976,6 +10021,10 @@ fn build_persist_payload(
                 container_name: torrent_state.container_name.clone(),
                 torrent_control_state: torrent_state.torrent_control_state.clone(),
                 delete_files: torrent_state.delete_files,
+                tag_ids: old_tag_ids
+                    .get(&torrent_state.torrent_or_magnet)
+                    .cloned()
+                    .unwrap_or_default(),
                 file_priorities: torrent_state.file_priorities.clone(),
             })
         })

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,7 @@ use crate::fs_atomic::{
     deserialize_versioned_toml, serialize_versioned_toml, write_string_atomically,
     write_toml_atomically,
 };
+use crate::tags::{TagCatalog, TagId};
 use crate::theme::ThemeName;
 
 use strum_macros::EnumCount;
@@ -225,6 +226,7 @@ pub struct Settings {
     #[serde(skip)]
     pub randomize_client_port: bool,
     pub torrents: Vec<TorrentSettings>,
+    pub tag_catalog: TagCatalog,
     pub lifetime_downloaded: u64,
     pub lifetime_uploaded: u64,
     pub private_client: bool,
@@ -263,6 +265,7 @@ impl Default for Settings {
             client_port: 6681,
             randomize_client_port: false,
             torrents: Vec::new(),
+            tag_catalog: TagCatalog::default(),
             watch_folder: None,
             default_download_folder: None,
             lifetime_downloaded: 0,
@@ -312,6 +315,7 @@ pub struct TorrentSettings {
     pub container_name: Option<String>,
     pub torrent_control_state: TorrentControlState,
     pub delete_files: bool,
+    pub tag_ids: Vec<TagId>,
     #[serde(with = "string_usize_map")]
     pub file_priorities: HashMap<usize, FilePriority>,
 }
@@ -439,6 +443,7 @@ struct CatalogTorrentSettings {
     pub container_name: Option<String>,
     pub torrent_control_state: TorrentControlState,
     pub delete_files: bool,
+    pub tag_ids: Vec<TagId>,
     #[serde(with = "string_usize_map")]
     pub file_priorities: HashMap<usize, FilePriority>,
 }
@@ -515,6 +520,7 @@ impl Default for SharedSettingsConfig {
 #[serde(default)]
 struct CatalogConfig {
     pub torrents: Vec<CatalogTorrentSettings>,
+    pub tag_catalog: TagCatalog,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -724,6 +730,7 @@ impl CatalogTorrentSettings {
             container_name: settings.container_name.clone(),
             torrent_control_state: settings.torrent_control_state.clone(),
             delete_files: settings.delete_files,
+            tag_ids: settings.tag_ids.clone(),
             file_priorities: settings.file_priorities.clone(),
         })
     }
@@ -755,6 +762,7 @@ impl CatalogTorrentSettings {
             container_name: self.container_name.clone(),
             torrent_control_state: self.torrent_control_state.clone(),
             delete_files: self.delete_files,
+            tag_ids: self.tag_ids.clone(),
             file_priorities: self.file_priorities.clone(),
         })
     }
@@ -1009,6 +1017,7 @@ impl CatalogConfig {
                     )
                 })
                 .collect::<io::Result<Vec<_>>>()?,
+            tag_catalog: settings.tag_catalog.clone(),
         })
     }
 
@@ -1023,7 +1032,20 @@ impl CatalogConfig {
             .iter()
             .map(|torrent| torrent.to_settings(shared_config_root, shared_mount_root))
             .collect::<io::Result<Vec<_>>>()?;
+        settings.tag_catalog = self.tag_catalog.clone();
+        repair_tag_assignments(settings);
         Ok(())
+    }
+}
+
+fn repair_tag_assignments(settings: &mut Settings) {
+    settings.tag_catalog.repair();
+    let valid_ids: std::collections::HashSet<TagId> =
+        settings.tag_catalog.tags.iter().map(|tag| tag.id).collect();
+    for torrent in &mut settings.torrents {
+        torrent.tag_ids.retain(|id| valid_ids.contains(id));
+        torrent.tag_ids.sort_unstable();
+        torrent.tag_ids.dedup();
     }
 }
 
@@ -3959,6 +3981,102 @@ mod tests {
     }
 
     #[test]
+    fn test_layered_catalog_round_trips_tags_and_assignments() {
+        let shared_mount_root = Path::new("/shared-root");
+        let shared_config_root = Path::new("/shared-root/superseedr-config");
+        let mut settings = Settings {
+            torrents: vec![TorrentSettings {
+                torrent_or_magnet: "magnet:?xt=urn:btih:6666666666666666666666666666666666666666"
+                    .to_string(),
+                name: "Sample Archive".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let tag_id = settings
+            .tag_catalog
+            .create_manual("Research")
+            .expect("create tag");
+        settings.torrents[0].tag_ids.push(tag_id);
+
+        let layered = LayeredConfig::from_shared_settings(
+            &settings,
+            shared_mount_root,
+            shared_config_root,
+            None,
+        )
+        .expect("encode shared settings");
+        let resolved = layered
+            .resolve_shared_settings(shared_mount_root, shared_config_root)
+            .expect("decode shared settings");
+
+        assert_eq!(resolved.tag_catalog, settings.tag_catalog);
+        assert_eq!(resolved.torrents[0].tag_ids, vec![tag_id]);
+    }
+
+    #[test]
+    fn tag_repair_removes_dangling_and_duplicate_assignments() {
+        let mut settings = Settings {
+            torrents: vec![TorrentSettings {
+                tag_ids: vec![1, 1, 99],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let tag_id = settings
+            .tag_catalog
+            .create_manual("Archive")
+            .expect("create tag");
+        assert_eq!(tag_id, 1);
+        repair_tag_assignments(&mut settings);
+        assert_eq!(settings.torrents[0].tag_ids, vec![tag_id]);
+    }
+
+    #[test]
+    fn tag_repair_preserves_non_ascii_case_pairs_and_their_assignments() {
+        let mut settings = Settings {
+            tag_catalog: TagCatalog {
+                next_id: 4,
+                tags: vec![
+                    crate::tags::TagDefinition {
+                        id: 1,
+                        name: "Äther".to_string(),
+                        origin: crate::tags::TagOrigin::Manual,
+                    },
+                    crate::tags::TagDefinition {
+                        id: 2,
+                        name: "äther".to_string(),
+                        origin: crate::tags::TagOrigin::Manual,
+                    },
+                    crate::tags::TagDefinition {
+                        id: 3,
+                        name: "123".to_string(),
+                        origin: crate::tags::TagOrigin::Manual,
+                    },
+                ],
+            },
+            torrents: vec![TorrentSettings {
+                tag_ids: vec![1, 2, 3],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        repair_tag_assignments(&mut settings);
+
+        assert_eq!(
+            settings
+                .tag_catalog
+                .tags
+                .iter()
+                .map(|tag| tag.id)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert_eq!(settings.torrents[0].tag_ids, vec![1, 2]);
+    }
+
+    #[test]
     fn test_catalog_and_host_merge_into_runtime_settings() {
         let shared_mount_root = Path::new("/shared-root");
         let shared_config_root = Path::new("/shared-root/superseedr-config");
@@ -3976,6 +4094,7 @@ mod tests {
                 download_path: Some(PathBuf::from("downloads").join("shared")),
                 ..CatalogTorrentSettings::default()
             }],
+            ..CatalogConfig::default()
         };
         let host = HostConfig {
             client_id: Some("host-a".to_string()),
@@ -4595,6 +4714,7 @@ mod tests {
                 name: "Sample Item".to_string(),
                 ..CatalogTorrentSettings::default()
             }],
+            ..CatalogConfig::default()
         };
         write_toml_atomically(&paths.catalog_path, &catalog).expect("seed catalog");
 

--- a/src/control_service.rs
+++ b/src/control_service.rs
@@ -1183,6 +1183,20 @@ pub enum ControlExecutionPlan {
     },
 }
 
+fn manual_tag_name(settings: &Settings, tag_id: u64, action: &str) -> Result<String, String> {
+    let tag = settings
+        .tag_catalog
+        .get(tag_id)
+        .ok_or_else(|| format!("Tag '{}' was not found", tag_id))?;
+    if !tag.origin.is_manual() {
+        return Err(format!(
+            "Generated tag '{}' cannot be {} manually",
+            tag.name, action
+        ));
+    }
+    Ok(tag.name.clone())
+}
+
 pub fn plan_control_request(
     settings: &Settings,
     request: &ControlRequest,
@@ -1260,17 +1274,7 @@ pub fn plan_control_request(
             tag_id,
             info_hash_hex,
         } => {
-            let tag = settings
-                .tag_catalog
-                .get(*tag_id)
-                .ok_or_else(|| format!("Tag '{}' was not found", tag_id))?;
-            if !tag.origin.is_manual() {
-                return Err(format!(
-                    "Generated tag '{}' cannot be assigned manually",
-                    tag.name
-                ));
-            }
-            let tag_name = tag.name.clone();
+            let tag_name = manual_tag_name(settings, *tag_id, "assigned")?;
             let info_hash = decode_info_hash(info_hash_hex)?;
             let Some(index) = find_torrent_settings_index_by_info_hash(settings, &info_hash) else {
                 return Err(format!("Torrent '{}' was not found", info_hash_hex));
@@ -1292,17 +1296,7 @@ pub fn plan_control_request(
             tag_id,
             info_hash_hex,
         } => {
-            let tag = settings
-                .tag_catalog
-                .get(*tag_id)
-                .ok_or_else(|| format!("Tag '{}' was not found", tag_id))?;
-            if !tag.origin.is_manual() {
-                return Err(format!(
-                    "Generated tag '{}' cannot be removed manually",
-                    tag.name
-                ));
-            }
-            let tag_name = tag.name.clone();
+            let tag_name = manual_tag_name(settings, *tag_id, "removed")?;
             let info_hash = decode_info_hash(info_hash_hex)?;
             let Some(index) = find_torrent_settings_index_by_info_hash(settings, &info_hash) else {
                 return Err(format!("Torrent '{}' was not found", info_hash_hex));

--- a/src/control_service.rs
+++ b/src/control_service.rs
@@ -1292,12 +1292,17 @@ pub fn plan_control_request(
             tag_id,
             info_hash_hex,
         } => {
-            let tag_name = settings
+            let tag = settings
                 .tag_catalog
                 .get(*tag_id)
-                .ok_or_else(|| format!("Tag '{}' was not found", tag_id))?
-                .name
-                .clone();
+                .ok_or_else(|| format!("Tag '{}' was not found", tag_id))?;
+            if !tag.origin.is_manual() {
+                return Err(format!(
+                    "Generated tag '{}' cannot be removed manually",
+                    tag.name
+                ));
+            }
+            let tag_name = tag.name.clone();
             let info_hash = decode_info_hash(info_hash_hex)?;
             let Some(index) = find_torrent_settings_index_by_info_hash(settings, &info_hash) else {
                 return Err(format!("Torrent '{}' was not found", info_hash_hex));
@@ -2248,6 +2253,35 @@ mod tests {
     }
 
     #[test]
+    fn create_and_assign_tag_rejects_invalid_target_without_creating_tag() {
+        let mut settings = Settings {
+            torrents: vec![TorrentSettings {
+                torrent_or_magnet: "magnet:?xt=urn:btih:7777777777777777777777777777777777777777"
+                    .to_string(),
+                name: "Sample Archive".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let error = apply_offline_control_request(
+            &mut settings,
+            &ControlRequest::CreateAndAssignTag {
+                name: "Review Queue".to_string(),
+                info_hashes: vec![
+                    "7777777777777777777777777777777777777777".to_string(),
+                    "8888888888888888888888888888888888888888".to_string(),
+                ],
+            },
+        )
+        .expect_err("invalid target must reject the request");
+
+        assert!(error.contains("was not found"));
+        assert!(settings.tag_catalog.tags.is_empty());
+        assert!(settings.torrents[0].tag_ids.is_empty());
+    }
+
+    #[test]
     fn assigning_a_tag_is_idempotent() {
         let mut settings = Settings {
             torrents: vec![TorrentSettings {
@@ -2269,5 +2303,39 @@ mod tests {
         apply_offline_control_request(&mut settings, &request).expect("first assignment");
         apply_offline_control_request(&mut settings, &request).expect("second assignment");
         assert_eq!(settings.torrents[0].tag_ids, vec![tag_id]);
+    }
+
+    #[test]
+    fn generated_tag_assignment_cannot_be_removed_manually() {
+        let mut settings = Settings {
+            torrents: vec![TorrentSettings {
+                torrent_or_magnet: "magnet:?xt=urn:btih:9999999999999999999999999999999999999999"
+                    .to_string(),
+                name: "Generated Collection".to_string(),
+                tag_ids: vec![1],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        settings.tag_catalog.tags.push(crate::tags::TagDefinition {
+            id: 1,
+            name: "Provider Group".to_string(),
+            origin: crate::tags::TagOrigin::Generated {
+                provider: "fictional-provider".to_string(),
+                key: "group-a".to_string(),
+            },
+        });
+
+        let error = plan_control_request(
+            &settings,
+            &ControlRequest::RemoveTag {
+                tag_id: 1,
+                info_hash_hex: "9999999999999999999999999999999999999999".to_string(),
+            },
+        )
+        .expect_err("generated assignment removal should fail");
+
+        assert!(error.contains("cannot be removed manually"));
+        assert_eq!(settings.torrents[0].tag_ids, vec![1]);
     }
 }

--- a/src/control_service.rs
+++ b/src/control_service.rs
@@ -100,6 +100,38 @@ pub fn build_move_torrent_request(
 
 pub fn online_control_success_message(request: &ControlRequest) -> String {
     match request {
+        ControlRequest::CreateTag { name } => {
+            format!("Queued create request for tag '{}'", name)
+        }
+        ControlRequest::CreateAndAssignTag { name, info_hashes } => format!(
+            "Queued creation of tag '{}' for {} torrent{}",
+            name,
+            info_hashes.len(),
+            if info_hashes.len() == 1 { "" } else { "s" }
+        ),
+        ControlRequest::RenameTag { tag_id, new_name } => {
+            format!(
+                "Queued rename request for tag '{}' -> '{}'",
+                tag_id, new_name
+            )
+        }
+        ControlRequest::DeleteTag { tag_id } => {
+            format!("Queued delete request for tag '{}'", tag_id)
+        }
+        ControlRequest::AssignTag {
+            tag_id,
+            info_hash_hex,
+        } => format!(
+            "Queued assignment of tag '{}' to torrent '{}'",
+            tag_id, info_hash_hex
+        ),
+        ControlRequest::RemoveTag {
+            tag_id,
+            info_hash_hex,
+        } => format!(
+            "Queued removal of tag '{}' from torrent '{}'",
+            tag_id, info_hash_hex
+        ),
         ControlRequest::Pause { info_hash_hex } => {
             format!("Queued pause request for torrent '{}'", info_hash_hex)
         }
@@ -1163,6 +1195,125 @@ pub fn plan_control_request(
             })
         }
         ControlRequest::StatusFollowStop => Ok(ControlExecutionPlan::StatusFollowStop),
+        ControlRequest::CreateTag { name } => {
+            let mut next_settings = settings.clone();
+            let tag_id = next_settings.tag_catalog.create_manual(name)?;
+            Ok(ControlExecutionPlan::ApplySettings {
+                next_settings,
+                success_message: format!("Created tag '{}' with ID {}", name.trim(), tag_id),
+            })
+        }
+        ControlRequest::CreateAndAssignTag { name, info_hashes } => {
+            if info_hashes.is_empty() {
+                return Err(
+                    "At least one torrent is required when creating an assigned tag".to_string(),
+                );
+            }
+            let mut target_indices = Vec::with_capacity(info_hashes.len());
+            for info_hash_hex in info_hashes {
+                let info_hash = decode_info_hash(info_hash_hex)?;
+                let Some(index) = find_torrent_settings_index_by_info_hash(settings, &info_hash)
+                else {
+                    return Err(format!("Torrent '{}' was not found", info_hash_hex));
+                };
+                if !target_indices.contains(&index) {
+                    target_indices.push(index);
+                }
+            }
+            let mut next_settings = settings.clone();
+            let tag_id = next_settings.tag_catalog.create_manual(name)?;
+            for index in target_indices.iter().copied() {
+                next_settings.torrents[index].tag_ids.push(tag_id);
+                next_settings.torrents[index].tag_ids.sort_unstable();
+                next_settings.torrents[index].tag_ids.dedup();
+            }
+            Ok(ControlExecutionPlan::ApplySettings {
+                next_settings,
+                success_message: format!(
+                    "Created tag '{}' and assigned it to {} torrent{}",
+                    name.trim(),
+                    target_indices.len(),
+                    if target_indices.len() == 1 { "" } else { "s" }
+                ),
+            })
+        }
+        ControlRequest::RenameTag { tag_id, new_name } => {
+            let mut next_settings = settings.clone();
+            next_settings.tag_catalog.rename_manual(*tag_id, new_name)?;
+            Ok(ControlExecutionPlan::ApplySettings {
+                next_settings,
+                success_message: format!("Renamed tag '{}' to '{}'", tag_id, new_name.trim()),
+            })
+        }
+        ControlRequest::DeleteTag { tag_id } => {
+            let mut next_settings = settings.clone();
+            let deleted = next_settings.tag_catalog.delete_manual(*tag_id)?;
+            for torrent in &mut next_settings.torrents {
+                torrent.tag_ids.retain(|assigned_id| assigned_id != tag_id);
+            }
+            Ok(ControlExecutionPlan::ApplySettings {
+                next_settings,
+                success_message: format!("Deleted tag '{}'", deleted.name),
+            })
+        }
+        ControlRequest::AssignTag {
+            tag_id,
+            info_hash_hex,
+        } => {
+            let tag = settings
+                .tag_catalog
+                .get(*tag_id)
+                .ok_or_else(|| format!("Tag '{}' was not found", tag_id))?;
+            if !tag.origin.is_manual() {
+                return Err(format!(
+                    "Generated tag '{}' cannot be assigned manually",
+                    tag.name
+                ));
+            }
+            let tag_name = tag.name.clone();
+            let info_hash = decode_info_hash(info_hash_hex)?;
+            let Some(index) = find_torrent_settings_index_by_info_hash(settings, &info_hash) else {
+                return Err(format!("Torrent '{}' was not found", info_hash_hex));
+            };
+            let mut next_settings = settings.clone();
+            if !next_settings.torrents[index].tag_ids.contains(tag_id) {
+                next_settings.torrents[index].tag_ids.push(*tag_id);
+                next_settings.torrents[index].tag_ids.sort_unstable();
+            }
+            Ok(ControlExecutionPlan::ApplySettings {
+                next_settings,
+                success_message: format!(
+                    "Assigned tag '{}' to torrent '{}'",
+                    tag_name, info_hash_hex
+                ),
+            })
+        }
+        ControlRequest::RemoveTag {
+            tag_id,
+            info_hash_hex,
+        } => {
+            let tag_name = settings
+                .tag_catalog
+                .get(*tag_id)
+                .ok_or_else(|| format!("Tag '{}' was not found", tag_id))?
+                .name
+                .clone();
+            let info_hash = decode_info_hash(info_hash_hex)?;
+            let Some(index) = find_torrent_settings_index_by_info_hash(settings, &info_hash) else {
+                return Err(format!("Torrent '{}' was not found", info_hash_hex));
+            };
+            let mut next_settings = settings.clone();
+            next_settings.torrents[index]
+                .tag_ids
+                .retain(|assigned_id| assigned_id != tag_id);
+            Ok(ControlExecutionPlan::ApplySettings {
+                next_settings,
+                success_message: format!(
+                    "Removed tag '{}' from torrent '{}'",
+                    tag_name, info_hash_hex
+                ),
+            })
+        }
         ControlRequest::Pause { info_hash_hex } => {
             let info_hash = decode_info_hash(info_hash_hex)?;
             let Some(index) = find_torrent_settings_index_by_info_hash(settings, &info_hash) else {
@@ -2006,5 +2157,117 @@ mod tests {
         assert!(resolve_error.contains("No torrent matched file path"));
 
         set_app_paths_override_for_tests(None);
+    }
+
+    #[test]
+    fn tag_control_lifecycle_persists_assignments_by_stable_id() {
+        let mut settings = Settings {
+            torrents: vec![TorrentSettings {
+                torrent_or_magnet: "magnet:?xt=urn:btih:4444444444444444444444444444444444444444"
+                    .to_string(),
+                name: "Sample Dataset".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        apply_offline_control_request(
+            &mut settings,
+            &ControlRequest::CreateTag {
+                name: "Archive".to_string(),
+            },
+        )
+        .expect("create tag");
+        let tag_id = settings.tag_catalog.tags[0].id;
+
+        apply_offline_control_request(
+            &mut settings,
+            &ControlRequest::AssignTag {
+                tag_id,
+                info_hash_hex: "4444444444444444444444444444444444444444".to_string(),
+            },
+        )
+        .expect("assign tag");
+        assert_eq!(settings.torrents[0].tag_ids, vec![tag_id]);
+
+        apply_offline_control_request(
+            &mut settings,
+            &ControlRequest::RenameTag {
+                tag_id,
+                new_name: "Research".to_string(),
+            },
+        )
+        .expect("rename tag");
+        assert_eq!(settings.torrents[0].tag_ids, vec![tag_id]);
+        assert_eq!(settings.tag_catalog.get(tag_id).unwrap().name, "Research");
+
+        apply_offline_control_request(&mut settings, &ControlRequest::DeleteTag { tag_id })
+            .expect("delete tag");
+        assert!(settings.tag_catalog.tags.is_empty());
+        assert!(settings.torrents[0].tag_ids.is_empty());
+    }
+
+    #[test]
+    fn create_and_assign_tag_updates_all_targets_atomically() {
+        let mut settings = Settings {
+            torrents: vec![
+                TorrentSettings {
+                    torrent_or_magnet:
+                        "magnet:?xt=urn:btih:5555555555555555555555555555555555555555".to_string(),
+                    name: "Sample Archive".to_string(),
+                    ..Default::default()
+                },
+                TorrentSettings {
+                    torrent_or_magnet:
+                        "magnet:?xt=urn:btih:6666666666666666666666666666666666666666".to_string(),
+                    name: "Field Notes".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        apply_offline_control_request(
+            &mut settings,
+            &ControlRequest::CreateAndAssignTag {
+                name: "Review Queue".to_string(),
+                info_hashes: vec![
+                    "5555555555555555555555555555555555555555".to_string(),
+                    "6666666666666666666666666666666666666666".to_string(),
+                ],
+            },
+        )
+        .expect("create and assign tag");
+
+        let tag = settings.tag_catalog.tags.first().expect("created tag");
+        assert_eq!(tag.name, "Review Queue");
+        assert!(settings
+            .torrents
+            .iter()
+            .all(|torrent| torrent.tag_ids == vec![tag.id]));
+    }
+
+    #[test]
+    fn assigning_a_tag_is_idempotent() {
+        let mut settings = Settings {
+            torrents: vec![TorrentSettings {
+                torrent_or_magnet: "magnet:?xt=urn:btih:5555555555555555555555555555555555555555"
+                    .to_string(),
+                name: "Field Notes".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let tag_id = settings
+            .tag_catalog
+            .create_manual("Review")
+            .expect("create tag");
+        let request = ControlRequest::AssignTag {
+            tag_id,
+            info_hash_hex: "5555555555555555555555555555555555555555".to_string(),
+        };
+        apply_offline_control_request(&mut settings, &request).expect("first assignment");
+        apply_offline_control_request(&mut settings, &request).expect("second assignment");
+        assert_eq!(settings.torrents[0].tag_ids, vec![tag_id]);
     }
 }

--- a/src/integrations/cli.rs
+++ b/src/integrations/cli.rs
@@ -107,6 +107,11 @@ pub enum Commands {
     ToStandalone,
     #[command(about = "List configured torrents")]
     Torrents,
+    #[command(about = "List and manage torrent tags")]
+    Tags {
+        #[command(subcommand)]
+        command: TagCommand,
+    },
     #[command(about = "Show one torrent by info hash, or resolve it from a unique file path")]
     Info {
         #[arg(
@@ -207,6 +212,48 @@ pub enum Commands {
         about = "Run a local synthetic BitTorrent load harness"
     )]
     SyntheticLoad(SyntheticLoadArgs),
+}
+
+#[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
+pub enum TagCommand {
+    #[command(about = "List tag definitions and assignment counts")]
+    List,
+    #[command(about = "Show one tag and its assigned torrents")]
+    Show {
+        #[arg(value_name = "TAG_ID_OR_NAME")]
+        tag: String,
+    },
+    #[command(about = "Create a manual tag")]
+    Create {
+        #[arg(value_name = "NAME")]
+        name: String,
+    },
+    #[command(about = "Rename a manual tag")]
+    Rename {
+        #[arg(value_name = "TAG_ID_OR_NAME")]
+        tag: String,
+        #[arg(value_name = "NEW_NAME")]
+        new_name: String,
+    },
+    #[command(about = "Delete a manual tag and all of its assignments")]
+    Delete {
+        #[arg(value_name = "TAG_ID_OR_NAME")]
+        tag: String,
+    },
+    #[command(about = "Assign a tag to one or more torrents")]
+    Assign {
+        #[arg(value_name = "TAG_ID_OR_NAME")]
+        tag: String,
+        #[arg(value_name = "INFO_HASH_HEX_OR_PATH", num_args = 1..)]
+        targets: Vec<String>,
+    },
+    #[command(about = "Remove a tag from one or more torrents")]
+    Remove {
+        #[arg(value_name = "TAG_ID_OR_NAME")]
+        tag: String,
+        #[arg(value_name = "INFO_HASH_HEX_OR_PATH", num_args = 1..)]
+        targets: Vec<String>,
+    },
 }
 
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
@@ -674,6 +721,7 @@ where
         | Commands::ToShared { .. }
         | Commands::ToStandalone
         | Commands::Torrents
+        | Commands::Tags { .. }
         | Commands::Info { .. }
         | Commands::Purge { .. }
         | Commands::Files { .. }
@@ -986,6 +1034,24 @@ mod tests {
             priority: CliPriority::High,
         };
         assert!(command_to_control_request(&command).is_err());
+    }
+
+    #[test]
+    fn parses_nested_tag_commands() {
+        let cli = Cli::try_parse_from([
+            "superseedr",
+            "tags",
+            "assign",
+            "Archive",
+            "4444444444444444444444444444444444444444",
+        ])
+        .expect("parse tags assign");
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Tags {
+                command: TagCommand::Assign { tag, targets }
+            }) if tag == "Archive" && targets.len() == 1
+        ));
     }
 
     #[test]

--- a/src/integrations/control.rs
+++ b/src/integrations/control.rs
@@ -5,6 +5,7 @@ use crate::app::FilePriority;
 use crate::fs_atomic::{
     deserialize_versioned_toml, serialize_versioned_toml, write_string_atomically,
 };
+use crate::tags::TagId;
 use serde::{Deserialize, Serialize};
 use sha1::{Digest, Sha1};
 use std::fs;
@@ -43,6 +44,28 @@ pub enum ControlRequest {
         interval_secs: u64,
     },
     StatusFollowStop,
+    CreateTag {
+        name: String,
+    },
+    CreateAndAssignTag {
+        name: String,
+        info_hashes: Vec<String>,
+    },
+    RenameTag {
+        tag_id: TagId,
+        new_name: String,
+    },
+    DeleteTag {
+        tag_id: TagId,
+    },
+    AssignTag {
+        tag_id: TagId,
+        info_hash_hex: String,
+    },
+    RemoveTag {
+        tag_id: TagId,
+        info_hash_hex: String,
+    },
     Pause {
         info_hash_hex: String,
     },
@@ -96,6 +119,12 @@ impl ControlRequest {
             Self::StatusNow => "status_now",
             Self::StatusFollowStart { .. } => "status_follow_start",
             Self::StatusFollowStop => "status_follow_stop",
+            Self::CreateTag { .. } => "create_tag",
+            Self::CreateAndAssignTag { .. } => "create_and_assign_tag",
+            Self::RenameTag { .. } => "rename_tag",
+            Self::DeleteTag { .. } => "delete_tag",
+            Self::AssignTag { .. } => "assign_tag",
+            Self::RemoveTag { .. } => "remove_tag",
             Self::Pause { .. } => "pause",
             Self::Resume { .. } => "resume",
             Self::Delete { .. } => "delete",
@@ -115,9 +144,16 @@ impl ControlRequest {
             | Self::SetFilePriority { info_hash_hex, .. }
             | Self::MoveTorrent { info_hash_hex, .. }
             | Self::SetTorrentConfig { info_hash_hex, .. } => Some(info_hash_hex.as_str()),
+            Self::AssignTag { info_hash_hex, .. } | Self::RemoveTag { info_hash_hex, .. } => {
+                Some(info_hash_hex.as_str())
+            }
             Self::StatusNow
             | Self::StatusFollowStart { .. }
             | Self::StatusFollowStop
+            | Self::CreateTag { .. }
+            | Self::CreateAndAssignTag { .. }
+            | Self::RenameTag { .. }
+            | Self::DeleteTag { .. }
             | Self::AddTorrentFile { .. }
             | Self::AddMagnet { .. } => None,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod resource_manager;
 mod storage;
 #[cfg(feature = "synthetic-load")]
 mod synthetic_load;
+mod tags;
 mod telemetry;
 mod theme;
 mod token_bucket;
@@ -65,7 +66,7 @@ use crate::integrations::cli::{
     command_to_control_requests_with_resolver, expand_add_inputs, require_cli_targets,
     status_command_mode, status_control_request, status_file_modified_at,
     wait_for_status_json_after, write_control_command, write_input_command,
-    write_path_command_payload, write_stop_command, Cli, Commands, StatusCommandMode,
+    write_path_command_payload, write_stop_command, Cli, Commands, StatusCommandMode, TagCommand,
 };
 #[cfg(test)]
 use crate::integrations::control::ControlPriorityTarget;
@@ -2318,6 +2319,13 @@ fn process_cli_request(
         Commands::Torrents => {
             process_torrents_command(settings, output_mode).map_err(io::Error::other)
         }
+        Commands::Tags { command } => process_tags_command(
+            settings,
+            command,
+            shared_mode,
+            leader_is_running,
+            output_mode,
+        ),
         Commands::Info { target } => {
             process_info_command(settings, target, output_mode).map_err(io::Error::other)
         }
@@ -3236,6 +3244,179 @@ fn process_torrents_command(settings: &Settings, output_mode: OutputMode) -> Res
     Ok(())
 }
 
+fn tag_details_value(settings: &Settings, tag: &crate::tags::TagDefinition) -> Value {
+    let torrents = settings
+        .torrents
+        .iter()
+        .filter(|torrent| torrent.tag_ids.contains(&tag.id))
+        .map(|torrent| {
+            json!({
+                "name": torrent.name,
+                "info_hash_hex": info_hash_from_torrent_source(&torrent.torrent_or_magnet)
+                    .map(hex::encode),
+            })
+        })
+        .collect::<Vec<_>>();
+    json!({
+        "id": tag.id,
+        "name": tag.name,
+        "origin": tag.origin,
+        "assignment_count": torrents.len(),
+        "torrents": torrents,
+    })
+}
+
+fn process_tags_command(
+    settings: &Settings,
+    command: &TagCommand,
+    shared_mode: bool,
+    leader_is_running: bool,
+    output_mode: OutputMode,
+) -> io::Result<()> {
+    match command {
+        TagCommand::List => {
+            let tags = settings
+                .tag_catalog
+                .tags
+                .iter()
+                .map(|tag| tag_details_value(settings, tag))
+                .collect::<Vec<_>>();
+            if output_mode == OutputMode::Json {
+                print_success(output_mode, "tags", "Listed tags.", json!({ "tags": tags }));
+            } else if settings.tag_catalog.tags.is_empty() {
+                println!("No tags configured.");
+            } else {
+                for tag in &settings.tag_catalog.tags {
+                    let count = settings
+                        .torrents
+                        .iter()
+                        .filter(|torrent| torrent.tag_ids.contains(&tag.id))
+                        .count();
+                    println!("{}\t{}\t{} torrent(s)", tag.id, tag.name, count);
+                }
+            }
+            Ok(())
+        }
+        TagCommand::Show { tag } => {
+            let tag = settings
+                .tag_catalog
+                .resolve(tag)
+                .map_err(io::Error::other)?;
+            if output_mode == OutputMode::Json {
+                print_success(
+                    output_mode,
+                    "tags",
+                    "Loaded tag.",
+                    json!({ "tag": tag_details_value(settings, tag) }),
+                );
+            } else {
+                println!("Tag: {}", tag.name);
+                println!("ID: {}", tag.id);
+                println!("Origin: {:?}", tag.origin);
+                println!("Torrents:");
+                let mut found = false;
+                for torrent in settings
+                    .torrents
+                    .iter()
+                    .filter(|torrent| torrent.tag_ids.contains(&tag.id))
+                {
+                    found = true;
+                    let hash = info_hash_from_torrent_source(&torrent.torrent_or_magnet)
+                        .map(hex::encode)
+                        .unwrap_or_else(|| "<unavailable>".to_string());
+                    println!("  {}\t{}", hash, torrent.name);
+                }
+                if !found {
+                    println!("  <none>");
+                }
+            }
+            Ok(())
+        }
+        TagCommand::Create { name } => process_control_requests(
+            settings,
+            &[ControlRequest::CreateTag { name: name.clone() }],
+            "tags",
+            shared_mode,
+            leader_is_running,
+            output_mode,
+        ),
+        TagCommand::Rename { tag, new_name } => {
+            let tag_id = settings
+                .tag_catalog
+                .resolve(tag)
+                .map_err(io::Error::other)?
+                .id;
+            process_control_requests(
+                settings,
+                &[ControlRequest::RenameTag {
+                    tag_id,
+                    new_name: new_name.clone(),
+                }],
+                "tags",
+                shared_mode,
+                leader_is_running,
+                output_mode,
+            )
+        }
+        TagCommand::Delete { tag } => {
+            let tag_id = settings
+                .tag_catalog
+                .resolve(tag)
+                .map_err(io::Error::other)?
+                .id;
+            process_control_requests(
+                settings,
+                &[ControlRequest::DeleteTag { tag_id }],
+                "tags",
+                shared_mode,
+                leader_is_running,
+                output_mode,
+            )
+        }
+        TagCommand::Assign { tag, targets } | TagCommand::Remove { tag, targets } => {
+            let tag_id = settings
+                .tag_catalog
+                .resolve(tag)
+                .map_err(io::Error::other)?
+                .id;
+            let command_name = if matches!(command, TagCommand::Assign { .. }) {
+                "tags assign"
+            } else {
+                "tags remove"
+            };
+            let targets = require_cli_targets(targets, command_name)
+                .map_err(|message| io::Error::new(io::ErrorKind::InvalidInput, message))?;
+            let requests = targets
+                .iter()
+                .map(|target| {
+                    resolve_target_info_hash(settings, target, command_name).map(|info_hash_hex| {
+                        if matches!(command, TagCommand::Assign { .. }) {
+                            ControlRequest::AssignTag {
+                                tag_id,
+                                info_hash_hex,
+                            }
+                        } else {
+                            ControlRequest::RemoveTag {
+                                tag_id,
+                                info_hash_hex,
+                            }
+                        }
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(io::Error::other)?;
+            process_control_requests(
+                settings,
+                &requests,
+                "tags",
+                shared_mode,
+                leader_is_running,
+                output_mode,
+            )
+        }
+    }
+}
+
 fn process_info_command(
     settings: &Settings,
     target: &str,
@@ -3275,6 +3456,20 @@ fn print_torrent_details(settings: &Settings, torrent: &crate::config::TorrentSe
         info_hash_hex.as_deref().unwrap_or("<unavailable>")
     );
     println!("Source: {}", torrent.torrent_or_magnet);
+    let tag_names = torrent
+        .tag_ids
+        .iter()
+        .filter_map(|id| settings.tag_catalog.get(*id))
+        .map(|tag| tag.name.as_str())
+        .collect::<Vec<_>>();
+    println!(
+        "Tags: {}",
+        if tag_names.is_empty() {
+            "<none>".to_string()
+        } else {
+            tag_names.join(", ")
+        }
+    );
     println!("Files:");
 
     match info_hash_hex.as_deref() {
@@ -3371,6 +3566,12 @@ fn torrent_details_value(settings: &Settings, torrent: &crate::config::TorrentSe
         },
         None => (json!([]), json!("info hash could not be derived")),
     };
+    let tags = torrent
+        .tag_ids
+        .iter()
+        .filter_map(|id| settings.tag_catalog.get(*id))
+        .map(|tag| json!({ "id": tag.id, "name": tag.name, "origin": tag.origin }))
+        .collect::<Vec<_>>();
 
     json!({
         "name": torrent.name,
@@ -3380,6 +3581,7 @@ fn torrent_details_value(settings: &Settings, torrent: &crate::config::TorrentSe
         "container_name": torrent.container_name,
         "torrent_control_state": torrent.torrent_control_state,
         "delete_files": torrent.delete_files,
+        "tags": tags,
         "file_priorities": torrent.file_priorities,
         "files": files,
         "files_error": files_error,
@@ -3401,6 +3603,7 @@ fn cli_command_name(command: Option<&Commands>) -> Option<&'static str> {
         Some(Commands::ToShared { .. }) => Some("to-shared"),
         Some(Commands::ToStandalone) => Some("to-standalone"),
         Some(Commands::Torrents) => Some("torrents"),
+        Some(Commands::Tags { .. }) => Some("tags"),
         Some(Commands::Info { .. }) => Some("info"),
         Some(Commands::Status { .. }) => Some("status"),
         Some(Commands::Pause { .. }) => Some("pause"),

--- a/src/persistence/README.md
+++ b/src/persistence/README.md
@@ -17,3 +17,8 @@ For RSS implementation:
 - RSS history is retention-capped at 1000 entries; oldest entries are pruned first on persist.
 
 The runtime should treat missing/corrupt `persistence/rss.toml` as recoverable and fall back to empty RSS state.
+
+Torrent tag definitions and assignments live with the torrent catalog rather
+than host-local runtime persistence. Standalone mode stores them in
+`settings.toml`; shared mode stores them atomically in `catalog.toml` so the
+leader, followers, TUI, and CLI observe one shared tag model.

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -1,0 +1,304 @@
+// SPDX-FileCopyrightText: 2026 The superseedr Contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use serde::{Deserialize, Serialize};
+
+pub type TagId = u64;
+
+const MAX_TAG_NAME_CHARS: usize = 64;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TagOrigin {
+    #[default]
+    Manual,
+    Generated {
+        provider: String,
+        key: String,
+    },
+}
+
+impl TagOrigin {
+    pub fn is_manual(&self) -> bool {
+        matches!(self, Self::Manual)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct TagDefinition {
+    pub id: TagId,
+    pub name: String,
+    pub origin: TagOrigin,
+}
+
+impl Default for TagDefinition {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            name: String::new(),
+            origin: TagOrigin::Manual,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct TagCatalog {
+    pub next_id: TagId,
+    pub tags: Vec<TagDefinition>,
+}
+
+impl Default for TagCatalog {
+    fn default() -> Self {
+        Self {
+            next_id: 1,
+            tags: Vec::new(),
+        }
+    }
+}
+
+impl TagCatalog {
+    pub fn create_manual(&mut self, name: &str) -> Result<TagId, String> {
+        let name = validate_tag_name(name)?;
+        self.ensure_unique_name(&name, None)?;
+
+        let mut id = self.next_id.max(1);
+        while self.tags.iter().any(|tag| tag.id == id) {
+            id = id
+                .checked_add(1)
+                .ok_or_else(|| "Tag ID space is exhausted".to_string())?;
+        }
+        self.next_id = id
+            .checked_add(1)
+            .ok_or_else(|| "Tag ID space is exhausted".to_string())?;
+        self.tags.push(TagDefinition {
+            id,
+            name,
+            origin: TagOrigin::Manual,
+        });
+        Ok(id)
+    }
+
+    pub fn rename_manual(&mut self, id: TagId, new_name: &str) -> Result<(), String> {
+        let new_name = validate_tag_name(new_name)?;
+        self.ensure_unique_name(&new_name, Some(id))?;
+        let tag = self
+            .tags
+            .iter_mut()
+            .find(|tag| tag.id == id)
+            .ok_or_else(|| format!("Tag '{}' was not found", id))?;
+        if !tag.origin.is_manual() {
+            return Err(format!("Generated tag '{}' cannot be renamed", tag.name));
+        }
+        tag.name = new_name;
+        Ok(())
+    }
+
+    pub fn delete_manual(&mut self, id: TagId) -> Result<TagDefinition, String> {
+        let index = self
+            .tags
+            .iter()
+            .position(|tag| tag.id == id)
+            .ok_or_else(|| format!("Tag '{}' was not found", id))?;
+        if !self.tags[index].origin.is_manual() {
+            return Err(format!(
+                "Generated tag '{}' cannot be deleted",
+                self.tags[index].name
+            ));
+        }
+        Ok(self.tags.remove(index))
+    }
+
+    pub fn get(&self, id: TagId) -> Option<&TagDefinition> {
+        self.tags.iter().find(|tag| tag.id == id)
+    }
+
+    pub fn resolve(&self, reference: &str) -> Result<&TagDefinition, String> {
+        let reference = reference.trim();
+        if let Ok(id) = reference.parse::<TagId>() {
+            if let Some(tag) = self.get(id) {
+                return Ok(tag);
+            }
+        }
+        self.tags
+            .iter()
+            .find(|tag| tag.name.eq_ignore_ascii_case(reference))
+            .ok_or_else(|| format!("Tag '{}' was not found", reference))
+    }
+
+    pub fn repair(&mut self) {
+        self.tags
+            .retain(|tag| tag.id != 0 && validate_tag_name(&tag.name).is_ok());
+        self.tags.sort_by_key(|tag| tag.id);
+        self.tags.dedup_by_key(|tag| tag.id);
+
+        let mut seen_names = Vec::<String>::new();
+        self.tags.retain(|tag| {
+            let folded = tag.name.to_ascii_lowercase();
+            if seen_names.contains(&folded) {
+                false
+            } else {
+                seen_names.push(folded);
+                true
+            }
+        });
+
+        let minimum_next = self
+            .tags
+            .iter()
+            .map(|tag| tag.id)
+            .max()
+            .unwrap_or(0)
+            .saturating_add(1)
+            .max(1);
+        self.next_id = self.next_id.max(minimum_next);
+    }
+
+    fn ensure_unique_name(&self, name: &str, except_id: Option<TagId>) -> Result<(), String> {
+        if self
+            .tags
+            .iter()
+            .any(|tag| Some(tag.id) != except_id && tag.name.eq_ignore_ascii_case(name))
+        {
+            return Err(format!("A tag named '{}' already exists", name));
+        }
+        Ok(())
+    }
+}
+
+pub fn validate_tag_name(name: &str) -> Result<String, String> {
+    let normalized = name.trim();
+    if normalized.is_empty() {
+        return Err("Tag name cannot be empty".to_string());
+    }
+    if normalized.chars().count() > MAX_TAG_NAME_CHARS {
+        return Err(format!(
+            "Tag name cannot be longer than {} characters",
+            MAX_TAG_NAME_CHARS
+        ));
+    }
+    if normalized.chars().any(char::is_control) {
+        return Err("Tag name cannot contain control characters".to_string());
+    }
+    if normalized.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(
+            "Tag name cannot be numeric because numbers are reserved for tag IDs".to_string(),
+        );
+    }
+    Ok(normalized.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manual_tag_lifecycle_keeps_stable_id() {
+        let mut catalog = TagCatalog::default();
+        let id = catalog.create_manual("Archive").expect("create tag");
+        catalog.rename_manual(id, "Research").expect("rename tag");
+        assert_eq!(
+            catalog.get(id).map(|tag| tag.name.as_str()),
+            Some("Research")
+        );
+        assert_eq!(catalog.delete_manual(id).expect("delete tag").id, id);
+    }
+
+    #[test]
+    fn names_are_trimmed_and_case_insensitively_unique() {
+        let mut catalog = TagCatalog::default();
+        catalog.create_manual("  Archive  ").expect("create tag");
+        let error = catalog
+            .create_manual("archive")
+            .expect_err("duplicate should fail");
+        assert!(error.contains("already exists"));
+    }
+
+    #[test]
+    fn numeric_names_are_rejected_for_create_and_rename() {
+        let mut catalog = TagCatalog::default();
+        let error = catalog
+            .create_manual("123")
+            .expect_err("numeric name should fail");
+        assert!(error.contains("reserved for tag IDs"));
+
+        let id = catalog.create_manual("Archive").expect("create tag");
+        let error = catalog
+            .rename_manual(id, "42")
+            .expect_err("numeric rename should fail");
+        assert!(error.contains("reserved for tag IDs"));
+        assert_eq!(
+            catalog.get(id).map(|tag| tag.name.as_str()),
+            Some("Archive")
+        );
+    }
+
+    #[test]
+    fn repair_uses_the_same_ascii_case_folding_as_name_resolution() {
+        let mut catalog = TagCatalog {
+            next_id: 1,
+            tags: vec![
+                TagDefinition {
+                    id: 1,
+                    name: "Äther".into(),
+                    origin: TagOrigin::Manual,
+                },
+                TagDefinition {
+                    id: 2,
+                    name: "äther".into(),
+                    origin: TagOrigin::Manual,
+                },
+                TagDefinition {
+                    id: 3,
+                    name: "ARCHIVE".into(),
+                    origin: TagOrigin::Manual,
+                },
+                TagDefinition {
+                    id: 4,
+                    name: "archive".into(),
+                    origin: TagOrigin::Manual,
+                },
+            ],
+        };
+
+        catalog.repair();
+
+        assert_eq!(
+            catalog
+                .tags
+                .iter()
+                .map(|tag| tag.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Äther", "äther", "ARCHIVE"]
+        );
+    }
+
+    #[test]
+    fn repair_drops_invalid_and_duplicate_entries_and_advances_id() {
+        let mut catalog = TagCatalog {
+            next_id: 1,
+            tags: vec![
+                TagDefinition {
+                    id: 2,
+                    name: "Archive".into(),
+                    origin: TagOrigin::Manual,
+                },
+                TagDefinition {
+                    id: 2,
+                    name: "Duplicate ID".into(),
+                    origin: TagOrigin::Manual,
+                },
+                TagDefinition {
+                    id: 3,
+                    name: "archive".into(),
+                    origin: TagOrigin::Manual,
+                },
+                TagDefinition::default(),
+            ],
+        };
+        catalog.repair();
+        assert_eq!(catalog.tags.len(), 1);
+        assert_eq!(catalog.next_id, 3);
+    }
+}

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -4,7 +4,8 @@
 use crate::app::{App, AppMode};
 use crate::tui::paste_burst::FlushResult as PasteBurstFlushResult;
 use crate::tui::screens::{
-    browser, config, delete_confirm, help, journal, normal, peers, power, rss, torrents, welcome,
+    browser, config, delete_confirm, help, journal, normal, peers, power, rss, tags, torrents,
+    welcome,
 };
 
 use ratatui::crossterm::event::{
@@ -201,6 +202,9 @@ async fn dispatch_mode_event(event: CrosstermEvent, app: &mut App) {
         }
         AppMode::TorrentManagement => {
             torrents::handle_event(event, app);
+        }
+        AppMode::TagManagement => {
+            tags::handle_event(event, app);
         }
         AppMode::PeerManagement => {
             peers::handle_event(event, &mut app.app_state);

--- a/src/tui/formatters.rs
+++ b/src/tui/formatters.rs
@@ -159,6 +159,17 @@ pub fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
         .split(popup_layout[1])[1]
 }
 
+pub fn centered_fixed_rect(area: Rect, width: u16, height: u16) -> Rect {
+    let width = width.min(area.width);
+    let height = height.min(area.height);
+    Rect::new(
+        area.x + area.width.saturating_sub(width) / 2,
+        area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    )
+}
+
 pub fn path_to_string(path: Option<&Path>) -> String {
     path.map(|p| p.to_string_lossy().to_string())
         .unwrap_or_else(|| "Not Set".to_string())

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -317,6 +317,13 @@ fn build_help_items(settings: &Settings, app_state: &AppState) -> Vec<HelpItem> 
     action_item!(
         HelpSection::General,
         "Global Routes",
+        "L",
+        "Open tag management",
+        ActionTone::Open
+    );
+    action_item!(
+        HelpSection::General,
+        "Global Routes",
         "P",
         "Open peer management",
         ActionTone::Open
@@ -595,6 +602,13 @@ fn build_help_items(settings: &Settings, app_state: &AppState) -> Vec<HelpItem> 
     action_item!(
         HelpSection::Screens,
         "Torrent Management",
+        "t",
+        "Open the inline tag picker for the selected torrents or current row",
+        ActionTone::Mode
+    );
+    action_item!(
+        HelpSection::Screens,
+        "Torrent Management",
         "d / D",
         "Queue remove, or purge files with D, for the current target set",
         ActionTone::Destructive
@@ -612,6 +626,48 @@ fn build_help_items(settings: &Settings, app_state: &AppState) -> Vec<HelpItem> 
         "u",
         "Clear the current selection and its draft commands",
         ActionTone::Clear
+    );
+    action_item!(
+        HelpSection::Screens,
+        "Tag Management",
+        "Left / Right / h / l",
+        "Move through tag filter pills; 0 returns to All torrents",
+        ActionTone::Navigate
+    );
+    action_item!(
+        HelpSection::Screens,
+        "Tag Management",
+        "Tab / Space",
+        "Focus filtered results; Space removes or restores the active tag assignment",
+        ActionTone::Toggle
+    );
+    action_item!(
+        HelpSection::Screens,
+        "Tag Management",
+        "t",
+        "Open the inline tag picker for the highlighted torrent",
+        ActionTone::Mode
+    );
+    action_item!(
+        HelpSection::Screens,
+        "Tag Management",
+        "m",
+        "Toggle assignment mode to include untagged torrents in the results",
+        ActionTone::Mode
+    );
+    action_item!(
+        HelpSection::Screens,
+        "Tag Management",
+        "n / e / d",
+        "Create, rename, or delete a manual tag",
+        ActionTone::Queue
+    );
+    action_item!(
+        HelpSection::Screens,
+        "Tag Management",
+        "/",
+        "Search torrent names and their file paths inside the active tag filter",
+        ActionTone::Search
     );
     action_item!(
         HelpSection::Screens,

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -11,5 +11,7 @@ pub mod normal;
 pub mod peers;
 pub mod power;
 pub mod rss;
+pub mod tag_picker;
+pub mod tags;
 pub mod torrents;
 pub mod welcome;

--- a/src/tui/screens/normal.rs
+++ b/src/tui/screens/normal.rs
@@ -414,6 +414,7 @@ pub enum UiAction {
     OpenJournal,
     OpenPeerManagement,
     OpenTorrentManagement,
+    OpenTagManagement,
     DataRateSlower,
     DataRateFaster,
     ThemePrev,
@@ -436,6 +437,7 @@ pub enum UiEffect {
     OpenJournalScreen,
     OpenPeerManagementScreen,
     OpenTorrentManagementScreen,
+    OpenTagManagementScreen,
     BroadcastManagerDataRate(u64),
     ApplyThemePrev,
     ApplyThemeNext,
@@ -596,6 +598,10 @@ pub fn reduce_ui_action_with_layout_mode(
         UiAction::OpenTorrentManagement => ReduceResult {
             redraw: true,
             effects: vec![UiEffect::OpenTorrentManagementScreen],
+        },
+        UiAction::OpenTagManagement => ReduceResult {
+            redraw: true,
+            effects: vec![UiEffect::OpenTagManagementScreen],
         },
         UiAction::DataRateSlower => {
             app_state.data_rate = app_state.data_rate.next_slower();
@@ -794,6 +800,7 @@ fn map_key_to_ui_action(key: KeyEvent) -> Option<UiAction> {
         KeyCode::Char('J') => Some(UiAction::OpenJournal),
         KeyCode::Char('P') => Some(UiAction::OpenPeerManagement),
         KeyCode::Char('M') => Some(UiAction::OpenTorrentManagement),
+        KeyCode::Char('L') => Some(UiAction::OpenTagManagement),
         KeyCode::Char('m') => Some(UiAction::OpenHelp),
         KeyCode::Char('[') | KeyCode::Char('{') => Some(UiAction::DataRateSlower),
         KeyCode::Char(']') | KeyCode::Char('}') => Some(UiAction::DataRateFaster),
@@ -7046,6 +7053,10 @@ async fn execute_ui_effect(app: &mut App, effect: UiEffect) {
             app.app_state.ui.torrent_management.review_scroll_offset = 0;
             app.app_state.mode = AppMode::TorrentManagement;
             torrents::initialize_torrent_management_cursor(&mut app.app_state);
+        }
+        UiEffect::OpenTagManagementScreen => {
+            app.app_state.mode = AppMode::TagManagement;
+            crate::tui::screens::tags::initialize(app);
         }
         UiEffect::HandlePastedText(text) => {
             handle_pasted_text(app, &text).await;

--- a/src/tui/screens/tag_picker.rs
+++ b/src/tui/screens/tag_picker.rs
@@ -1,0 +1,477 @@
+// SPDX-FileCopyrightText: 2026 The superseedr Contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::app::{App, AppCommand, AppState};
+use crate::config::{Settings, TorrentSettings};
+use crate::integrations::control::ControlRequest;
+use crate::tags::{TagDefinition, TagId};
+use crate::theme::ThemeContext;
+use crate::torrent_identity::info_hash_from_torrent_source;
+use crate::tui::action_style::{footer_key_style, ActionTone};
+use crate::tui::app_command::{spawn_app_command_batch_sender, spawn_app_command_sender};
+use crate::tui::formatters::{sanitize_text, truncate_with_ellipsis};
+use crate::tui::screen_context::ScreenContext;
+use crate::tui::screens::input_panel::draw_prompt_panel;
+use ratatui::crossterm::event::{Event as CrosstermEvent, KeyCode, KeyEventKind, KeyModifiers};
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Padding, Paragraph};
+use ratatui::Frame;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AssignmentState {
+    None,
+    Partial,
+    All,
+}
+
+pub fn is_open(app_state: &AppState) -> bool {
+    app_state.ui.tag_picker.open
+}
+
+pub fn open(app: &mut App, mut target_hashes: Vec<Vec<u8>>) {
+    target_hashes.sort();
+    target_hashes.dedup();
+    target_hashes.retain(|hash| app.app_state.torrents.contains_key(hash));
+    let picker = &mut app.app_state.ui.tag_picker;
+    picker.open = !target_hashes.is_empty();
+    picker.selected_index = 0;
+    picker.creating = false;
+    picker.input_buffer.clear();
+    picker.target_hashes = target_hashes;
+    picker.status_message = if picker.open {
+        None
+    } else {
+        Some("No torrents are selected".to_string())
+    };
+    app.app_state.ui.needs_redraw = true;
+}
+
+pub fn handle_event(event: CrosstermEvent, app: &mut App) -> bool {
+    if !is_open(&app.app_state) {
+        return false;
+    }
+    let CrosstermEvent::Key(key) = event else {
+        return false;
+    };
+    if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat)
+        || !matches!(key.modifiers, KeyModifiers::NONE | KeyModifiers::SHIFT)
+    {
+        return false;
+    }
+
+    if app.app_state.ui.tag_picker.creating {
+        return handle_create_input(key.code, app);
+    }
+
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('t') => close(app),
+        KeyCode::Up | KeyCode::Char('k') => move_selection(app, -1),
+        KeyCode::Down | KeyCode::Char('j') => move_selection(app, 1),
+        KeyCode::Home => app.app_state.ui.tag_picker.selected_index = 0,
+        KeyCode::End => {
+            app.app_state.ui.tag_picker.selected_index =
+                app.client_configs.tag_catalog.tags.len().saturating_sub(1);
+        }
+        KeyCode::Char('n') => {
+            let picker = &mut app.app_state.ui.tag_picker;
+            picker.creating = true;
+            picker.input_buffer.clear();
+            picker.status_message = None;
+        }
+        KeyCode::Enter | KeyCode::Char(' ') => toggle_selected_tag(app),
+        _ => return false,
+    }
+    clamp_selection(app);
+    app.app_state.ui.needs_redraw = true;
+    true
+}
+
+fn handle_create_input(key_code: KeyCode, app: &mut App) -> bool {
+    match key_code {
+        KeyCode::Esc => {
+            let picker = &mut app.app_state.ui.tag_picker;
+            picker.creating = false;
+            picker.input_buffer.clear();
+        }
+        KeyCode::Backspace => {
+            app.app_state.ui.tag_picker.input_buffer.pop();
+        }
+        KeyCode::Enter => create_and_assign(app),
+        KeyCode::Char(character) => {
+            app.app_state.ui.tag_picker.input_buffer.push(character);
+        }
+        _ => return false,
+    }
+    app.app_state.ui.needs_redraw = true;
+    true
+}
+
+fn close(app: &mut App) {
+    let picker = &mut app.app_state.ui.tag_picker;
+    picker.open = false;
+    picker.creating = false;
+    picker.input_buffer.clear();
+    picker.target_hashes.clear();
+    picker.status_message = None;
+}
+
+fn move_selection(app: &mut App, delta: isize) {
+    app.app_state.ui.tag_picker.selected_index = app
+        .app_state
+        .ui
+        .tag_picker
+        .selected_index
+        .saturating_add_signed(delta);
+}
+
+fn clamp_selection(app: &mut App) {
+    app.app_state.ui.tag_picker.selected_index = app
+        .app_state
+        .ui
+        .tag_picker
+        .selected_index
+        .min(app.client_configs.tag_catalog.tags.len().saturating_sub(1));
+}
+
+fn create_and_assign(app: &mut App) {
+    let name = app.app_state.ui.tag_picker.input_buffer.trim().to_string();
+    if name.is_empty() {
+        app.app_state.ui.tag_picker.status_message = Some("Tag name cannot be empty".to_string());
+        return;
+    }
+    let info_hashes = app
+        .app_state
+        .ui
+        .tag_picker
+        .target_hashes
+        .iter()
+        .map(hex::encode)
+        .collect::<Vec<_>>();
+    let target_count = info_hashes.len();
+    let request = ControlRequest::CreateAndAssignTag {
+        name: name.clone(),
+        info_hashes,
+    };
+    let picker = &mut app.app_state.ui.tag_picker;
+    picker.creating = false;
+    picker.input_buffer.clear();
+    picker.status_message = Some(format!(
+        "Creating '{name}' for {target_count} torrent{}",
+        if target_count == 1 { "" } else { "s" }
+    ));
+    spawn_app_command_sender(
+        app.app_command_tx.clone(),
+        app.shutdown_tx.subscribe(),
+        AppCommand::SubmitControlRequest(request),
+    );
+}
+
+fn toggle_selected_tag(app: &mut App) {
+    let Some(tag) = selected_tag(&app.client_configs, &app.app_state) else {
+        app.app_state.ui.tag_picker.status_message =
+            Some("Create a tag to begin assigning".to_string());
+        return;
+    };
+    if !tag.origin.is_manual() {
+        app.app_state.ui.tag_picker.status_message =
+            Some("Generated tags cannot be changed manually".to_string());
+        return;
+    }
+    let tag_id = tag.id;
+    let tag_name = tag.name.clone();
+    let targets = app.app_state.ui.tag_picker.target_hashes.clone();
+    let remove = matches!(
+        assignment_state(&app.client_configs, tag_id, &targets),
+        AssignmentState::All
+    );
+    let requests = targets
+        .iter()
+        .map(|hash| {
+            let info_hash_hex = hex::encode(hash);
+            let request = if remove {
+                ControlRequest::RemoveTag {
+                    tag_id,
+                    info_hash_hex,
+                }
+            } else {
+                ControlRequest::AssignTag {
+                    tag_id,
+                    info_hash_hex,
+                }
+            };
+            AppCommand::SubmitControlRequest(request)
+        })
+        .collect::<Vec<_>>();
+    app.app_state.ui.tag_picker.status_message = Some(format!(
+        "{} '{}' for {} torrent{}",
+        if remove { "Removing" } else { "Assigning" },
+        tag_name,
+        targets.len(),
+        if targets.len() == 1 { "" } else { "s" }
+    ));
+    spawn_app_command_batch_sender(
+        app.app_command_tx.clone(),
+        app.shutdown_tx.subscribe(),
+        requests,
+    );
+}
+
+fn selected_tag<'a>(settings: &'a Settings, app_state: &AppState) -> Option<&'a TagDefinition> {
+    settings
+        .tag_catalog
+        .tags
+        .get(app_state.ui.tag_picker.selected_index)
+}
+
+fn assignment_state(settings: &Settings, tag_id: TagId, targets: &[Vec<u8>]) -> AssignmentState {
+    let assigned = targets
+        .iter()
+        .filter(|hash| {
+            torrent_settings_for_hash(settings, hash)
+                .is_some_and(|torrent| torrent.tag_ids.contains(&tag_id))
+        })
+        .count();
+    match assigned {
+        0 => AssignmentState::None,
+        count if count == targets.len() => AssignmentState::All,
+        _ => AssignmentState::Partial,
+    }
+}
+
+fn torrent_settings_for_hash<'a>(
+    settings: &'a Settings,
+    target_hash: &[u8],
+) -> Option<&'a TorrentSettings> {
+    settings.torrents.iter().find(|torrent| {
+        info_hash_from_torrent_source(&torrent.torrent_or_magnet)
+            .is_some_and(|hash| hash.as_slice() == target_hash)
+    })
+}
+
+pub fn draw(frame: &mut Frame, screen: &ScreenContext<'_>) {
+    let picker = &screen.ui.ui.tag_picker;
+    if !picker.open {
+        return;
+    }
+    let ctx = screen.theme;
+    let area = centered_fixed(
+        frame.area(),
+        frame.area().width.min(64),
+        frame.area().height.min(18),
+    );
+    frame.render_widget(Clear, area);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .padding(Padding::new(2, 2, 1, 1))
+        .border_style(ctx.apply(Style::default().fg(ctx.state_selected())))
+        .title(Span::styled(
+            format!(
+                " Tags · {} torrent{} ",
+                picker.target_hashes.len(),
+                if picker.target_hashes.len() == 1 {
+                    ""
+                } else {
+                    "s"
+                }
+            ),
+            ctx.apply(
+                Style::default()
+                    .fg(ctx.state_selected())
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let rows = if picker.creating {
+        Layout::vertical([
+            Constraint::Length(3),
+            Constraint::Min(3),
+            Constraint::Length(1),
+        ])
+        .split(inner)
+    } else {
+        Layout::vertical([Constraint::Min(3), Constraint::Length(1)]).split(inner)
+    };
+    let list_index = usize::from(picker.creating);
+    let footer_index = list_index + 1;
+    if picker.creating {
+        draw_prompt_panel(
+            frame,
+            rows[0],
+            " New tag and assign ".to_string(),
+            sanitize_text(&picker.input_buffer),
+            Vec::new(),
+            ctx,
+        );
+    }
+
+    draw_tag_list(frame, rows[list_index], screen);
+    draw_footer(frame, rows[footer_index], picker.creating, ctx);
+}
+
+fn draw_tag_list(frame: &mut Frame, area: Rect, screen: &ScreenContext<'_>) {
+    let picker = &screen.ui.ui.tag_picker;
+    let ctx = screen.theme;
+    let items = screen
+        .settings
+        .tag_catalog
+        .tags
+        .iter()
+        .map(|tag| {
+            let (marker, marker_color) =
+                match assignment_state(screen.settings, tag.id, &picker.target_hashes) {
+                    AssignmentState::None => ("[ ]", ctx.theme.semantic.overlay0),
+                    AssignmentState::Partial => ("[~]", ctx.state_warning()),
+                    AssignmentState::All => ("[x]", ctx.state_success()),
+                };
+            let count = screen
+                .settings
+                .torrents
+                .iter()
+                .filter(|torrent| torrent.tag_ids.contains(&tag.id))
+                .count();
+            ListItem::new(Line::from(vec![
+                Span::styled(
+                    format!("{marker} "),
+                    ctx.apply(Style::default().fg(marker_color)),
+                ),
+                Span::styled(
+                    truncate_with_ellipsis(&sanitize_text(&tag.name), 36),
+                    ctx.apply(Style::default().fg(ctx.theme.semantic.text)),
+                ),
+                Span::styled(
+                    format!("  {count}"),
+                    ctx.apply(Style::default().fg(ctx.theme.semantic.overlay0)),
+                ),
+            ]))
+        })
+        .collect::<Vec<_>>();
+    if items.is_empty() {
+        frame.render_widget(
+            Paragraph::new(vec![
+                Line::from(Span::styled(
+                    "No tags yet",
+                    ctx.apply(
+                        Style::default()
+                            .fg(ctx.state_warning())
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                )),
+                Line::from("Press n to create and assign one here."),
+            ])
+            .alignment(Alignment::Center),
+            area,
+        );
+        return;
+    }
+    let mut state = ListState::default();
+    state.select(Some(
+        picker.selected_index.min(items.len().saturating_sub(1)),
+    ));
+    let mut list = List::new(items).highlight_symbol("▶ ").highlight_style(
+        ctx.apply(
+            Style::default()
+                .fg(ctx.state_warning())
+                .add_modifier(Modifier::BOLD),
+        ),
+    );
+    if let Some(message) = &picker.status_message {
+        list = list.block(Block::default().title_bottom(Span::styled(
+            format!(" {} ", truncate_with_ellipsis(&sanitize_text(message), 52)),
+            ctx.apply(Style::default().fg(ctx.state_info())),
+        )));
+    }
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+fn draw_footer(frame: &mut Frame, area: Rect, creating: bool, ctx: &ThemeContext) {
+    let actions = if creating {
+        vec![
+            ("Enter", "create + assign", ActionTone::Confirm),
+            ("Esc", "cancel", ActionTone::Cancel),
+        ]
+    } else {
+        vec![
+            ("↑/↓", "tag", ActionTone::Navigate),
+            ("Space", "toggle", ActionTone::Toggle),
+            ("n", "new + assign", ActionTone::Add),
+            ("Esc", "close", ActionTone::Cancel),
+        ]
+    };
+    let mut spans = Vec::new();
+    for (index, (key, label, tone)) in actions.into_iter().enumerate() {
+        if index > 0 {
+            spans.push(Span::styled(
+                " | ",
+                ctx.apply(Style::default().fg(ctx.theme.semantic.overlay0)),
+            ));
+        }
+        spans.push(Span::styled(
+            format!("[{key}]"),
+            footer_key_style(ctx, tone),
+        ));
+        spans.push(Span::styled(
+            label,
+            ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0)),
+        ));
+    }
+    frame.render_widget(
+        Paragraph::new(Line::from(spans)).alignment(Alignment::Center),
+        area,
+    );
+}
+
+fn centered_fixed(area: Rect, width: u16, height: u16) -> Rect {
+    Rect::new(
+        area.x + area.width.saturating_sub(width) / 2,
+        area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn assignment_state_reports_none_partial_and_all() {
+        let mut settings = Settings::default();
+        let tag_id = settings
+            .tag_catalog
+            .create_manual("Curated")
+            .expect("create tag");
+        let first = vec![0x11; 20];
+        let second = vec![0x22; 20];
+        settings.torrents = vec![
+            TorrentSettings {
+                torrent_or_magnet: format!("magnet:?xt=urn:btih:{}", hex::encode(&first)),
+                name: "Sample Archive".to_string(),
+                ..Default::default()
+            },
+            TorrentSettings {
+                torrent_or_magnet: format!("magnet:?xt=urn:btih:{}", hex::encode(&second)),
+                name: "Field Notes".to_string(),
+                ..Default::default()
+            },
+        ];
+        let targets = vec![first, second];
+        assert_eq!(
+            assignment_state(&settings, tag_id, &targets),
+            AssignmentState::None
+        );
+        settings.torrents[0].tag_ids.push(tag_id);
+        assert_eq!(
+            assignment_state(&settings, tag_id, &targets),
+            AssignmentState::Partial
+        );
+        settings.torrents[1].tag_ids.push(tag_id);
+        assert_eq!(
+            assignment_state(&settings, tag_id, &targets),
+            AssignmentState::All
+        );
+    }
+}

--- a/src/tui/screens/tag_picker.rs
+++ b/src/tui/screens/tag_picker.rs
@@ -9,7 +9,7 @@ use crate::theme::ThemeContext;
 use crate::torrent_identity::info_hash_from_torrent_source;
 use crate::tui::action_style::{footer_key_style, ActionTone};
 use crate::tui::app_command::{spawn_app_command_batch_sender, spawn_app_command_sender};
-use crate::tui::formatters::{sanitize_text, truncate_with_ellipsis};
+use crate::tui::formatters::{centered_fixed_rect, sanitize_text, truncate_with_ellipsis};
 use crate::tui::screen_context::ScreenContext;
 use crate::tui::screens::input_panel::draw_prompt_panel;
 use ratatui::crossterm::event::{Event as CrosstermEvent, KeyCode, KeyEventKind, KeyModifiers};
@@ -282,7 +282,7 @@ pub fn draw(frame: &mut Frame, screen: &ScreenContext<'_>) {
         return;
     }
     let ctx = screen.theme;
-    let area = centered_fixed(
+    let area = centered_fixed_rect(
         frame.area(),
         frame.area().width.min(64),
         frame.area().height.min(18),
@@ -448,15 +448,6 @@ fn draw_footer(frame: &mut Frame, area: Rect, creating: bool, ctx: &ThemeContext
         Paragraph::new(Line::from(spans)).alignment(Alignment::Center),
         area,
     );
-}
-
-fn centered_fixed(area: Rect, width: u16, height: u16) -> Rect {
-    Rect::new(
-        area.x + area.width.saturating_sub(width) / 2,
-        area.y + area.height.saturating_sub(height) / 2,
-        width,
-        height,
-    )
 }
 
 #[cfg(test)]

--- a/src/tui/screens/tag_picker.rs
+++ b/src/tui/screens/tag_picker.rs
@@ -4,7 +4,7 @@
 use crate::app::{App, AppCommand, AppState};
 use crate::config::{Settings, TorrentSettings};
 use crate::integrations::control::ControlRequest;
-use crate::tags::{TagDefinition, TagId};
+use crate::tags::{validate_tag_name, TagDefinition, TagId};
 use crate::theme::ThemeContext;
 use crate::torrent_identity::info_hash_from_torrent_source;
 use crate::tui::action_style::{footer_key_style, ActionTone};
@@ -33,7 +33,8 @@ pub fn is_open(app_state: &AppState) -> bool {
 pub fn open(app: &mut App, mut target_hashes: Vec<Vec<u8>>) {
     target_hashes.sort();
     target_hashes.dedup();
-    target_hashes.retain(|hash| app.app_state.torrents.contains_key(hash));
+    target_hashes
+        .retain(|hash| target_exists(&app.client_configs, &app.app_state, hash.as_slice()));
     let picker = &mut app.app_state.ui.tag_picker;
     picker.open = !target_hashes.is_empty();
     picker.selected_index = 0;
@@ -46,6 +47,10 @@ pub fn open(app: &mut App, mut target_hashes: Vec<Vec<u8>>) {
         Some("No torrents are selected".to_string())
     };
     app.app_state.ui.needs_redraw = true;
+}
+
+fn target_exists(settings: &Settings, app_state: &AppState, hash: &[u8]) -> bool {
+    app_state.torrents.contains_key(hash) || torrent_settings_for_hash(settings, hash).is_some()
 }
 
 pub fn handle_event(event: CrosstermEvent, app: &mut App) -> bool {
@@ -74,7 +79,7 @@ pub fn handle_event(event: CrosstermEvent, app: &mut App) -> bool {
             app.app_state.ui.tag_picker.selected_index =
                 app.client_configs.tag_catalog.tags.len().saturating_sub(1);
         }
-        KeyCode::Char('n') => {
+        KeyCode::Char('a') => {
             let picker = &mut app.app_state.ui.tag_picker;
             picker.creating = true;
             picker.input_buffer.clear();
@@ -136,29 +141,24 @@ fn clamp_selection(app: &mut App) {
 }
 
 fn create_and_assign(app: &mut App) {
-    let name = app.app_state.ui.tag_picker.input_buffer.trim().to_string();
-    if name.is_empty() {
-        app.app_state.ui.tag_picker.status_message = Some("Tag name cannot be empty".to_string());
-        return;
-    }
-    let info_hashes = app
-        .app_state
-        .ui
-        .tag_picker
-        .target_hashes
-        .iter()
-        .map(hex::encode)
-        .collect::<Vec<_>>();
-    let target_count = info_hashes.len();
-    let request = ControlRequest::CreateAndAssignTag {
-        name: name.clone(),
-        info_hashes,
+    let picker = &app.app_state.ui.tag_picker;
+    let prepared = prepare_create_and_assign_request(
+        &app.client_configs,
+        &picker.input_buffer,
+        &picker.target_hashes,
+    );
+    let (name, request, target_count) = match prepared {
+        Ok(prepared) => prepared,
+        Err(message) => {
+            app.app_state.ui.tag_picker.status_message = Some(message);
+            return;
+        }
     };
     let picker = &mut app.app_state.ui.tag_picker;
     picker.creating = false;
     picker.input_buffer.clear();
     picker.status_message = Some(format!(
-        "Creating '{name}' for {target_count} torrent{}",
+        "Submitting '{name}' for {target_count} torrent{}",
         if target_count == 1 { "" } else { "s" }
     ));
     spawn_app_command_sender(
@@ -166,6 +166,32 @@ fn create_and_assign(app: &mut App) {
         app.shutdown_tx.subscribe(),
         AppCommand::SubmitControlRequest(request),
     );
+}
+
+fn prepare_create_and_assign_request(
+    settings: &Settings,
+    input: &str,
+    target_hashes: &[Vec<u8>],
+) -> Result<(String, ControlRequest, usize), String> {
+    let name = validate_tag_name(input)?;
+    if settings
+        .tag_catalog
+        .tags
+        .iter()
+        .any(|tag| tag.name.eq_ignore_ascii_case(&name))
+    {
+        return Err(format!("A tag named '{}' already exists", name));
+    }
+    if target_hashes.is_empty() {
+        return Err("At least one torrent is required when creating an assigned tag".to_string());
+    }
+    let info_hashes = target_hashes.iter().map(hex::encode).collect::<Vec<_>>();
+    let target_count = info_hashes.len();
+    let request = ControlRequest::CreateAndAssignTag {
+        name: name.clone(),
+        info_hashes,
+    };
+    Ok((name, request, target_count))
 }
 
 fn toggle_selected_tag(app: &mut App) {
@@ -360,7 +386,7 @@ fn draw_tag_list(frame: &mut Frame, area: Rect, screen: &ScreenContext<'_>) {
                             .add_modifier(Modifier::BOLD),
                     ),
                 )),
-                Line::from("Press n to create and assign one here."),
+                Line::from("Press a to add and assign one here."),
             ])
             .alignment(Alignment::Center),
             area,
@@ -397,7 +423,7 @@ fn draw_footer(frame: &mut Frame, area: Rect, creating: bool, ctx: &ThemeContext
         vec![
             ("↑/↓", "tag", ActionTone::Navigate),
             ("Space", "toggle", ActionTone::Toggle),
-            ("n", "new + assign", ActionTone::Add),
+            ("a", "add tag", ActionTone::Add),
             ("Esc", "close", ActionTone::Cancel),
         ]
     };
@@ -473,5 +499,49 @@ mod tests {
             assignment_state(&settings, tag_id, &targets),
             AssignmentState::All
         );
+    }
+
+    #[test]
+    fn create_and_assign_preflight_rejects_numeric_name_without_claiming_submission() {
+        let error =
+            prepare_create_and_assign_request(&Settings::default(), "123", &[vec![0x11; 20]])
+                .expect_err("numeric tag name should fail locally");
+
+        assert!(error.contains("reserved for tag IDs"));
+    }
+
+    #[test]
+    fn create_and_assign_preflight_builds_atomic_request_for_persisted_target() {
+        let (name, request, target_count) = prepare_create_and_assign_request(
+            &Settings::default(),
+            "Review Queue",
+            &[vec![0x11; 20]],
+        )
+        .expect("valid create and assign request");
+
+        assert_eq!(name, "Review Queue");
+        assert_eq!(target_count, 1);
+        assert_eq!(
+            request,
+            ControlRequest::CreateAndAssignTag {
+                name: "Review Queue".to_string(),
+                info_hashes: vec!["1111111111111111111111111111111111111111".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn persisted_torrent_is_a_valid_picker_target_without_runtime_state() {
+        let hash = vec![0x11; 20];
+        let settings = Settings {
+            torrents: vec![TorrentSettings {
+                torrent_or_magnet: format!("magnet:?xt=urn:btih:{}", hex::encode(&hash)),
+                name: "Queued Dataset".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        assert!(target_exists(&settings, &AppState::default(), &hash));
     }
 }

--- a/src/tui/screens/tags.rs
+++ b/src/tui/screens/tags.rs
@@ -13,7 +13,9 @@ use crate::theme::ThemeContext;
 use crate::torrent_identity::info_hash_from_torrent_source;
 use crate::tui::action_style::{footer_key_style, ActionTone};
 use crate::tui::app_command::spawn_app_command_sender;
-use crate::tui::formatters::{centered_rect, format_bytes, sanitize_text, truncate_with_ellipsis};
+use crate::tui::formatters::{
+    centered_fixed_rect, centered_rect, format_bytes, sanitize_text, truncate_with_ellipsis,
+};
 use crate::tui::screen_context::ScreenContext;
 use crate::tui::screens::{input_panel::draw_prompt_panel, tag_picker};
 use crate::tui::tree::RawNode;
@@ -470,19 +472,6 @@ fn preview_tree_contains_query(nodes: &[RawNode<TorrentPreviewPayload>], query: 
     false
 }
 
-fn count_preview_files(nodes: &[RawNode<TorrentPreviewPayload>]) -> usize {
-    nodes
-        .iter()
-        .map(|node| {
-            if node.is_dir {
-                count_preview_files(&node.children)
-            } else {
-                1
-            }
-        })
-        .sum()
-}
-
 fn collect_first_preview_files(
     nodes: &[RawNode<TorrentPreviewPayload>],
     rows: &mut Vec<FilePreviewRow>,
@@ -528,28 +517,51 @@ fn collect_matching_preview_files(
 }
 
 fn summarize_preview_files(
-    torrent: &TorrentSettings,
     runtime: Option<&TorrentDisplayState>,
-    query: &str,
+    query: Option<&str>,
 ) -> FilePreviewSummary {
     let Some(runtime) = runtime else {
         return FilePreviewSummary::default();
     };
-    let query = query.trim().to_lowercase();
-    if query.is_empty() || torrent.name.to_lowercase().contains(&query) {
+    let Some(query) = query else {
         let mut rows = Vec::with_capacity(MAX_FILES_PER_TORRENT);
         collect_first_preview_files(&runtime.file_preview_tree, &mut rows);
         return FilePreviewSummary {
-            total_files: runtime
-                .latest_state
-                .file_count
-                .unwrap_or_else(|| count_preview_files(&runtime.file_preview_tree)),
+            total_files: runtime.latest_state.file_count.unwrap_or(rows.len()),
             rows,
         };
-    }
+    };
     let mut summary = FilePreviewSummary::default();
-    collect_matching_preview_files(&runtime.file_preview_tree, &query, &mut summary);
+    collect_matching_preview_files(&runtime.file_preview_tree, query, &mut summary);
     summary
+}
+
+fn rendered_torrents<'a>(
+    settings: &'a Settings,
+    app_state: &'a AppState,
+    state: &TagManagementUiState,
+) -> Vec<(
+    &'a TorrentSettings,
+    Option<&'a TorrentDisplayState>,
+    FilePreviewSummary,
+)> {
+    let selected_tag = selected_tag_id(settings, state);
+    let query = state.search_query.trim().to_lowercase();
+    settings
+        .torrents
+        .iter()
+        .filter(|torrent| {
+            state.assignment_mode
+                || selected_tag.is_none_or(|tag_id| torrent.tag_ids.contains(&tag_id))
+        })
+        .filter_map(|torrent| {
+            let runtime = runtime_torrent(torrent, app_state);
+            let name_matches = query.is_empty() || torrent.name.to_lowercase().contains(&query);
+            let summary =
+                summarize_preview_files(runtime, (!name_matches).then_some(query.as_str()));
+            (name_matches || summary.total_files > 0).then_some((torrent, runtime, summary))
+        })
+        .collect()
 }
 
 pub fn draw(frame: &mut Frame, screen: &ScreenContext<'_>) {
@@ -733,16 +745,8 @@ fn draw_tag_filters(
 fn draw_results(frame: &mut Frame, area: Rect, screen: &ScreenContext<'_>) {
     let state = &screen.ui.ui.tag_management;
     let ctx = screen.theme;
-    let torrents = visible_torrents(screen.settings, screen.ui, state);
-    let query = state.search_query.as_str();
-    let rendered_torrents = torrents
-        .iter()
-        .map(|torrent| {
-            let runtime = runtime_torrent(torrent, screen.ui);
-            let summary = summarize_preview_files(torrent, runtime, query);
-            (*torrent, runtime, summary)
-        })
-        .collect::<Vec<_>>();
+    let rendered_torrents = rendered_torrents(screen.settings, screen.ui, state);
+    let torrent_count = rendered_torrents.len();
     let file_count = rendered_torrents
         .iter()
         .map(|(_, _, summary)| summary.total_files)
@@ -759,8 +763,8 @@ fn draw_results(frame: &mut Frame, area: Rect, screen: &ScreenContext<'_>) {
     };
     let title = format!(
         " {surface_label} · {} torrent{} · {} file{} ",
-        torrents.len(),
-        if torrents.len() == 1 { "" } else { "s" },
+        torrent_count,
+        if torrent_count == 1 { "" } else { "s" },
         file_count,
         if file_count == 1 { "" } else { "s" },
     );
@@ -789,7 +793,7 @@ fn draw_results(frame: &mut Frame, area: Rect, screen: &ScreenContext<'_>) {
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    if torrents.is_empty() {
+    if rendered_torrents.is_empty() {
         let message = if state.search_query.is_empty() {
             "No torrents use this tag yet"
         } else {
@@ -812,7 +816,7 @@ fn draw_results(frame: &mut Frame, area: Rect, screen: &ScreenContext<'_>) {
             ])
             .alignment(Alignment::Center)
             .wrap(Wrap { trim: true }),
-            centered_fixed(inner, inner.width.min(54), 2),
+            centered_fixed_rect(inner, inner.width.min(54), 2),
         );
         return;
     }
@@ -1126,7 +1130,7 @@ fn draw_delete_confirmation(
         .iter()
         .filter(|torrent| torrent.tag_ids.contains(&tag_id))
         .count();
-    let dialog = centered_fixed(area, area.width.min(58), area.height.min(9));
+    let dialog = centered_fixed_rect(area, area.width.min(58), area.height.min(9));
     frame.render_widget(Clear, dialog);
     let block = Block::default()
         .borders(Borders::ALL)
@@ -1161,17 +1165,6 @@ fn draw_delete_confirmation(
         .wrap(Wrap { trim: true }),
         inner,
     );
-}
-
-fn centered_fixed(area: Rect, width: u16, height: u16) -> Rect {
-    let width = width.min(area.width);
-    let height = height.min(area.height);
-    Rect::new(
-        area.x + area.width.saturating_sub(width) / 2,
-        area.y + area.height.saturating_sub(height) / 2,
-        width,
-        height,
-    )
 }
 
 #[cfg(test)]
@@ -1350,10 +1343,6 @@ mod tests {
 
     #[test]
     fn normal_preview_summary_uses_cached_count_and_caps_materialized_rows() {
-        let torrent = TorrentSettings {
-            name: "Large Fictional Dataset".to_string(),
-            ..Default::default()
-        };
         let files = (0..10)
             .map(|index| RawNode {
                 name: format!("part-{index}.bin"),
@@ -1376,7 +1365,7 @@ mod tests {
             ..Default::default()
         };
 
-        let summary = summarize_preview_files(&torrent, Some(&runtime), "");
+        let summary = summarize_preview_files(Some(&runtime), None);
 
         assert_eq!(summary.total_files, 100_000);
         assert_eq!(summary.rows.len(), MAX_FILES_PER_TORRENT);

--- a/src/tui/screens/tags.rs
+++ b/src/tui/screens/tags.rs
@@ -37,11 +37,27 @@ struct FilePreviewRow {
 
 struct ResultItemContext<'a> {
     settings: &'a Settings,
-    query: &'a str,
     active_tag_id: Option<TagId>,
     assignment_mode: bool,
     width: u16,
     theme: &'a ThemeContext,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DeleteConfirmationInput {
+    Confirm,
+    Cancel,
+    Consume,
+}
+
+fn delete_confirmation_input(key_code: KeyCode) -> DeleteConfirmationInput {
+    match key_code {
+        KeyCode::Enter | KeyCode::Char('y') | KeyCode::Char('Y') => {
+            DeleteConfirmationInput::Confirm
+        }
+        KeyCode::Esc | KeyCode::Char('q') => DeleteConfirmationInput::Cancel,
+        _ => DeleteConfirmationInput::Consume,
+    }
 }
 
 pub fn initialize(app: &mut App) {
@@ -74,22 +90,35 @@ pub fn handle_event(event: CrosstermEvent, app: &mut App) -> bool {
         return false;
     }
 
+    if app
+        .app_state
+        .ui
+        .tag_management
+        .delete_confirm_tag_id
+        .is_some()
+    {
+        match delete_confirmation_input(key.code) {
+            DeleteConfirmationInput::Confirm => {
+                if let Some(tag_id) = app.app_state.ui.tag_management.delete_confirm_tag_id.take() {
+                    submit_request(app, ControlRequest::DeleteTag { tag_id });
+                }
+            }
+            DeleteConfirmationInput::Cancel => {
+                app.app_state.ui.tag_management.delete_confirm_tag_id.take();
+            }
+            DeleteConfirmationInput::Consume => {}
+        }
+        app.app_state.ui.needs_redraw = true;
+        return true;
+    }
+
     if app.app_state.ui.tag_management.input_mode.is_some() {
         return handle_input_key(key.code, app);
     }
 
     match key.code {
         KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('L') => {
-            if app
-                .app_state
-                .ui
-                .tag_management
-                .delete_confirm_tag_id
-                .take()
-                .is_none()
-            {
-                app.app_state.mode = AppMode::Normal;
-            }
+            app.app_state.mode = AppMode::Normal;
         }
         KeyCode::Tab | KeyCode::BackTab => toggle_focus(app),
         KeyCode::Left | KeyCode::Char('h') => move_selection(app, -1),
@@ -120,18 +149,11 @@ pub fn handle_event(event: CrosstermEvent, app: &mut App) -> bool {
         KeyCode::Char('e') => begin_rename(app),
         KeyCode::Char('d') => begin_delete(app),
         KeyCode::Enter => {
-            if let Some(tag_id) = app.app_state.ui.tag_management.delete_confirm_tag_id.take() {
-                submit_request(app, ControlRequest::DeleteTag { tag_id });
-            } else if matches!(
+            if matches!(
                 app.app_state.ui.tag_management.active_pane,
                 TagManagementPane::Tags
             ) {
                 app.app_state.ui.tag_management.active_pane = TagManagementPane::Torrents;
-            }
-        }
-        KeyCode::Char('y') | KeyCode::Char('Y') => {
-            if let Some(tag_id) = app.app_state.ui.tag_management.delete_confirm_tag_id.take() {
-                submit_request(app, ControlRequest::DeleteTag { tag_id });
             }
         }
         KeyCode::Char(' ') => toggle_selected_assignment(app),
@@ -197,9 +219,15 @@ fn toggle_focus(app: &mut App) {
 }
 
 fn toggle_assignment_mode(app: &mut App) {
-    if selected_tag(&app.client_configs, &app.app_state.ui.tag_management).is_none() {
+    let selected = selected_tag(&app.client_configs, &app.app_state.ui.tag_management);
+    let Some(tag) = selected else {
         app.app_state.ui.tag_management.status_message =
             Some("Choose a tag before managing assignments".to_string());
+        return;
+    };
+    if !tag.origin.is_manual() {
+        app.app_state.ui.tag_management.status_message =
+            Some("Generated tags cannot be changed manually".to_string());
         return;
     }
     let state = &mut app.app_state.ui.tag_management;
@@ -234,19 +262,34 @@ fn begin_rename(app: &mut App) {
             Some("Choose a tag before renaming".to_string());
         return;
     };
+    if app
+        .client_configs
+        .tag_catalog
+        .get(tag_id)
+        .is_some_and(|tag| !tag.origin.is_manual())
+    {
+        app.app_state.ui.tag_management.status_message =
+            Some("Generated tags cannot be renamed manually".to_string());
+        return;
+    }
     let state = &mut app.app_state.ui.tag_management;
     state.input_buffer = name;
     state.input_mode = Some(TagInputMode::Rename(tag_id));
 }
 
 fn begin_delete(app: &mut App) {
-    let selected_tag_id =
-        selected_tag(&app.client_configs, &app.app_state.ui.tag_management).map(|tag| tag.id);
-    let Some(tag_id) = selected_tag_id else {
+    let selected = selected_tag(&app.client_configs, &app.app_state.ui.tag_management)
+        .map(|tag| (tag.id, tag.origin.is_manual()));
+    let Some((tag_id, is_manual)) = selected else {
         app.app_state.ui.tag_management.status_message =
             Some("Choose a tag before deleting".to_string());
         return;
     };
+    if !is_manual {
+        app.app_state.ui.tag_management.status_message =
+            Some("Generated tags cannot be deleted manually".to_string());
+        return;
+    }
     app.app_state.ui.tag_management.delete_confirm_tag_id = Some(tag_id);
 }
 
@@ -262,11 +305,17 @@ fn submit_request(app: &mut App, request: ControlRequest) {
 
 fn toggle_selected_assignment(app: &mut App) {
     let state = &app.app_state.ui.tag_management;
-    let Some(tag_id) = selected_tag(&app.client_configs, state).map(|tag| tag.id) else {
+    let Some(tag) = selected_tag(&app.client_configs, state) else {
         app.app_state.ui.tag_management.status_message =
             Some("Choose a tag filter before changing assignments".to_string());
         return;
     };
+    if !tag.origin.is_manual() {
+        app.app_state.ui.tag_management.status_message =
+            Some("Generated tags cannot be changed manually".to_string());
+        return;
+    }
+    let tag_id = tag.id;
     let selected_torrent = visible_torrents(&app.client_configs, &app.app_state, state)
         .get(state.selected_torrent_index)
         .copied();
@@ -385,11 +434,8 @@ fn torrent_matches_query(torrent: &TorrentSettings, app_state: &AppState, query:
     if query.is_empty() || torrent.name.to_lowercase().contains(query) {
         return true;
     }
-    runtime_torrent(torrent, app_state).is_some_and(|runtime| {
-        preview_files(runtime)
-            .iter()
-            .any(|file| file.path.to_lowercase().contains(query))
-    })
+    runtime_torrent(torrent, app_state)
+        .is_some_and(|runtime| preview_tree_contains_query(&runtime.file_preview_tree, query))
 }
 
 fn runtime_torrent<'a>(
@@ -400,21 +446,55 @@ fn runtime_torrent<'a>(
     app_state.torrents.get(info_hash.as_slice())
 }
 
-fn preview_files(torrent: &TorrentDisplayState) -> Vec<FilePreviewRow> {
-    let mut files = Vec::new();
-    collect_preview_files(&torrent.file_preview_tree, &mut files);
-    files
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct FilePreviewSummary {
+    total_files: usize,
+    rows: Vec<FilePreviewRow>,
 }
 
-fn collect_preview_files(
-    nodes: &[RawNode<TorrentPreviewPayload>],
-    files: &mut Vec<FilePreviewRow>,
-) {
+fn preview_tree_contains_query(nodes: &[RawNode<TorrentPreviewPayload>], query: &str) -> bool {
     for node in nodes {
         if node.is_dir {
-            collect_preview_files(&node.children, files);
+            if preview_tree_contains_query(&node.children, query) {
+                return true;
+            }
+        } else if node
+            .full_path
+            .to_string_lossy()
+            .to_lowercase()
+            .contains(query)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn count_preview_files(nodes: &[RawNode<TorrentPreviewPayload>]) -> usize {
+    nodes
+        .iter()
+        .map(|node| {
+            if node.is_dir {
+                count_preview_files(&node.children)
+            } else {
+                1
+            }
+        })
+        .sum()
+}
+
+fn collect_first_preview_files(
+    nodes: &[RawNode<TorrentPreviewPayload>],
+    rows: &mut Vec<FilePreviewRow>,
+) {
+    for node in nodes {
+        if rows.len() >= MAX_FILES_PER_TORRENT {
+            return;
+        }
+        if node.is_dir {
+            collect_first_preview_files(&node.children, rows);
         } else {
-            files.push(FilePreviewRow {
+            rows.push(FilePreviewRow {
                 path: node.full_path.to_string_lossy().to_string(),
                 size: node.payload.size,
             });
@@ -422,23 +502,54 @@ fn collect_preview_files(
     }
 }
 
-fn visible_preview_files(
+fn collect_matching_preview_files(
+    nodes: &[RawNode<TorrentPreviewPayload>],
+    query: &str,
+    summary: &mut FilePreviewSummary,
+) {
+    for node in nodes {
+        if node.is_dir {
+            collect_matching_preview_files(&node.children, query, summary);
+        } else if node
+            .full_path
+            .to_string_lossy()
+            .to_lowercase()
+            .contains(query)
+        {
+            summary.total_files += 1;
+            if summary.rows.len() < MAX_FILES_PER_TORRENT {
+                summary.rows.push(FilePreviewRow {
+                    path: node.full_path.to_string_lossy().to_string(),
+                    size: node.payload.size,
+                });
+            }
+        }
+    }
+}
+
+fn summarize_preview_files(
     torrent: &TorrentSettings,
     runtime: Option<&TorrentDisplayState>,
     query: &str,
-) -> Vec<FilePreviewRow> {
+) -> FilePreviewSummary {
     let Some(runtime) = runtime else {
-        return Vec::new();
+        return FilePreviewSummary::default();
     };
-    let files = preview_files(runtime);
     let query = query.trim().to_lowercase();
     if query.is_empty() || torrent.name.to_lowercase().contains(&query) {
-        return files;
+        let mut rows = Vec::with_capacity(MAX_FILES_PER_TORRENT);
+        collect_first_preview_files(&runtime.file_preview_tree, &mut rows);
+        return FilePreviewSummary {
+            total_files: runtime
+                .latest_state
+                .file_count
+                .unwrap_or_else(|| count_preview_files(&runtime.file_preview_tree)),
+            rows,
+        };
     }
-    files
-        .into_iter()
-        .filter(|file| file.path.to_lowercase().contains(&query))
-        .collect()
+    let mut summary = FilePreviewSummary::default();
+    collect_matching_preview_files(&runtime.file_preview_tree, &query, &mut summary);
+    summary
 }
 
 pub fn draw(frame: &mut Frame, screen: &ScreenContext<'_>) {
@@ -532,21 +643,8 @@ fn build_tag_pill_lines(
     let max_width = usize::from(width.max(1));
     for (index, (name, count, tag_id)) in pills.into_iter().enumerate() {
         let name = truncate_with_ellipsis(&sanitize_text(&name), MAX_TAG_NAME_WIDTH);
-        let marker = if index == state.selected_tag_index {
-            if matches!(state.active_pane, TagManagementPane::Tags) {
-                "●"
-            } else {
-                "◆"
-            }
-        } else {
-            ""
-        };
-        let label = if marker.is_empty() {
-            format!("  {name}  {count}  ")
-        } else {
-            format!(" {marker} {name}  {count} ")
-        };
-        let pill_width = label.chars().count();
+        let label = format!(" {name}  {count} ");
+        let pill_width = label.chars().count() + 2;
         let separator_width = usize::from(!spans.is_empty());
         if !spans.is_empty() && used + separator_width + pill_width > max_width {
             lines.push(Line::from(std::mem::take(&mut spans)));
@@ -557,17 +655,29 @@ fn build_tag_pill_lines(
             used += 1;
         }
         let color = tag_id.map_or_else(|| ctx.state_selected(), |id| tag_color(id, ctx));
-        let style = if index == state.selected_tag_index {
+        let selected = index == state.selected_tag_index;
+        let focused = selected && matches!(state.active_pane, TagManagementPane::Tags);
+        let border_style = if selected {
+            ctx.apply(Style::default().fg(color).add_modifier(Modifier::BOLD))
+        } else {
+            ctx.apply(Style::default().fg(ctx.theme.semantic.overlay0))
+        };
+        let label_style = if selected {
+            let mut modifiers = Modifier::UNDERLINED;
+            if focused {
+                modifiers |= Modifier::BOLD;
+            }
             ctx.apply(
                 Style::default()
-                    .fg(ctx.theme.semantic.white)
-                    .bg(color)
-                    .add_modifier(Modifier::BOLD),
+                    .fg(ctx.theme.semantic.text)
+                    .add_modifier(modifiers),
             )
         } else {
-            ctx.apply(Style::default().fg(color).bg(ctx.theme.semantic.surface0))
+            ctx.apply(Style::default().fg(ctx.theme.semantic.overlay0))
         };
-        spans.push(Span::styled(label, style));
+        spans.push(Span::styled("[", border_style));
+        spans.push(Span::styled(label, label_style));
+        spans.push(Span::styled("]", border_style));
         used += pill_width;
     }
     if !spans.is_empty() {
@@ -625,11 +735,17 @@ fn draw_results(frame: &mut Frame, area: Rect, screen: &ScreenContext<'_>) {
     let ctx = screen.theme;
     let torrents = visible_torrents(screen.settings, screen.ui, state);
     let query = state.search_query.as_str();
-    let file_count = torrents
+    let rendered_torrents = torrents
         .iter()
         .map(|torrent| {
-            visible_preview_files(torrent, runtime_torrent(torrent, screen.ui), query).len()
+            let runtime = runtime_torrent(torrent, screen.ui);
+            let summary = summarize_preview_files(torrent, runtime, query);
+            (*torrent, runtime, summary)
         })
+        .collect::<Vec<_>>();
+    let file_count = rendered_torrents
+        .iter()
+        .map(|(_, _, summary)| summary.total_files)
         .sum::<usize>();
     let border_color = if matches!(state.active_pane, TagManagementPane::Torrents) {
         ctx.state_selected()
@@ -701,17 +817,17 @@ fn draw_results(frame: &mut Frame, area: Rect, screen: &ScreenContext<'_>) {
         return;
     }
 
-    let items = torrents
+    let items = rendered_torrents
         .iter()
         .enumerate()
-        .map(|(index, torrent)| {
+        .map(|(index, (torrent, runtime, summary))| {
             result_item(
                 torrent,
-                runtime_torrent(torrent, screen.ui),
+                *runtime,
+                summary,
                 index == state.selected_torrent_index,
                 ResultItemContext {
                     settings: screen.settings,
-                    query,
                     active_tag_id: selected_tag_id(screen.settings, state),
                     assignment_mode: state.assignment_mode,
                     width: inner.width,
@@ -728,12 +844,12 @@ fn draw_results(frame: &mut Frame, area: Rect, screen: &ScreenContext<'_>) {
 fn result_item(
     torrent: &TorrentSettings,
     runtime: Option<&TorrentDisplayState>,
+    preview: &FilePreviewSummary,
     selected: bool,
     render: ResultItemContext<'_>,
 ) -> ListItem<'static> {
     let ResultItemContext {
         settings,
-        query,
         active_tag_id,
         assignment_mode,
         width,
@@ -791,12 +907,10 @@ fn result_item(
     ];
     append_inline_tag_chips(&mut header, torrent, settings, ctx, width);
 
-    let files = visible_preview_files(torrent, runtime, query);
-    let total_files = files.len();
+    let total_files = preview.total_files;
     let mut lines = vec![Line::from(header)];
-    for (index, file) in files.iter().take(MAX_FILES_PER_TORRENT).enumerate() {
-        let is_last_visible = index + 1 == total_files.min(MAX_FILES_PER_TORRENT)
-            && total_files <= MAX_FILES_PER_TORRENT;
+    for (index, file) in preview.rows.iter().enumerate() {
+        let is_last_visible = index + 1 == preview.rows.len() && total_files == preview.rows.len();
         let branch = if is_last_visible { "└─" } else { "├─" };
         let size = format_bytes(file.size);
         let path_budget = usize::from(width).saturating_sub(size.chars().count() + 11);
@@ -815,12 +929,9 @@ fn result_item(
             ),
         ]));
     }
-    if total_files > MAX_FILES_PER_TORRENT {
+    if total_files > preview.rows.len() {
         lines.push(Line::from(Span::styled(
-            format!(
-                "     └─ … {} more files",
-                total_files - MAX_FILES_PER_TORRENT
-            ),
+            format!("     └─ … {} more files", total_files - preview.rows.len()),
             ctx.apply(Style::default().fg(ctx.theme.semantic.overlay0)),
         )));
     } else if total_files == 0 {
@@ -941,7 +1052,7 @@ fn draw_tag_footer(
         push("Esc", "back", ActionTone::Cancel);
     } else {
         push("↑/↓", "torrent", ActionTone::Navigate);
-        push("t", "tags", ActionTone::Mode);
+        push("t", "assign", ActionTone::Mode);
         if selected_tag(settings, state).is_some() {
             push("Space", "toggle", ActionTone::Toggle);
             push(
@@ -954,7 +1065,7 @@ fn draw_tag_footer(
                 ActionTone::Mode,
             );
         }
-        push("Tab", "tags", ActionTone::Mode);
+        push("Tab", "filters", ActionTone::Mode);
         push("/", "search", ActionTone::Search);
         push("Esc", "back", ActionTone::Cancel);
     }
@@ -1214,6 +1325,96 @@ mod tests {
     }
 
     #[test]
+    fn delete_confirmation_consumes_background_actions() {
+        for key in [
+            KeyCode::Char('n'),
+            KeyCode::Char('m'),
+            KeyCode::Char('t'),
+            KeyCode::Char(' '),
+            KeyCode::Tab,
+        ] {
+            assert_eq!(
+                delete_confirmation_input(key),
+                DeleteConfirmationInput::Consume
+            );
+        }
+        assert_eq!(
+            delete_confirmation_input(KeyCode::Enter),
+            DeleteConfirmationInput::Confirm
+        );
+        assert_eq!(
+            delete_confirmation_input(KeyCode::Esc),
+            DeleteConfirmationInput::Cancel
+        );
+    }
+
+    #[test]
+    fn normal_preview_summary_uses_cached_count_and_caps_materialized_rows() {
+        let torrent = TorrentSettings {
+            name: "Large Fictional Dataset".to_string(),
+            ..Default::default()
+        };
+        let files = (0..10)
+            .map(|index| RawNode {
+                name: format!("part-{index}.bin"),
+                full_path: PathBuf::from(format!("dataset/part-{index}.bin")),
+                children: Vec::new(),
+                payload: TorrentPreviewPayload {
+                    file_index: Some(index),
+                    size: 1024,
+                    ..Default::default()
+                },
+                is_dir: false,
+            })
+            .collect();
+        let runtime = TorrentDisplayState {
+            latest_state: TorrentMetrics {
+                file_count: Some(100_000),
+                ..Default::default()
+            },
+            file_preview_tree: files,
+            ..Default::default()
+        };
+
+        let summary = summarize_preview_files(&torrent, Some(&runtime), "");
+
+        assert_eq!(summary.total_files, 100_000);
+        assert_eq!(summary.rows.len(), MAX_FILES_PER_TORRENT);
+        assert_eq!(summary.rows[0].path, "dataset/part-0.bin");
+        assert_eq!(summary.rows[2].path, "dataset/part-2.bin");
+    }
+
+    #[test]
+    fn inactive_pills_are_grey_and_selected_pill_is_underlined() {
+        let settings = test_settings();
+        let state = TagManagementUiState::default();
+        let app_state = test_app_state();
+        let ctx = ThemeContext::new(app_state.theme, 0.0);
+        let lines = build_tag_pill_lines(&settings, &state, 120, &ctx);
+        let spans = lines
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .collect::<Vec<_>>();
+
+        let selected = spans
+            .iter()
+            .find(|span| span.content.contains("All"))
+            .expect("selected All pill");
+        assert!(selected.style.add_modifier.contains(Modifier::UNDERLINED));
+
+        let inactive = spans
+            .iter()
+            .find(|span| span.content.contains("Curated"))
+            .expect("inactive Curated pill");
+        assert_eq!(
+            inactive.style.fg,
+            ctx.apply(Style::default().fg(ctx.theme.semantic.overlay0))
+                .fg
+        );
+        assert!(!inactive.style.add_modifier.contains(Modifier::UNDERLINED));
+    }
+
+    #[test]
     fn redesigned_screen_renders_filter_pills_and_file_results() {
         let settings = test_settings();
         let state = test_app_state();
@@ -1229,6 +1430,27 @@ mod tests {
             "notes/summary.txt",
             "Field Notes",
             "[Tab]results",
+        ] {
+            assert!(
+                rendered.contains(expected),
+                "missing {expected:?}\n{rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn inline_picker_renders_existing_assignment_for_highlighted_torrent() {
+        let settings = test_settings();
+        let mut state = test_app_state();
+        state.ui.tag_picker.open = true;
+        state.ui.tag_picker.target_hashes = vec![vec![0x11; 20]];
+        let rendered = render_screen(&settings, &state, 100, 30);
+
+        for expected in [
+            "Tags · 1 torrent",
+            "[x] Curated",
+            "[ ] Read Later",
+            "[a]add tag",
         ] {
             assert!(
                 rendered.contains(expected),

--- a/src/tui/screens/tags.rs
+++ b/src/tui/screens/tags.rs
@@ -1,0 +1,1250 @@
+// SPDX-FileCopyrightText: 2026 The superseedr Contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::app::{
+    torrent_completion_percent, App, AppCommand, AppMode, AppState, TagInputMode,
+    TagManagementPane, TagManagementUiState, TorrentControlState, TorrentDisplayState,
+    TorrentPreviewPayload,
+};
+use crate::config::{Settings, TorrentSettings};
+use crate::integrations::control::ControlRequest;
+use crate::tags::{TagDefinition, TagId};
+use crate::theme::ThemeContext;
+use crate::torrent_identity::info_hash_from_torrent_source;
+use crate::tui::action_style::{footer_key_style, ActionTone};
+use crate::tui::app_command::spawn_app_command_sender;
+use crate::tui::formatters::{centered_rect, format_bytes, sanitize_text, truncate_with_ellipsis};
+use crate::tui::screen_context::ScreenContext;
+use crate::tui::screens::{input_panel::draw_prompt_panel, tag_picker};
+use crate::tui::tree::RawNode;
+use ratatui::crossterm::event::{Event as CrosstermEvent, KeyCode, KeyEventKind, KeyModifiers};
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{
+    Block, Borders, Clear, List, ListItem, ListState, Padding, Paragraph, Wrap,
+};
+use ratatui::Frame;
+
+const MAX_FILES_PER_TORRENT: usize = 3;
+const MAX_TAG_NAME_WIDTH: usize = 22;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct FilePreviewRow {
+    path: String,
+    size: u64,
+}
+
+struct ResultItemContext<'a> {
+    settings: &'a Settings,
+    query: &'a str,
+    active_tag_id: Option<TagId>,
+    assignment_mode: bool,
+    width: u16,
+    theme: &'a ThemeContext,
+}
+
+pub fn initialize(app: &mut App) {
+    let state = &mut app.app_state.ui.tag_management;
+    state.selected_tag_index = 0;
+    state.selected_torrent_index = 0;
+    state.active_pane = TagManagementPane::Tags;
+    state.assignment_mode = false;
+    state.input_mode = None;
+    state.input_buffer.clear();
+    state.search_query.clear();
+    state.delete_confirm_tag_id = None;
+    state.status_message = None;
+    clamp_selection(app);
+}
+
+pub fn handle_event(event: CrosstermEvent, app: &mut App) -> bool {
+    if !matches!(app.app_state.mode, AppMode::TagManagement) {
+        return false;
+    }
+    if tag_picker::is_open(&app.app_state) {
+        return tag_picker::handle_event(event, app);
+    }
+    let CrosstermEvent::Key(key) = event else {
+        return false;
+    };
+    if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat)
+        || !matches!(key.modifiers, KeyModifiers::NONE | KeyModifiers::SHIFT)
+    {
+        return false;
+    }
+
+    if app.app_state.ui.tag_management.input_mode.is_some() {
+        return handle_input_key(key.code, app);
+    }
+
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('L') => {
+            if app
+                .app_state
+                .ui
+                .tag_management
+                .delete_confirm_tag_id
+                .take()
+                .is_none()
+            {
+                app.app_state.mode = AppMode::Normal;
+            }
+        }
+        KeyCode::Tab | KeyCode::BackTab => toggle_focus(app),
+        KeyCode::Left | KeyCode::Char('h') => move_selection(app, -1),
+        KeyCode::Right | KeyCode::Char('l') => move_selection(app, 1),
+        KeyCode::Up | KeyCode::Char('k') => move_selection(app, -1),
+        KeyCode::Down | KeyCode::Char('j') => move_selection(app, 1),
+        KeyCode::Home => move_selection_to_edge(app, false),
+        KeyCode::End => move_selection_to_edge(app, true),
+        KeyCode::Char('0') => {
+            let state = &mut app.app_state.ui.tag_management;
+            state.selected_tag_index = 0;
+            state.selected_torrent_index = 0;
+            state.assignment_mode = false;
+            state.status_message = Some("Showing all torrents".to_string());
+        }
+        KeyCode::Char('m') => toggle_assignment_mode(app),
+        KeyCode::Char('t') => open_picker_for_selected_torrent(app),
+        KeyCode::Char('/') => {
+            let state = &mut app.app_state.ui.tag_management;
+            state.input_buffer = state.search_query.clone();
+            state.input_mode = Some(TagInputMode::Search);
+        }
+        KeyCode::Char('n') => {
+            let state = &mut app.app_state.ui.tag_management;
+            state.input_buffer.clear();
+            state.input_mode = Some(TagInputMode::Create);
+        }
+        KeyCode::Char('e') => begin_rename(app),
+        KeyCode::Char('d') => begin_delete(app),
+        KeyCode::Enter => {
+            if let Some(tag_id) = app.app_state.ui.tag_management.delete_confirm_tag_id.take() {
+                submit_request(app, ControlRequest::DeleteTag { tag_id });
+            } else if matches!(
+                app.app_state.ui.tag_management.active_pane,
+                TagManagementPane::Tags
+            ) {
+                app.app_state.ui.tag_management.active_pane = TagManagementPane::Torrents;
+            }
+        }
+        KeyCode::Char('y') | KeyCode::Char('Y') => {
+            if let Some(tag_id) = app.app_state.ui.tag_management.delete_confirm_tag_id.take() {
+                submit_request(app, ControlRequest::DeleteTag { tag_id });
+            }
+        }
+        KeyCode::Char(' ') => toggle_selected_assignment(app),
+        _ => return false,
+    }
+
+    clamp_selection(app);
+    app.app_state.ui.needs_redraw = true;
+    true
+}
+
+fn handle_input_key(key_code: KeyCode, app: &mut App) -> bool {
+    match key_code {
+        KeyCode::Esc => {
+            let state = &mut app.app_state.ui.tag_management;
+            state.input_mode = None;
+            state.input_buffer.clear();
+        }
+        KeyCode::Backspace => {
+            app.app_state.ui.tag_management.input_buffer.pop();
+        }
+        KeyCode::Enter => {
+            let state = &mut app.app_state.ui.tag_management;
+            let Some(mode) = state.input_mode.take() else {
+                return true;
+            };
+            let value = std::mem::take(&mut state.input_buffer);
+            match mode {
+                TagInputMode::Search => {
+                    state.search_query = value;
+                    state.selected_torrent_index = 0;
+                }
+                TagInputMode::Create => {
+                    submit_request(app, ControlRequest::CreateTag { name: value });
+                }
+                TagInputMode::Rename(tag_id) => {
+                    submit_request(
+                        app,
+                        ControlRequest::RenameTag {
+                            tag_id,
+                            new_name: value,
+                        },
+                    );
+                }
+            }
+        }
+        KeyCode::Char(character) => {
+            app.app_state.ui.tag_management.input_buffer.push(character);
+        }
+        _ => return false,
+    }
+    clamp_selection(app);
+    app.app_state.ui.needs_redraw = true;
+    true
+}
+
+fn toggle_focus(app: &mut App) {
+    let state = &mut app.app_state.ui.tag_management;
+    state.active_pane = match state.active_pane {
+        TagManagementPane::Tags => TagManagementPane::Torrents,
+        TagManagementPane::Torrents => TagManagementPane::Tags,
+    };
+}
+
+fn toggle_assignment_mode(app: &mut App) {
+    if selected_tag(&app.client_configs, &app.app_state.ui.tag_management).is_none() {
+        app.app_state.ui.tag_management.status_message =
+            Some("Choose a tag before managing assignments".to_string());
+        return;
+    }
+    let state = &mut app.app_state.ui.tag_management;
+    state.assignment_mode = !state.assignment_mode;
+    state.selected_torrent_index = 0;
+    state.active_pane = TagManagementPane::Torrents;
+    state.status_message = Some(if state.assignment_mode {
+        "Assignment mode: Space toggles the selected tag".to_string()
+    } else {
+        "Showing torrents that use this tag".to_string()
+    });
+}
+
+fn open_picker_for_selected_torrent(app: &mut App) {
+    let state = &app.app_state.ui.tag_management;
+    let info_hash = visible_torrents(&app.client_configs, &app.app_state, state)
+        .get(state.selected_torrent_index)
+        .and_then(|torrent| info_hash_from_torrent_source(&torrent.torrent_or_magnet))
+        .map(|hash| hash.to_vec());
+    if let Some(info_hash) = info_hash {
+        tag_picker::open(app, vec![info_hash]);
+    } else {
+        app.app_state.ui.tag_management.status_message = Some("No torrent is selected".to_string());
+    }
+}
+
+fn begin_rename(app: &mut App) {
+    let selected = selected_tag(&app.client_configs, &app.app_state.ui.tag_management)
+        .map(|tag| (tag.id, tag.name.clone()));
+    let Some((tag_id, name)) = selected else {
+        app.app_state.ui.tag_management.status_message =
+            Some("Choose a tag before renaming".to_string());
+        return;
+    };
+    let state = &mut app.app_state.ui.tag_management;
+    state.input_buffer = name;
+    state.input_mode = Some(TagInputMode::Rename(tag_id));
+}
+
+fn begin_delete(app: &mut App) {
+    let selected_tag_id =
+        selected_tag(&app.client_configs, &app.app_state.ui.tag_management).map(|tag| tag.id);
+    let Some(tag_id) = selected_tag_id else {
+        app.app_state.ui.tag_management.status_message =
+            Some("Choose a tag before deleting".to_string());
+        return;
+    };
+    app.app_state.ui.tag_management.delete_confirm_tag_id = Some(tag_id);
+}
+
+fn submit_request(app: &mut App, request: ControlRequest) {
+    app.app_state.ui.tag_management.status_message =
+        Some(format!("Submitted {} request", request.action_name()));
+    spawn_app_command_sender(
+        app.app_command_tx.clone(),
+        app.shutdown_tx.subscribe(),
+        AppCommand::SubmitControlRequest(request),
+    );
+}
+
+fn toggle_selected_assignment(app: &mut App) {
+    let state = &app.app_state.ui.tag_management;
+    let Some(tag_id) = selected_tag(&app.client_configs, state).map(|tag| tag.id) else {
+        app.app_state.ui.tag_management.status_message =
+            Some("Choose a tag filter before changing assignments".to_string());
+        return;
+    };
+    let selected_torrent = visible_torrents(&app.client_configs, &app.app_state, state)
+        .get(state.selected_torrent_index)
+        .copied();
+    let Some(torrent) = selected_torrent else {
+        app.app_state.ui.tag_management.status_message = Some("No torrent is selected".to_string());
+        return;
+    };
+    let Some(info_hash) = info_hash_from_torrent_source(&torrent.torrent_or_magnet) else {
+        app.app_state.ui.tag_management.status_message =
+            Some("Selected torrent has no resolvable info hash".to_string());
+        return;
+    };
+    let info_hash_hex = hex::encode(info_hash);
+    let request = if torrent.tag_ids.contains(&tag_id) {
+        ControlRequest::RemoveTag {
+            tag_id,
+            info_hash_hex,
+        }
+    } else {
+        ControlRequest::AssignTag {
+            tag_id,
+            info_hash_hex,
+        }
+    };
+    submit_request(app, request);
+}
+
+fn move_selection(app: &mut App, delta: isize) {
+    let state = &mut app.app_state.ui.tag_management;
+    match state.active_pane {
+        TagManagementPane::Tags => {
+            state.selected_tag_index = state.selected_tag_index.saturating_add_signed(delta);
+            state.selected_torrent_index = 0;
+            state.assignment_mode = false;
+        }
+        TagManagementPane::Torrents => {
+            state.selected_torrent_index =
+                state.selected_torrent_index.saturating_add_signed(delta);
+        }
+    }
+}
+
+fn move_selection_to_edge(app: &mut App, last: bool) {
+    let state = &app.app_state.ui.tag_management;
+    let tag_end = app.client_configs.tag_catalog.tags.len();
+    let torrent_end = visible_torrents(&app.client_configs, &app.app_state, state)
+        .len()
+        .saturating_sub(1);
+    let state = &mut app.app_state.ui.tag_management;
+    match state.active_pane {
+        TagManagementPane::Tags => {
+            state.selected_tag_index = if last { tag_end } else { 0 };
+            state.selected_torrent_index = 0;
+            state.assignment_mode = false;
+        }
+        TagManagementPane::Torrents => {
+            state.selected_torrent_index = if last { torrent_end } else { 0 };
+        }
+    }
+}
+
+fn clamp_selection(app: &mut App) {
+    let tag_end = app.client_configs.tag_catalog.tags.len();
+    app.app_state.ui.tag_management.selected_tag_index = app
+        .app_state
+        .ui
+        .tag_management
+        .selected_tag_index
+        .min(tag_end);
+    let torrent_end = visible_torrents(
+        &app.client_configs,
+        &app.app_state,
+        &app.app_state.ui.tag_management,
+    )
+    .len()
+    .saturating_sub(1);
+    app.app_state.ui.tag_management.selected_torrent_index = app
+        .app_state
+        .ui
+        .tag_management
+        .selected_torrent_index
+        .min(torrent_end);
+}
+
+fn selected_tag<'a>(
+    settings: &'a Settings,
+    state: &TagManagementUiState,
+) -> Option<&'a TagDefinition> {
+    let index = state.selected_tag_index.checked_sub(1)?;
+    settings.tag_catalog.tags.get(index)
+}
+
+fn selected_tag_id(settings: &Settings, state: &TagManagementUiState) -> Option<TagId> {
+    selected_tag(settings, state).map(|tag| tag.id)
+}
+
+fn visible_torrents<'a>(
+    settings: &'a Settings,
+    app_state: &AppState,
+    state: &TagManagementUiState,
+) -> Vec<&'a TorrentSettings> {
+    let selected_tag = selected_tag_id(settings, state);
+    let query = state.search_query.trim().to_lowercase();
+    settings
+        .torrents
+        .iter()
+        .filter(|torrent| {
+            (state.assignment_mode
+                || selected_tag.is_none_or(|tag_id| torrent.tag_ids.contains(&tag_id)))
+                && torrent_matches_query(torrent, app_state, &query)
+        })
+        .collect()
+}
+
+fn torrent_matches_query(torrent: &TorrentSettings, app_state: &AppState, query: &str) -> bool {
+    if query.is_empty() || torrent.name.to_lowercase().contains(query) {
+        return true;
+    }
+    runtime_torrent(torrent, app_state).is_some_and(|runtime| {
+        preview_files(runtime)
+            .iter()
+            .any(|file| file.path.to_lowercase().contains(query))
+    })
+}
+
+fn runtime_torrent<'a>(
+    torrent: &TorrentSettings,
+    app_state: &'a AppState,
+) -> Option<&'a TorrentDisplayState> {
+    let info_hash = info_hash_from_torrent_source(&torrent.torrent_or_magnet)?;
+    app_state.torrents.get(info_hash.as_slice())
+}
+
+fn preview_files(torrent: &TorrentDisplayState) -> Vec<FilePreviewRow> {
+    let mut files = Vec::new();
+    collect_preview_files(&torrent.file_preview_tree, &mut files);
+    files
+}
+
+fn collect_preview_files(
+    nodes: &[RawNode<TorrentPreviewPayload>],
+    files: &mut Vec<FilePreviewRow>,
+) {
+    for node in nodes {
+        if node.is_dir {
+            collect_preview_files(&node.children, files);
+        } else {
+            files.push(FilePreviewRow {
+                path: node.full_path.to_string_lossy().to_string(),
+                size: node.payload.size,
+            });
+        }
+    }
+}
+
+fn visible_preview_files(
+    torrent: &TorrentSettings,
+    runtime: Option<&TorrentDisplayState>,
+    query: &str,
+) -> Vec<FilePreviewRow> {
+    let Some(runtime) = runtime else {
+        return Vec::new();
+    };
+    let files = preview_files(runtime);
+    let query = query.trim().to_lowercase();
+    if query.is_empty() || torrent.name.to_lowercase().contains(&query) {
+        return files;
+    }
+    files
+        .into_iter()
+        .filter(|file| file.path.to_lowercase().contains(&query))
+        .collect()
+}
+
+pub fn draw(frame: &mut Frame, screen: &ScreenContext<'_>) {
+    let area = centered_rect(92, 92, frame.area());
+    let state = &screen.ui.ui.tag_management;
+    let ctx = screen.theme;
+    frame.render_widget(Clear, frame.area());
+
+    let show_input = state.input_mode.is_some();
+    let layout = if show_input {
+        Layout::vertical([
+            Constraint::Length(3),
+            Constraint::Min(8),
+            Constraint::Length(1),
+        ])
+        .split(area)
+    } else {
+        Layout::vertical([Constraint::Min(8), Constraint::Length(1)]).split(area)
+    };
+    let body_index = usize::from(show_input);
+    let footer_index = body_index + 1;
+
+    if show_input {
+        draw_tag_input(frame, layout[0], state, ctx);
+    }
+    draw_tag_workspace(frame, layout[body_index], screen);
+    draw_tag_footer(frame, layout[footer_index], state, screen.settings, ctx);
+
+    if let Some(tag_id) = state.delete_confirm_tag_id {
+        draw_delete_confirmation(frame, area, tag_id, screen.settings, ctx);
+    }
+    tag_picker::draw(frame, screen);
+}
+
+fn draw_tag_input(frame: &mut Frame, area: Rect, state: &TagManagementUiState, ctx: &ThemeContext) {
+    let title = match state.input_mode.as_ref() {
+        Some(TagInputMode::Search) => " Search torrents and files ",
+        Some(TagInputMode::Create) => " Create tag ",
+        Some(TagInputMode::Rename(_)) => " Rename tag ",
+        None => return,
+    };
+    draw_prompt_panel(
+        frame,
+        area,
+        title.to_string(),
+        sanitize_text(&state.input_buffer),
+        Vec::new(),
+        ctx,
+    );
+}
+
+fn draw_tag_workspace(frame: &mut Frame, area: Rect, screen: &ScreenContext<'_>) {
+    let state = &screen.ui.ui.tag_management;
+    let inner_width = area.width.saturating_sub(6).max(1);
+    let pill_lines = build_tag_pill_lines(screen.settings, state, inner_width, screen.theme);
+    let filter_height = (pill_lines.len() as u16)
+        .saturating_add(2)
+        .min(area.height.saturating_sub(5).max(3));
+    let regions = Layout::vertical([
+        Constraint::Length(filter_height),
+        Constraint::Length(1),
+        Constraint::Min(4),
+    ])
+    .split(area);
+
+    draw_tag_filters(frame, regions[0], screen, pill_lines);
+    draw_results(frame, regions[2], screen);
+}
+
+fn build_tag_pill_lines(
+    settings: &Settings,
+    state: &TagManagementUiState,
+    width: u16,
+    ctx: &ThemeContext,
+) -> Vec<Line<'static>> {
+    let total = settings.torrents.len();
+    let mut pills = Vec::with_capacity(settings.tag_catalog.tags.len() + 1);
+    pills.push(("All".to_string(), total, None));
+    pills.extend(settings.tag_catalog.tags.iter().map(|tag| {
+        let count = settings
+            .torrents
+            .iter()
+            .filter(|torrent| torrent.tag_ids.contains(&tag.id))
+            .count();
+        (tag.name.clone(), count, Some(tag.id))
+    }));
+
+    let mut lines = Vec::new();
+    let mut spans = Vec::new();
+    let mut used = 0usize;
+    let max_width = usize::from(width.max(1));
+    for (index, (name, count, tag_id)) in pills.into_iter().enumerate() {
+        let name = truncate_with_ellipsis(&sanitize_text(&name), MAX_TAG_NAME_WIDTH);
+        let marker = if index == state.selected_tag_index {
+            if matches!(state.active_pane, TagManagementPane::Tags) {
+                "●"
+            } else {
+                "◆"
+            }
+        } else {
+            ""
+        };
+        let label = if marker.is_empty() {
+            format!("  {name}  {count}  ")
+        } else {
+            format!(" {marker} {name}  {count} ")
+        };
+        let pill_width = label.chars().count();
+        let separator_width = usize::from(!spans.is_empty());
+        if !spans.is_empty() && used + separator_width + pill_width > max_width {
+            lines.push(Line::from(std::mem::take(&mut spans)));
+            used = 0;
+        }
+        if !spans.is_empty() {
+            spans.push(Span::raw(" "));
+            used += 1;
+        }
+        let color = tag_id.map_or_else(|| ctx.state_selected(), |id| tag_color(id, ctx));
+        let style = if index == state.selected_tag_index {
+            ctx.apply(
+                Style::default()
+                    .fg(ctx.theme.semantic.white)
+                    .bg(color)
+                    .add_modifier(Modifier::BOLD),
+            )
+        } else {
+            ctx.apply(Style::default().fg(color).bg(ctx.theme.semantic.surface0))
+        };
+        spans.push(Span::styled(label, style));
+        used += pill_width;
+    }
+    if !spans.is_empty() {
+        lines.push(Line::from(spans));
+    }
+    if lines.is_empty() {
+        lines.push(Line::default());
+    }
+    lines
+}
+
+fn draw_tag_filters(
+    frame: &mut Frame,
+    area: Rect,
+    screen: &ScreenContext<'_>,
+    lines: Vec<Line<'static>>,
+) {
+    let state = &screen.ui.ui.tag_management;
+    let ctx = screen.theme;
+    let border_color = if matches!(state.active_pane, TagManagementPane::Tags) {
+        ctx.state_selected()
+    } else {
+        ctx.theme.semantic.border
+    };
+    let selected_label = selected_tag(screen.settings, state)
+        .map(|tag| sanitize_text(&tag.name))
+        .unwrap_or_else(|| "All torrents".to_string());
+    let mut block = Block::default()
+        .borders(Borders::ALL)
+        .padding(Padding::horizontal(2))
+        .border_style(ctx.apply(Style::default().fg(border_color)))
+        .title(Span::styled(
+            " Filter by tag ",
+            ctx.apply(
+                Style::default()
+                    .fg(ctx.state_selected())
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ))
+        .title_bottom(Span::styled(
+            format!(" {selected_label} "),
+            ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1)),
+        ));
+    if !state.search_query.is_empty() {
+        block = block.title_bottom(Span::styled(
+            format!(" search: {} ", sanitize_text(&state.search_query)),
+            ctx.apply(Style::default().fg(ctx.accent_sapphire())),
+        ));
+    }
+    frame.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn draw_results(frame: &mut Frame, area: Rect, screen: &ScreenContext<'_>) {
+    let state = &screen.ui.ui.tag_management;
+    let ctx = screen.theme;
+    let torrents = visible_torrents(screen.settings, screen.ui, state);
+    let query = state.search_query.as_str();
+    let file_count = torrents
+        .iter()
+        .map(|torrent| {
+            visible_preview_files(torrent, runtime_torrent(torrent, screen.ui), query).len()
+        })
+        .sum::<usize>();
+    let border_color = if matches!(state.active_pane, TagManagementPane::Torrents) {
+        ctx.state_selected()
+    } else {
+        ctx.theme.semantic.border
+    };
+    let surface_label = if state.assignment_mode {
+        "Assignments"
+    } else {
+        "Results"
+    };
+    let title = format!(
+        " {surface_label} · {} torrent{} · {} file{} ",
+        torrents.len(),
+        if torrents.len() == 1 { "" } else { "s" },
+        file_count,
+        if file_count == 1 { "" } else { "s" },
+    );
+    let mut block = Block::default()
+        .borders(Borders::ALL)
+        .padding(Padding::new(1, 1, 0, 0))
+        .border_style(ctx.apply(Style::default().fg(border_color)))
+        .title(Span::styled(
+            title,
+            ctx.apply(
+                Style::default()
+                    .fg(ctx.accent_sky())
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ));
+    if let Some(message) = &state.status_message {
+        block = block.title_bottom(Span::styled(
+            format!(" {} ", truncate_with_ellipsis(&sanitize_text(message), 72)),
+            ctx.apply(
+                Style::default()
+                    .fg(ctx.state_info())
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ));
+    }
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if torrents.is_empty() {
+        let message = if state.search_query.is_empty() {
+            "No torrents use this tag yet"
+        } else {
+            "No torrents or files match this search"
+        };
+        frame.render_widget(
+            Paragraph::new(vec![
+                Line::from(Span::styled(
+                    "No matches",
+                    ctx.apply(
+                        Style::default()
+                            .fg(ctx.state_warning())
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                )),
+                Line::from(Span::styled(
+                    message,
+                    ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1)),
+                )),
+            ])
+            .alignment(Alignment::Center)
+            .wrap(Wrap { trim: true }),
+            centered_fixed(inner, inner.width.min(54), 2),
+        );
+        return;
+    }
+
+    let items = torrents
+        .iter()
+        .enumerate()
+        .map(|(index, torrent)| {
+            result_item(
+                torrent,
+                runtime_torrent(torrent, screen.ui),
+                index == state.selected_torrent_index,
+                ResultItemContext {
+                    settings: screen.settings,
+                    query,
+                    active_tag_id: selected_tag_id(screen.settings, state),
+                    assignment_mode: state.assignment_mode,
+                    width: inner.width,
+                    theme: ctx,
+                },
+            )
+        })
+        .collect::<Vec<_>>();
+    let mut list_state = ListState::default();
+    list_state.select(Some(state.selected_torrent_index));
+    frame.render_stateful_widget(List::new(items), inner, &mut list_state);
+}
+
+fn result_item(
+    torrent: &TorrentSettings,
+    runtime: Option<&TorrentDisplayState>,
+    selected: bool,
+    render: ResultItemContext<'_>,
+) -> ListItem<'static> {
+    let ResultItemContext {
+        settings,
+        query,
+        active_tag_id,
+        assignment_mode,
+        width,
+        theme: ctx,
+    } = render;
+    let (status, status_color, progress) = torrent_status(torrent, runtime, ctx);
+    let marker = if selected { "▶ " } else { "  " };
+    let assignment_marker = if assignment_mode {
+        if active_tag_id.is_some_and(|tag_id| torrent.tag_ids.contains(&tag_id)) {
+            "[x] "
+        } else {
+            "[ ] "
+        }
+    } else {
+        ""
+    };
+    let name_budget = usize::from(width)
+        .saturating_sub(28 + assignment_marker.chars().count())
+        .max(12);
+    let name = truncate_with_ellipsis(&sanitize_text(&torrent.name), name_budget);
+    let mut header = vec![
+        Span::styled(
+            marker,
+            ctx.apply(
+                Style::default()
+                    .fg(ctx.state_warning())
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ),
+        Span::styled(
+            assignment_marker.to_string(),
+            ctx.apply(Style::default().fg(if assignment_mode {
+                ctx.state_selected()
+            } else {
+                ctx.theme.semantic.text
+            })),
+        ),
+        Span::styled("● ", ctx.apply(Style::default().fg(status_color))),
+        Span::styled(
+            name,
+            ctx.apply(
+                Style::default()
+                    .fg(if selected {
+                        ctx.theme.semantic.white
+                    } else {
+                        ctx.theme.semantic.text
+                    })
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ),
+        Span::styled(
+            format!("  {progress:>3.0}% · {status}"),
+            ctx.apply(Style::default().fg(status_color)),
+        ),
+    ];
+    append_inline_tag_chips(&mut header, torrent, settings, ctx, width);
+
+    let files = visible_preview_files(torrent, runtime, query);
+    let total_files = files.len();
+    let mut lines = vec![Line::from(header)];
+    for (index, file) in files.iter().take(MAX_FILES_PER_TORRENT).enumerate() {
+        let is_last_visible = index + 1 == total_files.min(MAX_FILES_PER_TORRENT)
+            && total_files <= MAX_FILES_PER_TORRENT;
+        let branch = if is_last_visible { "└─" } else { "├─" };
+        let size = format_bytes(file.size);
+        let path_budget = usize::from(width).saturating_sub(size.chars().count() + 11);
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("     {branch} "),
+                ctx.apply(Style::default().fg(ctx.theme.semantic.surface2)),
+            ),
+            Span::styled(
+                truncate_with_ellipsis(&sanitize_text(&file.path), path_budget.max(8)),
+                ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0)),
+            ),
+            Span::styled(
+                format!("  {size}"),
+                ctx.apply(Style::default().fg(ctx.theme.semantic.overlay0)),
+            ),
+        ]));
+    }
+    if total_files > MAX_FILES_PER_TORRENT {
+        lines.push(Line::from(Span::styled(
+            format!(
+                "     └─ … {} more files",
+                total_files - MAX_FILES_PER_TORRENT
+            ),
+            ctx.apply(Style::default().fg(ctx.theme.semantic.overlay0)),
+        )));
+    } else if total_files == 0 {
+        lines.push(Line::from(Span::styled(
+            "     └─ metadata pending",
+            ctx.apply(Style::default().fg(ctx.theme.semantic.surface2)),
+        )));
+    }
+    lines.push(Line::default());
+    ListItem::new(lines)
+}
+
+fn append_inline_tag_chips(
+    spans: &mut Vec<Span<'static>>,
+    torrent: &TorrentSettings,
+    settings: &Settings,
+    ctx: &ThemeContext,
+    width: u16,
+) {
+    let mut used = spans
+        .iter()
+        .map(|span| span.content.chars().count())
+        .sum::<usize>();
+    for tag_id in &torrent.tag_ids {
+        let Some(tag) = settings.tag_catalog.get(*tag_id) else {
+            continue;
+        };
+        let name = truncate_with_ellipsis(&sanitize_text(&tag.name), 14);
+        let label = format!(" {name} ");
+        if used + label.chars().count() + 1 >= usize::from(width) {
+            break;
+        }
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(
+            label.clone(),
+            ctx.apply(
+                Style::default()
+                    .fg(ctx.theme.semantic.white)
+                    .bg(tag_color(*tag_id, ctx)),
+            ),
+        ));
+        used += label.chars().count() + 1;
+    }
+}
+
+fn torrent_status(
+    torrent: &TorrentSettings,
+    runtime: Option<&TorrentDisplayState>,
+    ctx: &ThemeContext,
+) -> (&'static str, Color, f64) {
+    if matches!(torrent.torrent_control_state, TorrentControlState::Deleting) {
+        return ("Deleting", ctx.state_error(), 0.0);
+    }
+    if matches!(torrent.torrent_control_state, TorrentControlState::Paused) {
+        let progress = runtime.map_or(0.0, |state| torrent_completion_percent(&state.latest_state));
+        return ("Paused", ctx.state_warning(), progress);
+    }
+    let Some(runtime) = runtime else {
+        return ("Queued", ctx.theme.semantic.overlay0, 0.0);
+    };
+    let metrics = &runtime.latest_state;
+    let progress = torrent_completion_percent(metrics);
+    if !metrics.data_available {
+        ("Unavailable", ctx.state_error(), progress)
+    } else if metrics.is_complete || progress >= 100.0 {
+        ("Complete", ctx.state_complete(), 100.0)
+    } else if metrics.number_of_pieces_total == 0 {
+        ("Metadata", ctx.state_info(), 0.0)
+    } else {
+        ("Downloading", ctx.metric_download(), progress)
+    }
+}
+
+fn tag_color(tag_id: TagId, ctx: &ThemeContext) -> Color {
+    let colors = [
+        ctx.theme.scale.categorical.lavender,
+        ctx.accent_sapphire(),
+        ctx.accent_teal(),
+        ctx.accent_peach(),
+        ctx.theme.scale.categorical.mauve,
+        ctx.theme.scale.categorical.green,
+        ctx.accent_maroon(),
+    ];
+    colors[(tag_id as usize).wrapping_sub(1) % colors.len()]
+}
+
+fn draw_tag_footer(
+    frame: &mut Frame,
+    area: Rect,
+    state: &TagManagementUiState,
+    settings: &Settings,
+    ctx: &ThemeContext,
+) {
+    let mut spans = Vec::new();
+    let mut used = 0usize;
+    let max_width = usize::from(area.width);
+    let mut push = |key: &str, label: &str, tone: ActionTone| {
+        let _ = try_push_footer_action(&mut spans, &mut used, max_width, key, label, tone, ctx);
+    };
+
+    if state.input_mode.is_some() {
+        push("Enter", "apply", ActionTone::Confirm);
+        push("Esc", "cancel", ActionTone::Cancel);
+    } else if state.delete_confirm_tag_id.is_some() {
+        push("Y/Enter", "delete", ActionTone::Destructive);
+        push("Esc", "cancel", ActionTone::Cancel);
+    } else if matches!(state.active_pane, TagManagementPane::Tags) {
+        push("←/→", "filter", ActionTone::Navigate);
+        push("Tab", "results", ActionTone::Mode);
+        push("0", "all", ActionTone::Clear);
+        push("n", "new", ActionTone::Add);
+        if selected_tag(settings, state).is_some() {
+            push("m", "assign", ActionTone::Mode);
+            push("e", "rename", ActionTone::Edit);
+            push("d", "delete", ActionTone::Destructive);
+        }
+        push("/", "search", ActionTone::Search);
+        push("Esc", "back", ActionTone::Cancel);
+    } else {
+        push("↑/↓", "torrent", ActionTone::Navigate);
+        push("t", "tags", ActionTone::Mode);
+        if selected_tag(settings, state).is_some() {
+            push("Space", "toggle", ActionTone::Toggle);
+            push(
+                "m",
+                if state.assignment_mode {
+                    "filter"
+                } else {
+                    "assign"
+                },
+                ActionTone::Mode,
+            );
+        }
+        push("Tab", "tags", ActionTone::Mode);
+        push("/", "search", ActionTone::Search);
+        push("Esc", "back", ActionTone::Cancel);
+    }
+
+    frame.render_widget(
+        Paragraph::new(Line::from(spans))
+            .alignment(Alignment::Center)
+            .style(ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1))),
+        area,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn try_push_footer_action(
+    spans: &mut Vec<Span<'static>>,
+    used: &mut usize,
+    max_width: usize,
+    key: &str,
+    label: &str,
+    tone: ActionTone,
+    ctx: &ThemeContext,
+) -> bool {
+    let separator = if spans.is_empty() { "" } else { " | " };
+    let key_text = format!("[{key}]");
+    let width = separator.chars().count() + key_text.chars().count() + label.chars().count();
+    if used.saturating_add(width) > max_width {
+        return false;
+    }
+    if !separator.is_empty() {
+        spans.push(Span::styled(
+            separator.to_string(),
+            ctx.apply(Style::default().fg(ctx.theme.semantic.overlay0)),
+        ));
+    }
+    spans.push(Span::styled(key_text, footer_key_style(ctx, tone)));
+    spans.push(Span::styled(
+        label.to_string(),
+        ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0)),
+    ));
+    *used += width;
+    true
+}
+
+fn draw_delete_confirmation(
+    frame: &mut Frame,
+    area: Rect,
+    tag_id: TagId,
+    settings: &Settings,
+    ctx: &ThemeContext,
+) {
+    let tag_name = settings
+        .tag_catalog
+        .get(tag_id)
+        .map(|tag| sanitize_text(&tag.name))
+        .unwrap_or_else(|| format!("Tag {tag_id}"));
+    let assignments = settings
+        .torrents
+        .iter()
+        .filter(|torrent| torrent.tag_ids.contains(&tag_id))
+        .count();
+    let dialog = centered_fixed(area, area.width.min(58), area.height.min(9));
+    frame.render_widget(Clear, dialog);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .padding(Padding::new(2, 2, 1, 1))
+        .border_style(ctx.apply(Style::default().fg(ctx.state_error())));
+    let inner = block.inner(dialog);
+    frame.render_widget(block, dialog);
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(Span::styled(
+                "Delete tag?",
+                ctx.apply(
+                    Style::default()
+                        .fg(ctx.state_warning())
+                        .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+                ),
+            )),
+            Line::from(Span::styled(
+                tag_name,
+                ctx.apply(Style::default().fg(ctx.theme.semantic.text)),
+            )),
+            Line::default(),
+            Line::from(Span::styled(
+                format!(
+                    "This removes {assignments} assignment{}; torrent data is untouched.",
+                    if assignments == 1 { "" } else { "s" }
+                ),
+                ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1)),
+            )),
+        ])
+        .alignment(Alignment::Center)
+        .wrap(Wrap { trim: true }),
+        inner,
+    );
+}
+
+fn centered_fixed(area: Rect, width: u16, height: u16) -> Rect {
+    let width = width.min(area.width);
+    let height = height.min(area.height);
+    Rect::new(
+        area.x + area.width.saturating_sub(width) / 2,
+        area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::{TorrentMetrics, TorrentPreviewPayload};
+    use crate::config::TorrentSettings;
+    use crate::dht_service::{DhtStatus, DhtWaveTelemetry};
+    use crate::theme::ThemeContext;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    use std::path::PathBuf;
+
+    fn test_settings() -> Settings {
+        let mut settings = Settings::default();
+        let curated = settings
+            .tag_catalog
+            .create_manual("Curated")
+            .expect("create tag");
+        let later = settings
+            .tag_catalog
+            .create_manual("Read Later")
+            .expect("create tag");
+        settings.torrents = vec![
+            TorrentSettings {
+                torrent_or_magnet: "magnet:?xt=urn:btih:1111111111111111111111111111111111111111"
+                    .to_string(),
+                name: "Sample Archive".to_string(),
+                tag_ids: vec![curated],
+                ..Default::default()
+            },
+            TorrentSettings {
+                torrent_or_magnet: "magnet:?xt=urn:btih:2222222222222222222222222222222222222222"
+                    .to_string(),
+                name: "Field Notes".to_string(),
+                tag_ids: vec![later],
+                ..Default::default()
+            },
+        ];
+        settings
+    }
+
+    fn test_app_state() -> AppState {
+        let mut state = AppState {
+            mode: AppMode::TagManagement,
+            ..Default::default()
+        };
+        let hash = vec![0x11; 20];
+        let file = RawNode {
+            name: "summary.txt".to_string(),
+            full_path: PathBuf::from("notes/summary.txt"),
+            children: Vec::new(),
+            payload: TorrentPreviewPayload {
+                file_index: Some(0),
+                size: 2048,
+                ..Default::default()
+            },
+            is_dir: false,
+        };
+        state.torrents.insert(
+            hash.clone(),
+            TorrentDisplayState {
+                latest_state: TorrentMetrics {
+                    info_hash: hash.clone(),
+                    torrent_name: "Sample Archive".to_string(),
+                    number_of_pieces_total: 4,
+                    number_of_pieces_completed: 2,
+                    ..Default::default()
+                },
+                file_preview_tree: vec![file],
+                ..Default::default()
+            },
+        );
+        state.torrent_list_order.push(hash);
+        state
+    }
+
+    fn render_screen(settings: &Settings, state: &AppState, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        let dht_status = DhtStatus::default();
+        let telemetry = DhtWaveTelemetry::default();
+        let ctx = ThemeContext::new(state.theme, 0.0);
+        terminal
+            .draw(|frame| {
+                let screen = ScreenContext::new(state, &dht_status, &telemetry, settings, &ctx);
+                draw(frame, &screen);
+            })
+            .expect("draw tag screen");
+        let buffer = terminal.backend().buffer();
+        (0..height)
+            .map(|y| {
+                (0..width)
+                    .filter_map(|x| buffer.cell((x, y)).map(|cell| cell.symbol()))
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn all_filter_is_the_first_pill_and_specific_tags_filter_results() {
+        let settings = test_settings();
+        let app_state = test_app_state();
+        let mut state = TagManagementUiState::default();
+
+        assert!(selected_tag(&settings, &state).is_none());
+        assert_eq!(visible_torrents(&settings, &app_state, &state).len(), 2);
+
+        state.selected_tag_index = 1;
+        assert_eq!(
+            selected_tag(&settings, &state).map(|tag| tag.name.as_str()),
+            Some("Curated")
+        );
+        assert_eq!(visible_torrents(&settings, &app_state, &state).len(), 1);
+        assert_eq!(
+            visible_torrents(&settings, &app_state, &state)[0].name,
+            "Sample Archive"
+        );
+    }
+
+    #[test]
+    fn file_search_keeps_its_parent_torrent_visible() {
+        let settings = test_settings();
+        let app_state = test_app_state();
+        let state = TagManagementUiState {
+            search_query: "summary".to_string(),
+            ..Default::default()
+        };
+
+        let visible = visible_torrents(&settings, &app_state, &state);
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].name, "Sample Archive");
+    }
+
+    #[test]
+    fn assignment_mode_keeps_unassigned_torrents_available() {
+        let settings = test_settings();
+        let app_state = test_app_state();
+        let filtered = TagManagementUiState {
+            selected_tag_index: 1,
+            ..Default::default()
+        };
+        assert_eq!(visible_torrents(&settings, &app_state, &filtered).len(), 1);
+
+        let assigning = TagManagementUiState {
+            assignment_mode: true,
+            ..filtered
+        };
+        assert_eq!(visible_torrents(&settings, &app_state, &assigning).len(), 2);
+    }
+
+    #[test]
+    fn redesigned_screen_renders_filter_pills_and_file_results() {
+        let settings = test_settings();
+        let state = test_app_state();
+        let rendered = render_screen(&settings, &state, 100, 30);
+
+        for expected in [
+            "Filter by tag",
+            "All",
+            "Curated",
+            "Read Later",
+            "Results · 2 torrents · 1 file",
+            "Sample Archive",
+            "notes/summary.txt",
+            "Field Notes",
+            "[Tab]results",
+        ] {
+            assert!(
+                rendered.contains(expected),
+                "missing {expected:?}\n{rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn narrow_tag_pills_wrap_onto_multiple_lines() {
+        let settings = test_settings();
+        let state = TagManagementUiState::default();
+        let app_state = test_app_state();
+        let ctx = ThemeContext::new(app_state.theme, 0.0);
+
+        let lines = build_tag_pill_lines(&settings, &state, 18, &ctx);
+        assert!(lines.len() >= 2);
+    }
+}

--- a/src/tui/screens/torrents.rs
+++ b/src/tui/screens/torrents.rs
@@ -18,6 +18,7 @@ use crate::tui::formatters::{
 use crate::tui::layout::common::{compute_smart_table_layout, SmartCol};
 use crate::tui::screen_context::ScreenContext;
 use crate::tui::screens::input_panel::draw_prompt_panel;
+use crate::tui::screens::tag_picker;
 use chrono::{DateTime, Local};
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
@@ -174,6 +175,16 @@ pub fn handle_event(event: CrosstermEvent, app: &mut App) -> bool {
         return false;
     }
 
+    if tag_picker::is_open(&app.app_state) {
+        return tag_picker::handle_event(event, app);
+    }
+
+    if should_open_tag_picker(&event, &app.app_state) {
+        let targets = management_targets(&app.app_state);
+        tag_picker::open(app, targets);
+        return true;
+    }
+
     let CrosstermEvent::Key(key) = event else {
         return false;
     };
@@ -187,6 +198,23 @@ pub fn handle_event(event: CrosstermEvent, app: &mut App) -> bool {
     }
     execute_management_effects(app, result.effects);
     result.consumed
+}
+
+fn should_open_tag_picker(event: &CrosstermEvent, app_state: &AppState) -> bool {
+    if app_state.ui.torrent_management.is_searching
+        || app_state.ui.torrent_management.confirm_submit
+    {
+        return false;
+    }
+    matches!(
+        event,
+        CrosstermEvent::Key(KeyEvent {
+            code: KeyCode::Char('t'),
+            kind: KeyEventKind::Press,
+            modifiers: KeyModifiers::NONE,
+            ..
+        })
+    )
 }
 
 fn map_key_event_to_management_action_with_latch(
@@ -727,6 +755,7 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
     if app_state.ui.torrent_management.confirm_submit {
         draw_management_review_panel(f, app_state, ctx);
     }
+    tag_picker::draw(f, screen);
 }
 
 fn management_content_area(area: Rect) -> Rect {
@@ -1078,6 +1107,7 @@ fn draw_management_footer(f: &mut Frame, app_state: &AppState, area: Rect, ctx: 
         }
         push_action("u", core_label("clear"), ActionTone::Clear, true);
         push_action("Space", core_label("select"), ActionTone::Select, true);
+        push_action("t", core_label("tags"), ActionTone::Mode, true);
         push_action("A", core_label("all"), ActionTone::Select, true);
         push_action("p", core_label("pause"), ActionTone::Queue, true);
         push_action(

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -5,7 +5,8 @@ use ratatui::{prelude::*, widgets::*};
 
 use crate::tui::screen_context::ScreenContext;
 use crate::tui::screens::{
-    browser, config, delete_confirm, help, journal, normal, peers, power, rss, torrents, welcome,
+    browser, config, delete_confirm, help, journal, normal, peers, power, rss, tags, torrents,
+    welcome,
 };
 
 use crate::app::{AppMode, AppState};
@@ -50,6 +51,13 @@ pub fn draw(
         AppMode::TorrentManagement => {
             apply_theme_particles_background_to_frame(f, &ctx);
             torrents::draw(f, &screen);
+            apply_theme_effects_to_frame(f, &ctx);
+            apply_theme_particles_foreground_to_frame(f, &ctx);
+            return;
+        }
+        AppMode::TagManagement => {
+            apply_theme_particles_background_to_frame(f, &ctx);
+            tags::draw(f, &screen);
             apply_theme_effects_to_frame(f, &ctx);
             apply_theme_particles_foreground_to_frame(f, &ctx);
             return;


### PR DESCRIPTION
## Summary

- add persistent manual and generated torrent tag definitions and assignments
- add CLI commands for listing, creating, renaming, deleting, assigning, and removing tags
- add TUI tag management and torrent tag-picker screens with accessible selection styling
- preserve tag data across standalone and shared configurations
- harden tag-name resolution, generated-tag constraints, modal input handling, and large-file preview rendering

## Why

Superseedr did not have a structured way to organize torrents across the TUI, CLI, and shared configuration workflows. This introduces a common tag model while leaving room for future provider-generated tags.

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --all-targets --no-default-features -- -D warnings`

Closes #307
