### PR TITLE
Add automatic file priority rules

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -424,6 +424,7 @@ pub enum FilePriority {
     #[default]
     Normal,
     High,
+    Low,
     Skip,
     Mixed, // Used for folders that contain children with different priorities
 }
@@ -431,7 +432,8 @@ pub enum FilePriority {
 impl FilePriority {
     pub fn next(&self) -> Self {
         match self {
-            Self::Normal => Self::Skip,
+            Self::Normal => Self::Low,
+            Self::Low => Self::Skip,
             Self::Skip => Self::High,
             Self::High => Self::Normal,
             Self::Mixed => Self::Normal, // Reset mixed to Normal on toggle
@@ -1089,6 +1091,7 @@ pub enum AppMode {
     DeleteConfirm,
     Config,
     FileBrowser,
+    FilePriorityRules,
     Rss,
 }
 
@@ -1236,6 +1239,8 @@ pub struct TorrentMetrics {
     pub is_multi_file: bool,
     pub file_count: Option<usize>,
     pub file_priorities: HashMap<usize, FilePriority>,
+    #[serde(default)]
+    pub file_priority_rules_pending: bool,
     pub data_available: bool,
     pub is_complete: bool,
     pub number_of_successfully_connected_peers: usize,
@@ -1297,6 +1302,7 @@ impl Default for TorrentMetrics {
             is_multi_file: false,
             file_count: None,
             file_priorities: HashMap::new(),
+            file_priority_rules_pending: false,
             data_available: true,
             is_complete: false,
             number_of_successfully_connected_peers: 0,
@@ -1660,6 +1666,7 @@ pub struct UiState {
     pub config: ConfigUiState,
     pub delete_confirm: DeleteConfirmUiState,
     pub file_browser: FileBrowserUiState,
+    pub file_priority_rules: FilePriorityRulesUiState,
     pub help: HelpUiState,
     pub journal: JournalUiState,
     pub peer_management: PeerManagementUiState,
@@ -1667,6 +1674,48 @@ pub struct UiState {
     pub normal_paste_burst: PasteBurst,
     #[allow(dead_code)]
     pub rss: RssUiState,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum FilePriorityRuleEditField {
+    #[default]
+    Name,
+    Target,
+    Pattern,
+    Priority,
+    Enabled,
+}
+
+impl FilePriorityRuleEditField {
+    pub fn next(self) -> Self {
+        match self {
+            Self::Name => Self::Target,
+            Self::Target => Self::Pattern,
+            Self::Pattern => Self::Priority,
+            Self::Priority => Self::Enabled,
+            Self::Enabled => Self::Name,
+        }
+    }
+
+    pub fn previous(self) -> Self {
+        match self {
+            Self::Name => Self::Enabled,
+            Self::Target => Self::Name,
+            Self::Pattern => Self::Target,
+            Self::Priority => Self::Pattern,
+            Self::Enabled => Self::Priority,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct FilePriorityRulesUiState {
+    pub selected_index: usize,
+    pub draft: Option<crate::config::FilePriorityRule>,
+    pub draft_index: Option<usize>,
+    pub edit_field: FilePriorityRuleEditField,
+    pub delete_confirm_armed: bool,
+    pub status_message: Option<String>,
 }
 
 impl UiState {
@@ -1919,7 +1968,10 @@ pub fn build_torrent_preview_tree(
     build_torrent_preview_tree_from_entries(entries, file_priorities)
 }
 
-fn load_torrent_file_preview(path: &Path) -> Result<TorrentFilePreview, String> {
+fn load_torrent_file_preview(
+    path: &Path,
+    rules: &[crate::config::FilePriorityRule],
+) -> Result<TorrentFilePreview, String> {
     let file_bytes = fs::read(path).map_err(|error| {
         format_filesystem_path_error("Failed to read torrent preview", path, &error)
     })?;
@@ -1932,11 +1984,19 @@ fn load_torrent_file_preview(path: &Path) -> Result<TorrentFilePreview, String> 
     }
     .to_string();
 
+    let file_list = torrent.file_list();
+    let file_paths = file_list
+        .iter()
+        .map(|(parts, _)| parts.clone())
+        .collect::<Vec<_>>();
+    let priorities =
+        crate::file_priority_rules::evaluate_file_priority_rules(rules, &file_paths).priorities;
+
     Ok(TorrentFilePreview {
         name: torrent.info.name.clone(),
         protocol_version,
         total_size: torrent.info.total_length().max(0) as u64,
-        tree: build_torrent_preview_tree(torrent.file_list(), &HashMap::new()),
+        tree: build_torrent_preview_tree(file_list, &priorities),
     })
 }
 
@@ -4249,22 +4309,16 @@ impl App {
         let default_container_name = format!("{} [{}]", torrent.info.name, info_hash_hex);
         let file_list = torrent.file_list();
         let should_enclose = file_list.len() > 1;
-        let preview_payloads: Vec<(Vec<String>, TorrentPreviewPayload)> = file_list
-            .into_iter()
-            .enumerate()
-            .map(|(idx, (parts, size))| {
-                (
-                    parts,
-                    TorrentPreviewPayload {
-                        file_index: Some(idx),
-                        size,
-                        priority: FilePriority::Normal,
-                    },
-                )
-            })
-            .collect();
-
-        let preview_tree = RawNode::from_path_list(None, preview_payloads);
+        let file_paths = file_list
+            .iter()
+            .map(|(parts, _)| parts.clone())
+            .collect::<Vec<_>>();
+        let priorities = crate::file_priority_rules::evaluate_file_priority_rules(
+            &self.client_configs.file_priority_rules,
+            &file_paths,
+        )
+        .priorities;
+        let preview_tree = build_torrent_preview_tree(file_list, &priorities);
         let mut preview_state = TreeViewState::new();
         for node in &preview_tree {
             node.expand_all(&mut preview_state);
@@ -5875,7 +5929,7 @@ impl App {
         }
 
         let ingest_result = if torrent_config.torrent_or_magnet.starts_with("magnet:") {
-            self.add_magnet_torrent(
+            self.add_magnet_torrent_with_rule_policy(
                 torrent_config.name.clone(),
                 torrent_config.torrent_or_magnet.clone(),
                 torrent_config.download_path.clone(),
@@ -5883,16 +5937,18 @@ impl App {
                 torrent_config.torrent_control_state.clone(),
                 torrent_config.file_priorities.clone(),
                 torrent_config.container_name.clone(),
+                torrent_config.file_priority_rules_pending,
             )
             .await
         } else {
-            self.add_torrent_from_file(
+            self.add_torrent_from_file_with_rule_policy(
                 PathBuf::from(&torrent_config.torrent_or_magnet),
                 torrent_config.download_path.clone(),
                 torrent_config.validation_status,
                 torrent_config.torrent_control_state.clone(),
                 torrent_config.file_priorities.clone(),
                 torrent_config.container_name.clone(),
+                torrent_config.file_priority_rules_pending,
             )
             .await
         };
@@ -6088,6 +6144,13 @@ impl App {
             for manager_tx in self.torrent_manager_command_txs.values() {
                 let _ = manager_tx.try_send(ManagerCommand::SetDataRate(
                     new_settings.ui_refresh_rate.as_ms(),
+                ));
+            }
+        }
+        if new_settings.file_priority_rules != old_settings.file_priority_rules {
+            for manager_tx in self.torrent_manager_command_txs.values() {
+                let _ = manager_tx.try_send(ManagerCommand::UpdateFilePriorityRules(
+                    new_settings.file_priority_rules.clone(),
                 ));
             }
         }
@@ -6863,6 +6926,22 @@ impl App {
 
                 let mut file_priorities = HashMap::new();
                 if let Some(display) = self.app_state.torrents.get_mut(&info_hash) {
+                    if display.latest_state.file_priority_rules_pending {
+                        let file_paths = torrent
+                            .file_list()
+                            .into_iter()
+                            .map(|(parts, _)| parts)
+                            .collect::<Vec<_>>();
+                        let mut automatic =
+                            crate::file_priority_rules::evaluate_file_priority_rules(
+                                &self.client_configs.file_priority_rules,
+                                &file_paths,
+                            )
+                            .priorities;
+                        automatic.extend(display.latest_state.file_priorities.clone());
+                        display.latest_state.file_priorities = automatic;
+                        display.latest_state.file_priority_rules_pending = false;
+                    }
                     display.latest_state.is_multi_file = !torrent.info.files.is_empty();
                     display.latest_state.file_count = Some(torrent_file_count(&torrent));
                     display.latest_state.total_size = torrent.info.total_length().max(0) as u64;
@@ -6872,6 +6951,7 @@ impl App {
                 }
 
                 self.persist_torrent_metadata_snapshot(&info_hash, &torrent, &file_priorities);
+                self.save_state_to_disk();
 
                 self.dispatch_integrity_probe_batches();
 
@@ -7133,13 +7213,15 @@ impl App {
         self.app_state.ui.needs_redraw = true;
 
         let tx = self.app_command_tx.clone();
+        let rules = self.client_configs.file_priority_rules.clone();
         tokio::spawn(async move {
             let load_path = path.clone();
-            let result =
-                tokio::task::spawn_blocking(move || load_torrent_file_preview(load_path.as_path()))
-                    .await
-                    .map_err(|error| format!("Torrent preview task failed: {error}"))
-                    .and_then(|result| result);
+            let result = tokio::task::spawn_blocking(move || {
+                load_torrent_file_preview(load_path.as_path(), &rules)
+            })
+            .await
+            .map_err(|error| format!("Torrent preview task failed: {error}"))
+            .and_then(|result| result);
             let _ = tx
                 .send(AppCommand::UpdateTorrentFilePreview {
                     browser_generation,
@@ -7742,6 +7824,29 @@ impl App {
         file_priorities: HashMap<usize, FilePriority>,
         container_name: Option<String>,
     ) -> CommandIngestResult {
+        self.add_torrent_from_file_with_rule_policy(
+            path,
+            download_path,
+            is_validated,
+            torrent_control_state,
+            file_priorities,
+            container_name,
+            true,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn add_torrent_from_file_with_rule_policy(
+        &mut self,
+        path: PathBuf,
+        download_path: Option<PathBuf>,
+        is_validated: bool,
+        torrent_control_state: TorrentControlState,
+        file_priorities: HashMap<usize, FilePriority>,
+        container_name: Option<String>,
+        apply_file_priority_rules: bool,
+    ) -> CommandIngestResult {
         let buffer = match fs::read(&path) {
             Ok(buf) => buf,
             Err(e) => {
@@ -7780,6 +7885,23 @@ impl App {
                     message,
                 };
             }
+        };
+
+        let file_priorities = if apply_file_priority_rules {
+            let file_paths = torrent
+                .file_list()
+                .into_iter()
+                .map(|(parts, _)| parts)
+                .collect::<Vec<_>>();
+            let mut automatic = crate::file_priority_rules::evaluate_file_priority_rules(
+                &self.client_configs.file_priority_rules,
+                &file_paths,
+            )
+            .priorities;
+            automatic.extend(file_priorities);
+            automatic
+        } else {
+            file_priorities
         };
 
         #[cfg(all(feature = "dht", feature = "pex"))]
@@ -8028,6 +8150,7 @@ impl App {
             global_dl_bucket: global_dl_bucket_clone,
             global_ul_bucket: global_ul_bucket_clone,
             file_priorities: file_priorities.clone(),
+            file_priority_rules_pending: false,
         };
         let start_paused = torrent_control_state == TorrentControlState::Paused;
         let should_announce_on_add = torrent_control_state == TorrentControlState::Running
@@ -8095,6 +8218,31 @@ impl App {
         torrent_control_state: TorrentControlState,
         file_priorities: HashMap<usize, FilePriority>,
         container_name: Option<String>,
+    ) -> CommandIngestResult {
+        self.add_magnet_torrent_with_rule_policy(
+            torrent_name,
+            magnet_link,
+            download_path,
+            is_validated,
+            torrent_control_state,
+            file_priorities,
+            container_name,
+            true,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn add_magnet_torrent_with_rule_policy(
+        &mut self,
+        torrent_name: String,
+        magnet_link: String,
+        download_path: Option<PathBuf>,
+        is_validated: bool,
+        torrent_control_state: TorrentControlState,
+        file_priorities: HashMap<usize, FilePriority>,
+        container_name: Option<String>,
+        apply_file_priority_rules: bool,
     ) -> CommandIngestResult {
         let magnet = match Magnet::new(&magnet_link) {
             Ok(m) => m,
@@ -8174,6 +8322,7 @@ impl App {
                 is_complete: is_validated,
                 is_multi_file: false,
                 file_count: None,
+                file_priority_rules_pending: apply_file_priority_rules,
                 ..Default::default()
             },
             added_at_unix_secs: Some(current_unix_secs()),
@@ -8220,6 +8369,7 @@ impl App {
             global_dl_bucket: global_dl_bucket_clone,
             global_ul_bucket: global_ul_bucket_clone,
             file_priorities: file_priorities.clone(),
+            file_priority_rules_pending: apply_file_priority_rules,
         };
         let start_paused = torrent_control_state == TorrentControlState::Paused;
         let should_announce_on_add = torrent_control_state == TorrentControlState::Running
@@ -9977,6 +10127,7 @@ fn build_persist_payload(
                 torrent_control_state: torrent_state.torrent_control_state.clone(),
                 delete_files: torrent_state.delete_files,
                 file_priorities: torrent_state.file_priorities.clone(),
+                file_priority_rules_pending: torrent_state.file_priority_rules_pending,
             })
         })
         .collect();
@@ -16719,12 +16870,32 @@ mod tests {
             .join("v1")
             .join("single_4k.bin.torrent");
 
-        let preview = load_torrent_file_preview(&fixture).expect("load preview");
+        let preview = load_torrent_file_preview(&fixture, &[]).expect("load preview");
 
         assert!(!preview.name.is_empty());
         assert_eq!(preview.protocol_version, "BitTorrent v1");
         assert_eq!(preview.total_size, 4096);
         assert!(!preview.tree.is_empty());
+    }
+
+    #[test]
+    fn torrent_file_preview_loader_applies_automatic_rules() {
+        let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("integration_tests")
+            .join("torrents")
+            .join("v1")
+            .join("single_4k.bin.torrent");
+        let rules = vec![crate::config::FilePriorityRule {
+            name: "Deprioritize binary fixtures".to_string(),
+            target: crate::config::FilePriorityRuleTarget::Extension,
+            pattern: ".bin".to_string(),
+            priority: FilePriority::Low,
+            enabled: true,
+        }];
+
+        let preview = load_torrent_file_preview(&fixture, &rules).expect("load preview");
+
+        assert_eq!(preview.tree[0].payload.priority, FilePriority::Low);
     }
 
     #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,55 @@ use strum_macros::EnumIter;
 
 pub const UNLIMITED_RATE_LIMIT_BPS: u64 = i64::MAX as u64;
 
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum FilePriorityRuleTarget {
+    #[default]
+    Extension,
+    Name,
+    Path,
+}
+
+impl FilePriorityRuleTarget {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Extension => "extension",
+            Self::Name => "name",
+            Self::Path => "path",
+        }
+    }
+
+    pub fn next(self) -> Self {
+        match self {
+            Self::Extension => Self::Name,
+            Self::Name => Self::Path,
+            Self::Path => Self::Extension,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(default)]
+pub struct FilePriorityRule {
+    pub name: String,
+    pub enabled: bool,
+    pub target: FilePriorityRuleTarget,
+    pub pattern: String,
+    pub priority: FilePriority,
+}
+
+impl Default for FilePriorityRule {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            enabled: true,
+            target: FilePriorityRuleTarget::Extension,
+            pattern: String::new(),
+            priority: FilePriority::Skip,
+        }
+    }
+}
+
 pub fn is_unlimited_rate_limit_bps(limit_bps: u64) -> bool {
     limit_bps == 0 || limit_bps >= UNLIMITED_RATE_LIMIT_BPS
 }
@@ -253,6 +302,7 @@ pub struct Settings {
     pub tracker_fallback_interval_secs: u64,
     pub client_leeching_fallback_interval_secs: u64,
     pub output_status_interval: u64,
+    pub file_priority_rules: Vec<FilePriorityRule>,
     pub rss: RssSettings,
 }
 
@@ -296,6 +346,7 @@ impl Default for Settings {
             tracker_fallback_interval_secs: 1800,
             client_leeching_fallback_interval_secs: 60,
             output_status_interval: 0,
+            file_priority_rules: Vec::new(),
             rss: RssSettings::default(),
         }
     }
@@ -314,6 +365,8 @@ pub struct TorrentSettings {
     pub delete_files: bool,
     #[serde(with = "string_usize_map")]
     pub file_priorities: HashMap<usize, FilePriority>,
+    /// True only while a newly-added torrent is waiting for metadata-time rule evaluation.
+    pub file_priority_rules_pending: bool,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
@@ -441,6 +494,7 @@ struct CatalogTorrentSettings {
     pub delete_files: bool,
     #[serde(with = "string_usize_map")]
     pub file_priorities: HashMap<usize, FilePriority>,
+    pub file_priority_rules_pending: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -473,6 +527,7 @@ struct SharedSettingsConfig {
     pub tracker_fallback_interval_secs: u64,
     pub client_leeching_fallback_interval_secs: u64,
     pub output_status_interval: u64,
+    pub file_priority_rules: Vec<FilePriorityRule>,
     pub rss: RssSettings,
 }
 
@@ -506,6 +561,7 @@ impl Default for SharedSettingsConfig {
             tracker_fallback_interval_secs: settings.tracker_fallback_interval_secs,
             client_leeching_fallback_interval_secs: settings.client_leeching_fallback_interval_secs,
             output_status_interval: settings.output_status_interval,
+            file_priority_rules: settings.file_priority_rules,
             rss: settings.rss,
         }
     }
@@ -725,6 +781,7 @@ impl CatalogTorrentSettings {
             torrent_control_state: settings.torrent_control_state.clone(),
             delete_files: settings.delete_files,
             file_priorities: settings.file_priorities.clone(),
+            file_priority_rules_pending: settings.file_priority_rules_pending,
         })
     }
 
@@ -756,6 +813,7 @@ impl CatalogTorrentSettings {
             torrent_control_state: self.torrent_control_state.clone(),
             delete_files: self.delete_files,
             file_priorities: self.file_priorities.clone(),
+            file_priority_rules_pending: self.file_priority_rules_pending,
         })
     }
 }
@@ -941,6 +999,7 @@ impl SharedSettingsConfig {
             tracker_fallback_interval_secs: settings.tracker_fallback_interval_secs,
             client_leeching_fallback_interval_secs: settings.client_leeching_fallback_interval_secs,
             output_status_interval: settings.output_status_interval,
+            file_priority_rules: settings.file_priority_rules.clone(),
             rss: settings.rss.clone(),
         })
     }
@@ -986,6 +1045,7 @@ impl SharedSettingsConfig {
         settings.client_leeching_fallback_interval_secs =
             self.client_leeching_fallback_interval_secs;
         settings.output_status_interval = self.output_status_interval;
+        settings.file_priority_rules = self.file_priority_rules.clone();
         settings.rss = self.rss.clone();
         Ok(())
     }

--- a/src/control_service.rs
+++ b/src/control_service.rs
@@ -247,7 +247,6 @@ pub fn file_priorities_to_map(
 ) -> HashMap<usize, FilePriority> {
     values
         .iter()
-        .filter(|value| !matches!(value.priority, FilePriority::Normal))
         .map(|value| (value.file_index, value.priority))
         .collect()
 }
@@ -1407,6 +1406,7 @@ pub fn apply_offline_control_request(
                 container_name,
                 file_priorities,
                 validation_status,
+                file_priority_rules_pending: true,
                 ..TorrentSettings::default()
             });
             Ok(format!(
@@ -1430,6 +1430,7 @@ pub fn apply_offline_control_request(
                 container_name,
                 file_priorities,
                 validation_status,
+                file_priority_rules_pending: true,
                 ..TorrentSettings::default()
             });
             Ok("Queued magnet for the next runtime".to_string())
@@ -1895,7 +1896,10 @@ mod tests {
                 assert_eq!(torrent.container_name, Some(String::new()));
                 assert_eq!(
                     torrent.file_priorities,
-                    HashMap::from([(1, crate::app::FilePriority::Skip)])
+                    HashMap::from([
+                        (0, crate::app::FilePriority::Normal),
+                        (1, crate::app::FilePriority::Skip),
+                    ])
                 );
             }
             other => panic!("unexpected plan: {:?}", other),

--- a/src/file_priority_rules.rs
+++ b/src/file_priority_rules.rs
@@ -1,0 +1,255 @@
+// SPDX-FileCopyrightText: 2025 The superseedr Contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::collections::HashMap;
+
+use crate::app::FilePriority;
+use crate::config::{FilePriorityRule, FilePriorityRuleTarget};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RuleMatch {
+    pub rule_index: usize,
+    pub rule_name: String,
+    pub priority: FilePriority,
+    pub winning: bool,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RuleEvaluation {
+    pub priorities: HashMap<usize, FilePriority>,
+    pub matches: HashMap<usize, Vec<RuleMatch>>,
+}
+
+pub fn validate_rule(rule: &FilePriorityRule) -> Result<(), String> {
+    if rule.name.trim().is_empty() {
+        return Err("Rule name cannot be empty".to_string());
+    }
+    if rule.pattern.trim().is_empty() {
+        return Err("Rule pattern cannot be empty".to_string());
+    }
+    if matches!(rule.priority, FilePriority::Mixed) {
+        return Err("Mixed is a display-only priority".to_string());
+    }
+    if matches!(rule.target, FilePriorityRuleTarget::Extension)
+        && rule.pattern.contains(['/', '\\'])
+    {
+        return Err("Extension patterns cannot contain path separators".to_string());
+    }
+    Ok(())
+}
+
+pub fn evaluate_file_priority_rules(
+    rules: &[FilePriorityRule],
+    file_paths: &[Vec<String>],
+) -> RuleEvaluation {
+    let mut result = RuleEvaluation::default();
+
+    for (file_index, parts) in file_paths.iter().enumerate() {
+        let name = parts.last().map(String::as_str).unwrap_or_default();
+        let path = parts.join("/");
+        let mut file_matches = Vec::new();
+        let mut winner_selected = false;
+
+        for (rule_index, rule) in rules.iter().enumerate() {
+            if !rule.enabled || validate_rule(rule).is_err() || !rule_matches(rule, name, &path) {
+                continue;
+            }
+
+            let winning = !winner_selected;
+            if winning {
+                winner_selected = true;
+                if !matches!(rule.priority, FilePriority::Normal) {
+                    result.priorities.insert(file_index, rule.priority);
+                }
+            }
+            file_matches.push(RuleMatch {
+                rule_index,
+                rule_name: rule.name.clone(),
+                priority: rule.priority,
+                winning,
+            });
+        }
+
+        if !file_matches.is_empty() {
+            result.matches.insert(file_index, file_matches);
+        }
+    }
+
+    result
+}
+
+fn rule_matches(rule: &FilePriorityRule, name: &str, path: &str) -> bool {
+    match rule.target {
+        FilePriorityRuleTarget::Extension => extension_matches(name, &rule.pattern),
+        FilePriorityRuleTarget::Name => wildcard_match(&rule.pattern, name),
+        FilePriorityRuleTarget::Path => wildcard_match(&rule.pattern, path),
+    }
+}
+
+fn extension_matches(name: &str, pattern: &str) -> bool {
+    let normalized = pattern
+        .trim()
+        .trim_start_matches('*')
+        .trim_start_matches('.')
+        .to_lowercase();
+    if normalized.is_empty() {
+        return false;
+    }
+    name.to_lowercase().ends_with(&format!(".{normalized}"))
+}
+
+fn wildcard_match(pattern: &str, candidate: &str) -> bool {
+    let pattern: Vec<char> = pattern.trim().to_lowercase().chars().collect();
+    let candidate: Vec<char> = candidate.to_lowercase().chars().collect();
+    let mut previous = vec![false; candidate.len() + 1];
+    previous[0] = true;
+
+    for token in pattern {
+        let mut current = vec![false; candidate.len() + 1];
+        if token == '*' {
+            current[0] = previous[0];
+        }
+        for column in 1..=candidate.len() {
+            current[column] = match token {
+                '*' => previous[column] || current[column - 1],
+                '?' => previous[column - 1],
+                literal => previous[column - 1] && literal == candidate[column - 1],
+            };
+        }
+        previous = current;
+    }
+
+    previous[candidate.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule(
+        name: &str,
+        target: FilePriorityRuleTarget,
+        pattern: &str,
+        priority: FilePriority,
+    ) -> FilePriorityRule {
+        FilePriorityRule {
+            name: name.to_string(),
+            target,
+            pattern: pattern.to_string(),
+            priority,
+            ..FilePriorityRule::default()
+        }
+    }
+
+    #[test]
+    fn extension_rules_are_case_insensitive_and_accept_a_leading_dot() {
+        let rules = vec![rule(
+            "Skip executables",
+            FilePriorityRuleTarget::Extension,
+            ".exe",
+            FilePriority::Skip,
+        )];
+        let paths = vec![vec!["tools".into(), "helper.EXE".into()]];
+
+        let evaluation = evaluate_file_priority_rules(&rules, &paths);
+
+        assert_eq!(evaluation.priorities.get(&0), Some(&FilePriority::Skip));
+        assert!(evaluation.matches[&0][0].winning);
+    }
+
+    #[test]
+    fn name_and_path_rules_support_glob_wildcards() {
+        let rules = vec![
+            rule(
+                "Prefer samples",
+                FilePriorityRuleTarget::Name,
+                "sample-??.bin",
+                FilePriority::High,
+            ),
+            rule(
+                "Deprioritize extras",
+                FilePriorityRuleTarget::Path,
+                "bundle/extras/*",
+                FilePriority::Low,
+            ),
+        ];
+        let paths = vec![
+            vec!["bundle".into(), "sample-01.bin".into()],
+            vec!["bundle".into(), "extras".into(), "notes.txt".into()],
+        ];
+
+        let evaluation = evaluate_file_priority_rules(&rules, &paths);
+
+        assert_eq!(evaluation.priorities.get(&0), Some(&FilePriority::High));
+        assert_eq!(evaluation.priorities.get(&1), Some(&FilePriority::Low));
+    }
+
+    #[test]
+    fn first_enabled_match_wins_but_all_matches_are_reported() {
+        let mut disabled = rule(
+            "Disabled",
+            FilePriorityRuleTarget::Name,
+            "*",
+            FilePriority::High,
+        );
+        disabled.enabled = false;
+        let rules = vec![
+            disabled,
+            rule(
+                "Skip text",
+                FilePriorityRuleTarget::Extension,
+                "txt",
+                FilePriority::Skip,
+            ),
+            rule(
+                "Everything normal",
+                FilePriorityRuleTarget::Name,
+                "*",
+                FilePriority::Normal,
+            ),
+        ];
+
+        let evaluation =
+            evaluate_file_priority_rules(&rules, &[vec!["fictional-notes.txt".into()]]);
+
+        assert_eq!(evaluation.priorities.get(&0), Some(&FilePriority::Skip));
+        assert_eq!(evaluation.matches[&0].len(), 2);
+        assert!(evaluation.matches[&0][0].winning);
+        assert!(!evaluation.matches[&0][1].winning);
+    }
+
+    #[test]
+    fn invalid_and_disabled_rules_do_not_match() {
+        let rules = vec![FilePriorityRule::default()];
+        let evaluation = evaluate_file_priority_rules(&rules, &[vec!["sample.bin".into()]]);
+        assert!(evaluation.priorities.is_empty());
+        assert!(evaluation.matches.is_empty());
+    }
+
+    #[test]
+    fn settings_toml_round_trip_preserves_ordered_rules() {
+        let settings = crate::config::Settings {
+            file_priority_rules: vec![
+                rule(
+                    "Skip packages",
+                    FilePriorityRuleTarget::Extension,
+                    ".pkg",
+                    FilePriority::Skip,
+                ),
+                rule(
+                    "Prefer primary files",
+                    FilePriorityRuleTarget::Path,
+                    "fictional-set/primary/*",
+                    FilePriority::High,
+                ),
+            ],
+            ..Default::default()
+        };
+
+        let encoded = toml::to_string(&settings).expect("serialize settings");
+        let decoded: crate::config::Settings =
+            toml::from_str(&encoded).expect("deserialize settings");
+
+        assert_eq!(decoded.file_priority_rules, settings.file_priority_rules);
+    }
+}

--- a/src/integrations/cli.rs
+++ b/src/integrations/cli.rs
@@ -212,6 +212,7 @@ pub enum Commands {
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CliPriority {
     Normal,
+    Low,
     High,
     Skip,
 }
@@ -508,6 +509,7 @@ impl From<CliPriority> for FilePriority {
     fn from(value: CliPriority) -> Self {
         match value {
             CliPriority::Normal => FilePriority::Normal,
+            CliPriority::Low => FilePriority::Low,
             CliPriority::High => FilePriority::High,
             CliPriority::Skip => FilePriority::Skip,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod dht;
 mod dht;
 mod dht_service;
 mod errors;
+mod file_priority_rules;
 mod fs_atomic;
 mod integrations;
 mod integrity_scheduler;

--- a/src/synthetic_load.rs
+++ b/src/synthetic_load.rs
@@ -2013,6 +2013,7 @@ fn build_manager_with_rx(
         global_dl_bucket: harness.global_dl_bucket.clone(),
         global_ul_bucket: harness.global_ul_bucket.clone(),
         file_priorities: HashMap::new(),
+        file_priority_rules_pending: false,
     };
 
     let manager = TorrentManager::from_torrent(params, spec.torrent.clone())

--- a/src/torrent_manager/manager.rs
+++ b/src/torrent_manager/manager.rs
@@ -502,9 +502,29 @@ pub struct TorrentManager {
     telemetry: ManagerTelemetry,
     data_rate_ms: u64,
     run_loop_started: bool,
+    file_priority_rules_pending: bool,
 }
 
 impl TorrentManager {
+    fn apply_pending_file_priority_rules(&mut self, torrent: &Torrent) {
+        if !self.file_priority_rules_pending {
+            return;
+        }
+        let file_paths = torrent
+            .file_list()
+            .into_iter()
+            .map(|(parts, _)| parts)
+            .collect::<Vec<_>>();
+        let mut automatic = crate::file_priority_rules::evaluate_file_priority_rules(
+            &self.settings.file_priority_rules,
+            &file_paths,
+        )
+        .priorities;
+        automatic.extend(self.state.file_priorities.clone());
+        self.state.file_priorities = automatic;
+        self.file_priority_rules_pending = false;
+    }
+
     fn should_accept_new_peers(&self) -> bool {
         !self.state.is_paused && self.state.accepting_new_peers
     }
@@ -656,6 +676,7 @@ impl TorrentManager {
             global_dl_bucket,
             global_ul_bucket,
             file_priorities: _,
+            file_priority_rules_pending,
             ..
         } = torrent_parameters;
         let data_rate_ms = settings.ui_refresh_rate.as_ms();
@@ -723,6 +744,7 @@ impl TorrentManager {
             telemetry: ManagerTelemetry::default(),
             data_rate_ms,
             run_loop_started: false,
+            file_priority_rules_pending,
         }
     }
 
@@ -761,6 +783,9 @@ impl TorrentManager {
         // 3. Initialize Base Manager (Awaiting Metadata)
         let mut manager =
             Self::init_base(torrent_parameters, info_hash, trackers, validation_status);
+        manager.state.file_priorities = file_priorities.clone();
+        manager.apply_pending_file_priority_rules(&torrent);
+        let resolved_file_priorities = manager.state.file_priorities.clone();
 
         // 4. Calculate Metadata Length (Required for protocol)
         let bencoded_data = serde_bencode::to_bytes(&torrent)
@@ -776,7 +801,7 @@ impl TorrentManager {
         if let Some(torrent_data_path) = torrent_data_path {
             manager.apply_action(Action::SetUserTorrentConfig {
                 torrent_data_path,
-                file_priorities,
+                file_priorities: resolved_file_priorities,
                 container_name,
             });
         }
@@ -2866,6 +2891,7 @@ impl TorrentManager {
         torrent_state.total_size = total_size_bytes;
         torrent_state.bytes_written = bytes_written;
         torrent_state.file_priorities = self.state.file_priorities.clone();
+        torrent_state.file_priority_rules_pending = self.file_priority_rules_pending;
         torrent_state.file_activity_updates = file_activity_updates;
 
         if self.telemetry.should_emit(&torrent_state) {
@@ -3306,6 +3332,11 @@ impl TorrentManager {
                             }
 
                         },
+                        ManagerCommand::UpdateFilePriorityRules(rules) => {
+                            let mut settings = (*self.settings).clone();
+                            settings.file_priority_rules = rules;
+                            self.settings = Arc::new(settings);
+                        },
                         ManagerCommand::SetUserTorrentConfig { torrent_data_path, file_priorities, container_name } => {
                             self.apply_action(Action::SetUserTorrentConfig {
                                 torrent_data_path,
@@ -3700,6 +3731,7 @@ impl TorrentManager {
 
                             if calculated_hash == self.state.info_hash {
                                 tracing::debug!("METADATA VALIDATED - {}: Proceeding with metadata hydration.", hex::encode(&calculated_hash));
+                                self.apply_pending_file_priority_rules(&torrent);
                                 self.apply_action(Action::MetadataReceived {
                                     torrent: Box::new(torrent.clone()),
                                     metadata_length,
@@ -4057,6 +4089,7 @@ mod tests {
             global_dl_bucket: dl_bucket,
             global_ul_bucket: ul_bucket,
             file_priorities: HashMap::new(),
+            file_priority_rules_pending: false,
         };
 
         let manager = TorrentManager::from_magnet(params, magnet, magnet_link)
@@ -4269,7 +4302,90 @@ mod resource_tests {
             global_dl_bucket: Arc::new(TokenBucket::new(f64::INFINITY, f64::INFINITY)),
             global_ul_bucket: Arc::new(TokenBucket::new(f64::INFINITY, f64::INFINITY)),
             file_priorities: HashMap::new(),
+            file_priority_rules_pending: false,
         }
+    }
+
+    #[tokio::test]
+    async fn from_torrent_applies_pending_rules_before_piece_setup() {
+        let mut params = build_test_params();
+        let mut settings = (*params.settings).clone();
+        settings.file_priority_rules = vec![crate::config::FilePriorityRule {
+            name: "Deprioritize fictional payload".to_string(),
+            target: crate::config::FilePriorityRuleTarget::Name,
+            pattern: "*".to_string(),
+            priority: crate::app::FilePriority::Low,
+            enabled: true,
+        }];
+        params.settings = Arc::new(settings);
+        params.file_priority_rules_pending = true;
+
+        let manager = TorrentManager::from_torrent(params, create_dummy_torrent(1))
+            .expect("manager from torrent");
+
+        assert_eq!(
+            manager.state.file_priorities.get(&0),
+            Some(&crate::app::FilePriority::Low)
+        );
+        assert!(!manager.file_priority_rules_pending);
+        assert_eq!(
+            manager.state.piece_manager.piece_priorities,
+            vec![crate::torrent_manager::piece_manager::EffectivePiecePriority::Low]
+        );
+    }
+
+    #[tokio::test]
+    async fn automatic_executable_rule_skips_file_before_piece_scheduling() {
+        let mut params = build_test_params();
+        let mut settings = (*params.settings).clone();
+        settings.file_priority_rules = vec![crate::config::FilePriorityRule {
+            name: "Skip fictional executables".to_string(),
+            target: crate::config::FilePriorityRuleTarget::Extension,
+            pattern: ".exe".to_string(),
+            priority: crate::app::FilePriority::Skip,
+            enabled: true,
+        }];
+        params.settings = Arc::new(settings);
+        params.file_priority_rules_pending = true;
+
+        let mut torrent = create_dummy_torrent(1);
+        torrent.info.name = "fictional-helper.EXE".to_string();
+        let manager = TorrentManager::from_torrent(params, torrent).expect("manager from torrent");
+
+        assert_eq!(
+            manager.state.file_priorities.get(&0),
+            Some(&crate::app::FilePriority::Skip)
+        );
+        assert_eq!(
+            manager.state.piece_manager.piece_priorities,
+            vec![crate::torrent_manager::piece_manager::EffectivePiecePriority::Skip]
+        );
+        assert!(!manager.state.piece_manager.need_queue.contains(&0));
+    }
+
+    #[tokio::test]
+    async fn manual_normal_priority_wins_over_pending_automatic_rule() {
+        let mut params = build_test_params();
+        let mut settings = (*params.settings).clone();
+        settings.file_priority_rules = vec![crate::config::FilePriorityRule {
+            name: "Deprioritize fictional payload".to_string(),
+            target: crate::config::FilePriorityRuleTarget::Name,
+            pattern: "*".to_string(),
+            priority: crate::app::FilePriority::Low,
+            enabled: true,
+        }];
+        params.settings = Arc::new(settings);
+        params.file_priorities = HashMap::from([(0, crate::app::FilePriority::Normal)]);
+        params.file_priority_rules_pending = true;
+
+        let manager = TorrentManager::from_torrent(params, create_dummy_torrent(1))
+            .expect("manager from torrent");
+
+        assert_eq!(
+            manager.state.file_priorities.get(&0),
+            Some(&crate::app::FilePriority::Normal)
+        );
+        assert!(manager.state.piece_manager.need_queue.contains(&0));
     }
 
     #[tokio::test]
@@ -4618,6 +4734,7 @@ mod resource_tests {
             global_dl_bucket: Arc::new(TokenBucket::new(f64::INFINITY, f64::INFINITY)),
             global_ul_bucket: Arc::new(TokenBucket::new(f64::INFINITY, f64::INFINITY)),
             file_priorities: HashMap::new(),
+            file_priority_rules_pending: false,
         };
 
         let manager =
@@ -4904,6 +5021,7 @@ mod resource_tests {
             global_dl_bucket: Arc::new(TokenBucket::new(f64::INFINITY, f64::INFINITY)),
             global_ul_bucket: Arc::new(TokenBucket::new(f64::INFINITY, f64::INFINITY)),
             file_priorities: HashMap::new(),
+            file_priority_rules_pending: false,
         };
 
         let mut manager = TorrentManager::from_torrent(params, create_dummy_torrent(1)).unwrap();
@@ -4985,6 +5103,7 @@ mod resource_tests {
             global_dl_bucket: dl_bucket,
             global_ul_bucket: ul_bucket,
             file_priorities: HashMap::new(),
+            file_priority_rules_pending: false,
         };
 
         let manager = TorrentManager::from_magnet(params, magnet, magnet_link).unwrap();
@@ -5269,6 +5388,7 @@ mod resource_tests {
             global_dl_bucket: dl_bucket,
             global_ul_bucket: ul_bucket,
             file_priorities: HashMap::new(),
+            file_priority_rules_pending: false,
         };
 
         let mut manager = TorrentManager::from_magnet(params, magnet, magnet_link).unwrap();
@@ -5555,6 +5675,7 @@ mod resource_tests {
             global_dl_bucket: dl_bucket,
             global_ul_bucket: ul_bucket,
             file_priorities: HashMap::new(),
+            file_priority_rules_pending: false,
         };
 
         let mut manager = TorrentManager::from_torrent(params, torrent).unwrap();
@@ -5797,6 +5918,7 @@ mod resource_tests {
             global_dl_bucket: dl_bucket,
             global_ul_bucket: ul_bucket,
             file_priorities: HashMap::new(),
+            file_priority_rules_pending: false,
         };
 
         let mut manager = TorrentManager::from_torrent(params, torrent.clone()).unwrap();
@@ -6391,6 +6513,7 @@ mod resource_tests {
             global_dl_bucket: dl_bucket,
             global_ul_bucket: ul_bucket,
             file_priorities: HashMap::new(),
+            file_priority_rules_pending: false,
         };
 
         let manager = TorrentManager::from_magnet(params, magnet, magnet_link).unwrap();

--- a/src/torrent_manager/mod.rs
+++ b/src/torrent_manager/mod.rs
@@ -52,6 +52,7 @@ pub struct TorrentParameters {
     pub global_dl_bucket: Arc<TokenBucket>,
     pub global_ul_bucket: Arc<TokenBucket>,
     pub file_priorities: HashMap<usize, FilePriority>,
+    pub file_priority_rules_pending: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -217,6 +218,7 @@ pub enum ManagerCommand {
     DeleteFile,
     SetDataRate(u64),
     UpdateListenPort(u16),
+    UpdateFilePriorityRules(Vec<crate::config::FilePriorityRule>),
     SetUserTorrentConfig {
         torrent_data_path: PathBuf,
         file_priorities: HashMap<usize, FilePriority>,

--- a/src/torrent_manager/piece_manager.rs
+++ b/src/torrent_manager/piece_manager.rs
@@ -25,6 +25,7 @@ pub enum PieceStatus {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum EffectivePiecePriority {
     Skip,
+    Low,
     #[default]
     Normal,
     High,
@@ -859,6 +860,40 @@ mod tests {
 
         // THEN: Skip piece (2) should never be chosen
         assert_eq!(third_choice, None, "Skipped piece should not be chosen");
+    }
+
+    #[test]
+    fn low_priority_is_selected_after_normal_and_before_skip() {
+        let mut pm = setup_manager(4);
+        pm.apply_priorities(vec![
+            EffectivePiecePriority::Low,
+            EffectivePiecePriority::Normal,
+            EffectivePiecePriority::High,
+            EffectivePiecePriority::Skip,
+        ]);
+        let peer_bitfield = vec![true; 4];
+        let status = TorrentStatus::Standard;
+        let mut pending = HashSet::new();
+
+        assert_eq!(
+            pm.choose_piece_for_peer(&peer_bitfield, &pending, &status),
+            Some(2)
+        );
+        pending.insert(2);
+        assert_eq!(
+            pm.choose_piece_for_peer(&peer_bitfield, &pending, &status),
+            Some(1)
+        );
+        pending.insert(1);
+        assert_eq!(
+            pm.choose_piece_for_peer(&peer_bitfield, &pending, &status),
+            Some(0)
+        );
+        pending.insert(0);
+        assert_eq!(
+            pm.choose_piece_for_peer(&peer_bitfield, &pending, &status),
+            None
+        );
     }
 
     #[test]

--- a/src/torrent_manager/state.rs
+++ b/src/torrent_manager/state.rs
@@ -2953,6 +2953,11 @@ impl TorrentState {
                     FilePriority::High => {
                         *piece = EffectivePiecePriority::High;
                     }
+                    FilePriority::Low => {
+                        if *piece == EffectivePiecePriority::Skip {
+                            *piece = EffectivePiecePriority::Low;
+                        }
+                    }
                     FilePriority::Normal | FilePriority::Mixed => {
                         if *piece != EffectivePiecePriority::High {
                             *piece = EffectivePiecePriority::Normal;
@@ -12108,6 +12113,7 @@ mod integration_tests {
             global_dl_bucket: bucket.clone(),
             global_ul_bucket: bucket,
             file_priorities: HashMap::new(),
+            file_priority_rules_pending: false,
         };
 
         (

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -4,7 +4,8 @@
 use crate::app::{App, AppMode};
 use crate::tui::paste_burst::FlushResult as PasteBurstFlushResult;
 use crate::tui::screens::{
-    browser, config, delete_confirm, help, journal, normal, peers, power, rss, torrents, welcome,
+    browser, config, delete_confirm, file_priority_rules, help, journal, normal, peers, power, rss,
+    torrents, welcome,
 };
 
 use ratatui::crossterm::event::{
@@ -257,6 +258,9 @@ async fn dispatch_mode_event(event: CrosstermEvent, app: &mut App) {
             );
         }
         AppMode::FileBrowser => {}
+        AppMode::FilePriorityRules => {
+            file_priority_rules::handle_event(event, app).await;
+        }
     }
 }
 #[cfg(test)]
@@ -571,8 +575,8 @@ mod tests {
         let changed = browser::apply_priority_cycle(&mut nodes, &PathBuf::from("root"));
 
         assert!(changed);
-        assert_eq!(nodes[0].payload.priority, FilePriority::Skip);
-        assert_eq!(nodes[0].children[0].payload.priority, FilePriority::Skip);
+        assert_eq!(nodes[0].payload.priority, FilePriority::Low);
+        assert_eq!(nodes[0].children[0].payload.priority, FilePriority::Low);
     }
 
     #[test]

--- a/src/tui/screens/browser.rs
+++ b/src/tui/screens/browser.rs
@@ -7,6 +7,7 @@ use crate::app::{
     FileMetadata, FilePriority, SearchMode, TorrentFilePreview, TorrentFilePreviewState,
     TorrentPreviewPayload, AWAITING_MAGNET_METADATA_LABEL,
 };
+use crate::config::FilePriorityRule;
 use crate::integrations::control::{ControlFilePriorityOverride, ControlRequest};
 use crate::theme::ThemeContext;
 use crate::tui::action_style::{footer_key_style, ActionTone};
@@ -120,6 +121,7 @@ pub fn draw(
                 current_fs_path: &state.current_path,
                 preview_filter,
                 torrent_file_preview: &app_state.ui.file_browser.torrent_file_preview,
+                rules: &screen.settings.file_priority_rules,
             },
         );
     }
@@ -460,6 +462,38 @@ fn browser_search_mode_spans(search_mode: SearchMode, ctx: &ThemeContext) -> Vec
     ]
 }
 
+fn rule_badge(node: &RawNode<TorrentPreviewPayload>, rules: &[FilePriorityRule]) -> Option<String> {
+    if node.is_dir || rules.is_empty() {
+        return None;
+    }
+    let parts = node
+        .full_path
+        .components()
+        .filter_map(|component| component.as_os_str().to_str().map(str::to_string))
+        .collect::<Vec<_>>();
+    let evaluation = crate::file_priority_rules::evaluate_file_priority_rules(rules, &[parts]);
+    let matches = evaluation.matches.get(&0)?;
+    let winner = matches.iter().find(|rule_match| rule_match.winning)?;
+    let manually_overridden = node.payload.priority != winner.priority;
+    let matched_rules = matches
+        .iter()
+        .map(|rule_match| {
+            format!(
+                "{} {}{}",
+                rule_match.rule_index + 1,
+                rule_match.rule_name,
+                if rule_match.winning { "*" } else { "" }
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    Some(if manually_overridden {
+        format!("[manual · rules: {matched_rules}]")
+    } else {
+        format!("[rules: {matched_rules}]")
+    })
+}
+
 struct TorrentPreviewPanelProps<'a> {
     path: Option<&'a Path>,
     browser_mode: &'a FileBrowserMode,
@@ -467,6 +501,7 @@ struct TorrentPreviewPanelProps<'a> {
     current_fs_path: &'a Path,
     preview_filter: TreeFilter<TorrentPreviewPayload>,
     torrent_file_preview: &'a TorrentFilePreviewState,
+    rules: &'a [FilePriorityRule],
 }
 
 fn draw_torrent_preview_panel(
@@ -482,6 +517,7 @@ fn draw_torrent_preview_panel(
         current_fs_path,
         preview_filter,
         torrent_file_preview,
+        rules,
     } = props;
     let is_narrow = area.width < 50;
     let raw_title = "Torrent Preview";
@@ -618,6 +654,7 @@ fn draw_torrent_preview_panel(
                             .add_modifier(Modifier::BOLD),
                         "[H] ",
                     ),
+                    FilePriority::Low => (Style::default().fg(ctx.theme.semantic.surface2), "[L] "),
                     FilePriority::Mixed => (
                         Style::default()
                             .fg(ctx.state_warning())
@@ -660,6 +697,12 @@ fn draw_torrent_preview_panel(
                     if !tag.is_empty() {
                         spans.push(Span::styled(tag, structure_style));
                     }
+                    if let Some(rule_badge) = rule_badge(item.node, rules) {
+                        spans.push(Span::styled(
+                            rule_badge,
+                            ctx.apply(Style::default().fg(ctx.accent_sapphire())),
+                        ));
+                    }
                 }
                 ListItem::new(Line::from(spans))
             })
@@ -671,7 +714,15 @@ fn draw_torrent_preview_panel(
     }
 
     if let Some(path) = path {
-        draw_cached_torrent_file_preview(f, ctx, inner_area, is_narrow, path, torrent_file_preview);
+        draw_cached_torrent_file_preview(
+            f,
+            ctx,
+            inner_area,
+            is_narrow,
+            path,
+            torrent_file_preview,
+            rules,
+        );
     }
 }
 
@@ -682,10 +733,11 @@ fn draw_cached_torrent_file_preview(
     is_narrow: bool,
     selected_path: &Path,
     state: &TorrentFilePreviewState,
+    rules: &[FilePriorityRule],
 ) {
     match state {
         TorrentFilePreviewState::Ready { path, preview } if path == selected_path => {
-            draw_loaded_torrent_file_preview(f, ctx, area, is_narrow, preview);
+            draw_loaded_torrent_file_preview(f, ctx, area, is_narrow, preview, rules);
         }
         TorrentFilePreviewState::Error { path, message } if path == selected_path => {
             f.render_widget(
@@ -717,6 +769,7 @@ fn draw_loaded_torrent_file_preview(
     area: Rect,
     is_narrow: bool,
     preview: &TorrentFilePreview,
+    rules: &[FilePriorityRule],
 ) {
     let info_text = vec![
         Line::from(vec![
@@ -796,6 +849,12 @@ fn draw_loaded_torrent_file_preview(
                 spans.push(Span::styled(
                     format!(" ({})", format_bytes(item.node.payload.size)),
                     ctx.apply(Style::default().fg(ctx.theme.semantic.surface2)),
+                ));
+            }
+            if let Some(rule_badge) = rule_badge(item.node, rules) {
+                spans.push(Span::styled(
+                    format!(" {rule_badge}"),
+                    ctx.apply(Style::default().fg(ctx.accent_sapphire())),
                 ));
             }
             ListItem::new(Line::from(spans))
@@ -2315,7 +2374,6 @@ fn priority_overrides(
 ) -> Vec<ControlFilePriorityOverride> {
     let mut overrides: Vec<_> = priorities
         .into_iter()
-        .filter(|(_, priority)| !matches!(priority, FilePriority::Normal))
         .map(|(file_index, priority)| ControlFilePriorityOverride {
             file_index,
             priority,
@@ -3663,7 +3721,7 @@ mod tests {
         );
 
         assert!(out.consumed);
-        assert_eq!(tree[0].payload.priority, FilePriority::Skip);
+        assert_eq!(tree[0].payload.priority, FilePriority::Low);
     }
 
     #[test]
@@ -3689,7 +3747,7 @@ mod tests {
         );
 
         assert!(out.consumed);
-        assert_eq!(tree[0].payload.priority, FilePriority::Skip);
+        assert_eq!(tree[0].payload.priority, FilePriority::Low);
     }
 
     #[test]
@@ -3955,9 +4013,9 @@ mod tests {
         );
 
         assert!(out.consumed);
-        assert_eq!(tree[0].payload.priority, FilePriority::Skip);
-        assert_eq!(tree[0].children[0].payload.priority, FilePriority::Skip);
-        assert_eq!(tree[0].children[1].payload.priority, FilePriority::Skip);
+        assert_eq!(tree[0].payload.priority, FilePriority::Low);
+        assert_eq!(tree[0].children[0].payload.priority, FilePriority::Low);
+        assert_eq!(tree[0].children[1].payload.priority, FilePriority::Low);
     }
 
     #[test]
@@ -4422,7 +4480,42 @@ mod tests {
 
         let changed = apply_priority_cycle(&mut nodes, &PathBuf::from("root"));
         assert!(changed);
-        assert_eq!(nodes[0].payload.priority, FilePriority::Skip);
-        assert_eq!(nodes[0].children[0].payload.priority, FilePriority::Skip);
+        assert_eq!(nodes[0].payload.priority, FilePriority::Low);
+        assert_eq!(nodes[0].children[0].payload.priority, FilePriority::Low);
+    }
+
+    #[test]
+    fn rule_badge_names_every_match_and_marks_the_winner() {
+        let node = RawNode {
+            name: "sample.bin".to_string(),
+            full_path: PathBuf::from("fictional-set/sample.bin"),
+            children: vec![],
+            payload: TorrentPreviewPayload {
+                priority: FilePriority::Low,
+                ..Default::default()
+            },
+            is_dir: false,
+        };
+        let rules = vec![
+            FilePriorityRule {
+                name: "Binary payloads".to_string(),
+                target: crate::config::FilePriorityRuleTarget::Extension,
+                pattern: ".bin".to_string(),
+                priority: FilePriority::Low,
+                enabled: true,
+            },
+            FilePriorityRule {
+                name: "Fictional set".to_string(),
+                target: crate::config::FilePriorityRuleTarget::Path,
+                pattern: "fictional-set/*".to_string(),
+                priority: FilePriority::High,
+                enabled: true,
+            },
+        ];
+
+        assert_eq!(
+            rule_badge(&node, &rules).as_deref(),
+            Some("[rules: 1 Binary payloads*; 2 Fictional set]")
+        );
     }
 }

--- a/src/tui/screens/file_priority_rules.rs
+++ b/src/tui/screens/file_priority_rules.rs
@@ -1,0 +1,421 @@
+// SPDX-FileCopyrightText: 2025 The superseedr Contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::app::{App, AppMode, FilePriority, FilePriorityRuleEditField, FilePriorityRulesUiState};
+use crate::config::{FilePriorityRule, FilePriorityRuleTarget};
+use crate::file_priority_rules::validate_rule;
+use crate::tui::screen_context::ScreenContext;
+use ratatui::crossterm::event::{Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind};
+use ratatui::{prelude::*, widgets::*};
+
+fn next_priority(priority: FilePriority) -> FilePriority {
+    match priority {
+        FilePriority::Normal | FilePriority::Mixed => FilePriority::Low,
+        FilePriority::Low => FilePriority::Skip,
+        FilePriority::Skip => FilePriority::High,
+        FilePriority::High => FilePriority::Normal,
+    }
+}
+
+fn priority_label(priority: FilePriority) -> &'static str {
+    match priority {
+        FilePriority::Normal => "Normal",
+        FilePriority::Low => "Low",
+        FilePriority::High => "High",
+        FilePriority::Skip => "Skip",
+        FilePriority::Mixed => "Mixed",
+    }
+}
+
+fn field_label(field: FilePriorityRuleEditField) -> &'static str {
+    match field {
+        FilePriorityRuleEditField::Name => "Name",
+        FilePriorityRuleEditField::Target => "Target",
+        FilePriorityRuleEditField::Pattern => "Pattern",
+        FilePriorityRuleEditField::Priority => "Priority",
+        FilePriorityRuleEditField::Enabled => "Enabled",
+    }
+}
+
+fn begin_add(state: &mut FilePriorityRulesUiState, rule_count: usize) {
+    state.draft = Some(FilePriorityRule {
+        name: format!("Rule {}", rule_count + 1),
+        target: FilePriorityRuleTarget::Extension,
+        pattern: String::new(),
+        priority: FilePriority::Skip,
+        enabled: true,
+    });
+    state.draft_index = None;
+    state.edit_field = FilePriorityRuleEditField::Name;
+    state.delete_confirm_armed = false;
+    state.status_message = Some("Edit fields with Tab; Enter saves".to_string());
+}
+
+fn begin_edit(state: &mut FilePriorityRulesUiState, rules: &[FilePriorityRule], index: usize) {
+    let Some(rule) = rules.get(index).cloned() else {
+        return;
+    };
+    state.draft = Some(rule);
+    state.draft_index = Some(index);
+    state.edit_field = FilePriorityRuleEditField::Name;
+    state.delete_confirm_armed = false;
+    state.status_message = Some("Edit fields with Tab; Enter saves".to_string());
+}
+
+fn edit_text(draft: &mut FilePriorityRule, field: FilePriorityRuleEditField, text: &str) {
+    let target = match field {
+        FilePriorityRuleEditField::Name => Some(&mut draft.name),
+        FilePriorityRuleEditField::Pattern => Some(&mut draft.pattern),
+        _ => None,
+    };
+    if let Some(target) = target {
+        target.extend(text.chars().filter(|ch| !ch.is_control()));
+    }
+}
+
+fn backspace_text(draft: &mut FilePriorityRule, field: FilePriorityRuleEditField) {
+    match field {
+        FilePriorityRuleEditField::Name => {
+            draft.name.pop();
+        }
+        FilePriorityRuleEditField::Pattern => {
+            draft.pattern.pop();
+        }
+        _ => {}
+    }
+}
+
+fn cycle_draft_value(draft: &mut FilePriorityRule, field: FilePriorityRuleEditField) {
+    match field {
+        FilePriorityRuleEditField::Target => draft.target = draft.target.next(),
+        FilePriorityRuleEditField::Priority => draft.priority = next_priority(draft.priority),
+        FilePriorityRuleEditField::Enabled => draft.enabled = !draft.enabled,
+        _ => {}
+    }
+}
+
+async fn save_rules(app: &mut App, rules: Vec<FilePriorityRule>) {
+    let mut settings = app.client_configs.clone();
+    settings.file_priority_rules = rules;
+    app.apply_config_update_from_ui(settings).await;
+}
+
+async fn handle_edit_key(key: KeyEvent, app: &mut App) {
+    let mut commit = None;
+    {
+        let state = &mut app.app_state.ui.file_priority_rules;
+        let Some(draft) = state.draft.as_mut() else {
+            return;
+        };
+        match key.code {
+            KeyCode::Esc => {
+                state.draft = None;
+                state.draft_index = None;
+                state.status_message = Some("Edit cancelled".to_string());
+            }
+            KeyCode::Tab | KeyCode::Down => state.edit_field = state.edit_field.next(),
+            KeyCode::BackTab | KeyCode::Up => state.edit_field = state.edit_field.previous(),
+            KeyCode::Left | KeyCode::Right | KeyCode::Char(' ') => {
+                cycle_draft_value(draft, state.edit_field)
+            }
+            KeyCode::Backspace => backspace_text(draft, state.edit_field),
+            KeyCode::Enter => match validate_rule(draft) {
+                Ok(()) => commit = Some((state.draft_index, draft.clone())),
+                Err(message) => state.status_message = Some(message),
+            },
+            KeyCode::Char(ch) => edit_text(draft, state.edit_field, &ch.to_string()),
+            _ => {}
+        }
+    }
+
+    if let Some((index, draft)) = commit {
+        let mut rules = app.client_configs.file_priority_rules.clone();
+        if let Some(index) = index {
+            if let Some(rule) = rules.get_mut(index) {
+                *rule = draft;
+            }
+        } else {
+            rules.push(draft);
+        }
+        save_rules(app, rules).await;
+        let state = &mut app.app_state.ui.file_priority_rules;
+        state.draft = None;
+        state.draft_index = None;
+        state.selected_index = state.selected_index.min(
+            app.client_configs
+                .file_priority_rules
+                .len()
+                .saturating_sub(1),
+        );
+        state.status_message = Some("Rule saved".to_string());
+    }
+}
+
+async fn handle_list_key(key: KeyEvent, app: &mut App) {
+    let count = app.client_configs.file_priority_rules.len();
+    let selected = app
+        .app_state
+        .ui
+        .file_priority_rules
+        .selected_index
+        .min(count.saturating_sub(1));
+
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('q') => {
+            app.app_state.mode = AppMode::Normal;
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            let state = &mut app.app_state.ui.file_priority_rules;
+            state.selected_index = selected.saturating_sub(1);
+            state.delete_confirm_armed = false;
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            let state = &mut app.app_state.ui.file_priority_rules;
+            state.selected_index = (selected + 1).min(count.saturating_sub(1));
+            state.delete_confirm_armed = false;
+        }
+        KeyCode::Char('a') => begin_add(&mut app.app_state.ui.file_priority_rules, count),
+        KeyCode::Enter | KeyCode::Char('e') if count > 0 => begin_edit(
+            &mut app.app_state.ui.file_priority_rules,
+            &app.client_configs.file_priority_rules,
+            selected,
+        ),
+        KeyCode::Char('x') | KeyCode::Char(' ') if count > 0 => {
+            let mut rules = app.client_configs.file_priority_rules.clone();
+            rules[selected].enabled = !rules[selected].enabled;
+            save_rules(app, rules).await;
+        }
+        KeyCode::Char('p') if count > 0 => {
+            let mut rules = app.client_configs.file_priority_rules.clone();
+            rules[selected].priority = next_priority(rules[selected].priority);
+            save_rules(app, rules).await;
+        }
+        KeyCode::Char('t') if count > 0 => {
+            let mut rules = app.client_configs.file_priority_rules.clone();
+            rules[selected].target = rules[selected].target.next();
+            save_rules(app, rules).await;
+        }
+        KeyCode::Char('K') if selected > 0 => {
+            let mut rules = app.client_configs.file_priority_rules.clone();
+            rules.swap(selected, selected - 1);
+            app.app_state.ui.file_priority_rules.selected_index = selected - 1;
+            save_rules(app, rules).await;
+        }
+        KeyCode::Char('J') if selected + 1 < count => {
+            let mut rules = app.client_configs.file_priority_rules.clone();
+            rules.swap(selected, selected + 1);
+            app.app_state.ui.file_priority_rules.selected_index = selected + 1;
+            save_rules(app, rules).await;
+        }
+        KeyCode::Char('d') if count > 0 => {
+            if app.app_state.ui.file_priority_rules.delete_confirm_armed {
+                let mut rules = app.client_configs.file_priority_rules.clone();
+                rules.remove(selected);
+                save_rules(app, rules).await;
+                let state = &mut app.app_state.ui.file_priority_rules;
+                state.selected_index = selected.min(
+                    app.client_configs
+                        .file_priority_rules
+                        .len()
+                        .saturating_sub(1),
+                );
+                state.delete_confirm_armed = false;
+                state.status_message = Some("Rule deleted".to_string());
+            } else {
+                let state = &mut app.app_state.ui.file_priority_rules;
+                state.delete_confirm_armed = true;
+                state.status_message = Some("Press d again to delete this rule".to_string());
+            }
+        }
+        _ => {}
+    }
+}
+
+pub async fn handle_event(event: CrosstermEvent, app: &mut App) {
+    if let CrosstermEvent::Paste(text) = event {
+        let state = &mut app.app_state.ui.file_priority_rules;
+        if let Some(draft) = state.draft.as_mut() {
+            edit_text(draft, state.edit_field, &text);
+        }
+        return;
+    }
+
+    let CrosstermEvent::Key(key) = event else {
+        return;
+    };
+    if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+        return;
+    }
+
+    if app.app_state.ui.file_priority_rules.draft.is_some() {
+        handle_edit_key(key, app).await;
+    } else {
+        handle_list_key(key, app).await;
+    }
+    app.app_state.ui.needs_redraw = true;
+}
+
+pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
+    let ctx = screen.theme;
+    let state = &screen.ui.ui.file_priority_rules;
+    let rules = &screen.settings.file_priority_rules;
+    let area = f.area();
+    let outer = Block::default()
+        .borders(Borders::ALL)
+        .border_style(ctx.apply(Style::default().fg(ctx.accent_sapphire())))
+        .title(" Automatic File-Priority Rules ");
+    let inner = outer.inner(area);
+    f.render_widget(outer, area);
+
+    let rows = Layout::vertical([
+        Constraint::Min(4),
+        Constraint::Length(2),
+        Constraint::Length(1),
+    ])
+    .split(inner);
+    let columns =
+        Layout::horizontal([Constraint::Percentage(58), Constraint::Percentage(42)]).split(rows[0]);
+
+    let selected = state.selected_index.min(rules.len().saturating_sub(1));
+    let items = if rules.is_empty() {
+        vec![ListItem::new("No rules. Press a to create one.")]
+    } else {
+        rules
+            .iter()
+            .enumerate()
+            .map(|(index, rule)| {
+                let enabled = if rule.enabled { "x" } else { " " };
+                let text = format!(
+                    "{:>2}. [{}] {} · {}:{} → {}",
+                    index + 1,
+                    enabled,
+                    rule.name,
+                    rule.target.label(),
+                    rule.pattern,
+                    priority_label(rule.priority)
+                );
+                let style = if index == selected {
+                    Style::default()
+                        .fg(ctx.state_selected())
+                        .add_modifier(Modifier::BOLD | Modifier::REVERSED)
+                } else if rule.enabled {
+                    ctx.apply(Style::default().fg(ctx.theme.semantic.text))
+                } else {
+                    ctx.apply(Style::default().fg(ctx.theme.semantic.surface2))
+                };
+                ListItem::new(text).style(style)
+            })
+            .collect()
+    };
+    f.render_widget(
+        List::new(items).block(Block::default().borders(Borders::RIGHT).title(" Rules ")),
+        columns[0],
+    );
+
+    let shown = state.draft.as_ref().or_else(|| rules.get(selected));
+    let details = if let Some(rule) = shown {
+        let active_field = |field| {
+            if state.draft.is_some() && state.edit_field == field {
+                "▶"
+            } else {
+                " "
+            }
+        };
+        vec![
+            Line::from(format!(
+                "{} Name: {}",
+                active_field(FilePriorityRuleEditField::Name),
+                rule.name
+            )),
+            Line::from(format!(
+                "{} Target: {}",
+                active_field(FilePriorityRuleEditField::Target),
+                rule.target.label()
+            )),
+            Line::from(format!(
+                "{} Pattern: {}",
+                active_field(FilePriorityRuleEditField::Pattern),
+                rule.pattern
+            )),
+            Line::from(format!(
+                "{} Priority: {}",
+                active_field(FilePriorityRuleEditField::Priority),
+                priority_label(rule.priority)
+            )),
+            Line::from(format!(
+                "{} Enabled: {}",
+                active_field(FilePriorityRuleEditField::Enabled),
+                if rule.enabled { "yes" } else { "no" }
+            )),
+            Line::from(""),
+            Line::from(if state.draft.is_some() {
+                format!(
+                    "Editing {} · Tab changes field",
+                    field_label(state.edit_field)
+                )
+            } else {
+                "Topmost enabled match wins".to_string()
+            }),
+        ]
+    } else {
+        vec![Line::from("Rules apply when new torrent metadata arrives.")]
+    };
+    f.render_widget(
+        Paragraph::new(details)
+            .wrap(Wrap { trim: false })
+            .block(Block::default().title(" Details ")),
+        columns[1],
+    );
+
+    let status = state.status_message.as_deref().unwrap_or(
+        "Extension is exact; name/path support * and ? wildcards; matching ignores case",
+    );
+    f.render_widget(
+        Paragraph::new(status).style(ctx.apply(Style::default().fg(ctx.state_info()))),
+        rows[1],
+    );
+    let footer = if state.draft.is_some() {
+        "Tab field  ←/→ change  Enter save  Esc cancel"
+    } else {
+        "a add  e edit  x toggle  K/J reorder  t target  p priority  d delete  q close"
+    };
+    f.render_widget(
+        Paragraph::new(footer)
+            .alignment(Alignment::Center)
+            .style(ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0))),
+        rows[2],
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rule_priority_cycle_never_exposes_mixed() {
+        let mut value = FilePriority::Normal;
+        let mut seen = Vec::new();
+        for _ in 0..4 {
+            value = next_priority(value);
+            seen.push(value);
+        }
+        assert_eq!(
+            seen,
+            vec![
+                FilePriority::Low,
+                FilePriority::Skip,
+                FilePriority::High,
+                FilePriority::Normal
+            ]
+        );
+    }
+
+    #[test]
+    fn add_starts_with_fictional_editable_rule() {
+        let mut state = FilePriorityRulesUiState::default();
+        begin_add(&mut state, 2);
+        let draft = state.draft.expect("draft");
+        assert_eq!(draft.name, "Rule 3");
+        assert_eq!(draft.priority, FilePriority::Skip);
+    }
+}

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -303,6 +303,13 @@ fn build_help_items(settings: &Settings, app_state: &AppState) -> Vec<HelpItem> 
     action_item!(
         HelpSection::General,
         "Global Routes",
+        "R",
+        "Open automatic file-priority rules",
+        ActionTone::Open
+    );
+    action_item!(
+        HelpSection::General,
+        "Global Routes",
         "J",
         "Open the event journal",
         ActionTone::Open

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -4,6 +4,7 @@
 pub mod browser;
 pub mod config;
 pub mod delete_confirm;
+pub mod file_priority_rules;
 pub mod help;
 pub(crate) mod input_panel;
 pub mod journal;

--- a/src/tui/screens/normal.rs
+++ b/src/tui/screens/normal.rs
@@ -414,6 +414,7 @@ pub enum UiAction {
     OpenJournal,
     OpenPeerManagement,
     OpenTorrentManagement,
+    OpenFilePriorityRules,
     DataRateSlower,
     DataRateFaster,
     ThemePrev,
@@ -436,6 +437,7 @@ pub enum UiEffect {
     OpenJournalScreen,
     OpenPeerManagementScreen,
     OpenTorrentManagementScreen,
+    OpenFilePriorityRulesScreen,
     BroadcastManagerDataRate(u64),
     ApplyThemePrev,
     ApplyThemeNext,
@@ -596,6 +598,10 @@ pub fn reduce_ui_action_with_layout_mode(
         UiAction::OpenTorrentManagement => ReduceResult {
             redraw: true,
             effects: vec![UiEffect::OpenTorrentManagementScreen],
+        },
+        UiAction::OpenFilePriorityRules => ReduceResult {
+            redraw: true,
+            effects: vec![UiEffect::OpenFilePriorityRulesScreen],
         },
         UiAction::DataRateSlower => {
             app_state.data_rate = app_state.data_rate.next_slower();
@@ -794,6 +800,7 @@ fn map_key_to_ui_action(key: KeyEvent) -> Option<UiAction> {
         KeyCode::Char('J') => Some(UiAction::OpenJournal),
         KeyCode::Char('P') => Some(UiAction::OpenPeerManagement),
         KeyCode::Char('M') => Some(UiAction::OpenTorrentManagement),
+        KeyCode::Char('R') => Some(UiAction::OpenFilePriorityRules),
         KeyCode::Char('m') => Some(UiAction::OpenHelp),
         KeyCode::Char('[') | KeyCode::Char('{') => Some(UiAction::DataRateSlower),
         KeyCode::Char(']') | KeyCode::Char('}') => Some(UiAction::DataRateFaster),
@@ -7046,6 +7053,12 @@ async fn execute_ui_effect(app: &mut App, effect: UiEffect) {
             app.app_state.ui.torrent_management.review_scroll_offset = 0;
             app.app_state.mode = AppMode::TorrentManagement;
             torrents::initialize_torrent_management_cursor(&mut app.app_state);
+        }
+        UiEffect::OpenFilePriorityRulesScreen => {
+            app.app_state.ui.file_priority_rules.selected_index = 0;
+            app.app_state.ui.file_priority_rules.draft = None;
+            app.app_state.ui.file_priority_rules.delete_confirm_armed = false;
+            app.app_state.mode = AppMode::FilePriorityRules;
         }
         UiEffect::HandlePastedText(text) => {
             handle_pasted_text(app, &text).await;

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -5,7 +5,8 @@ use ratatui::{prelude::*, widgets::*};
 
 use crate::tui::screen_context::ScreenContext;
 use crate::tui::screens::{
-    browser, config, delete_confirm, help, journal, normal, peers, power, rss, torrents, welcome,
+    browser, config, delete_confirm, file_priority_rules, help, journal, normal, peers, power, rss,
+    torrents, welcome,
 };
 
 use crate::app::{AppMode, AppState};
@@ -107,6 +108,13 @@ pub fn draw(
                 &app_state.ui.file_browser.data,
                 &app_state.ui.file_browser.browser_mode,
             );
+            apply_theme_effects_to_frame(f, &ctx);
+            apply_theme_particles_foreground_to_frame(f, &ctx);
+            return;
+        }
+        AppMode::FilePriorityRules => {
+            apply_theme_particles_background_to_frame(f, &ctx);
+            file_priority_rules::draw(f, &screen);
             apply_theme_effects_to_frame(f, &ctx);
             apply_theme_particles_foreground_to_frame(f, &ctx);
             return;


### PR DESCRIPTION
## Summary

- add persistent, ordered file-priority rules for extension, filename, and path matching
- support Skip, Low, Normal, and High priorities with first-enabled-match precedence
- apply rules when torrent metadata arrives, including magnet metadata, while preserving manual overrides
- add a dedicated TUI rules editor and preview badges showing matched and winning rules
- add regression coverage for rule evaluation, persistence, metadata-time application, and skipped executable-like fixtures

## Why

Users need a reusable way to prioritize or skip matching files automatically instead of configuring every torrent manually. Applying the rules at the metadata boundary keeps behavior consistent across torrent files, magnets, CLI/TUI ingestion, and shared configurations.

## User impact

Rules can be created, edited, enabled, reordered, and deleted from the TUI. Existing torrents are not silently rewritten, and manual per-file changes continue to take precedence.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --all-targets --no-default-features -- -D warnings`
- `git diff --check`

Closes #308