### PR TITLE
docs: add live interactive demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@
 
 Superseedr is a modern Rust BitTorrent client featuring a high-performance terminal UI, real-time swarm observability, secure VPN-aware Docker setups, and zero manual network configuration. It is fast, privacy-oriented, and built for both desktop users and homelab/server workflows.
 
-## [Live Interactive Demo →](https://web.superseedr.com/)
-
-Experience the full superseedr terminal UI in the browser! This demo runs entirely client-side and does not perform real torrent, network, or disk operations.
+**[Live Interactive Demo →](https://web.superseedr.com/)** — Experience the full superseedr terminal UI in the browser! This demo runs entirely client-side and does not perform real torrent, network, or disk operations.
 
 ![Feature Demo](https://raw.githubusercontent.com/Jagalite/superseedr-assets/main/superseedr_landing.webp)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Superseedr is a modern Rust BitTorrent client featuring a high-performance termi
 
 ## Live Interactive Demo
 
-**[Launch the browser demo →](https://jagalite.github.io/superseedr/)**
+**[Launch the browser demo →](https://web.superseedr.com/)**
 
 This demo runs entirely client-side and does not perform real torrent, network, or disk operations. Experience the full superseedr terminal UI in the browser!
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Superseedr is a modern Rust BitTorrent client featuring a high-performance terminal UI, real-time swarm observability, secure VPN-aware Docker setups, and zero manual network configuration. It is fast, privacy-oriented, and built for both desktop users and homelab/server workflows.
 
-**[Live Interactive Demo](https://web.superseedr.com/)** — Experience the full superseedr terminal UI in the browser! This demo runs entirely client-side and does not perform real torrent, network, or disk operations.
+**[Live Interactive Demo](https://web.superseedr.com/)** Experience the full superseedr terminal UI in the browser! This demo runs entirely client-side and does not perform real torrent, network, or disk operations.
 
 ![Feature Demo](https://raw.githubusercontent.com/Jagalite/superseedr-assets/main/superseedr_landing.webp)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Superseedr is a modern Rust BitTorrent client featuring a high-performance termi
 
 ## [Live Interactive Demo →](https://web.superseedr.com/)
 
-This demo runs entirely client-side and does not perform real torrent, network, or disk operations. Experience the full superseedr terminal UI in the browser!
+Experience the full superseedr terminal UI in the browser! This demo runs entirely client-side and does not perform real torrent, network, or disk operations.
 
 ![Feature Demo](https://raw.githubusercontent.com/Jagalite/superseedr-assets/main/superseedr_landing.webp)
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@
 
 Superseedr is a modern Rust BitTorrent client featuring a high-performance terminal UI, real-time swarm observability, secure VPN-aware Docker setups, and zero manual network configuration. It is fast, privacy-oriented, and built for both desktop users and homelab/server workflows.
 
-## Live Interactive Demo
-
-**[Launch the browser demo →](https://web.superseedr.com/)**
+## [Live Interactive Demo →](https://web.superseedr.com/)
 
 This demo runs entirely client-side and does not perform real torrent, network, or disk operations. Experience the full superseedr terminal UI in the browser!
 

--- a/README.md
+++ b/README.md
@@ -391,12 +391,13 @@ Superseedr is built on a **Reactive Actor** architecture verified by model-based
 This section is designed for developers, contributors, and AI agents seeking to understand the internal design decisions that drive Superseedr's performance.
 
 ### 🌐 Shared TUI Browser Runtime
-The **[Live Interactive Demo](https://jagalite.github.io/superseedr/)** runs the Superseedr terminal interface entirely in the browser without a server-side application runtime.
+The **[Live Interactive Demo](https://web.superseedr.com/)** runs the Superseedr terminal interface entirely in the browser without a server-side application runtime.
 * **Production Ratatui Rendering:** The WebAssembly client invokes the same Ratatui screen renderers, shared state models, event dispatcher, and reducers used by the native application instead of recreating the interface in HTML.
 * **Ghostty Web Output:** A browser Ratatui backend emits ANSI frames into Ghostty Web, preserving the terminal presentation, keyboard interaction, responsive resizing, themes, visualizations, and 60 FPS target.
 * **Deterministic Simulation:** Browser-owned mocks provide fictional torrents, peers, files, lifecycle events, DHT activity, telemetry, and disk conditions without performing real torrent, network, or disk operations.
 * **Shared Interaction Contracts:** Magnet paste, navigation, pause, resume, delete, configuration, file-browser, and management interactions pass through production reducers and command boundaries before the simulated service fulfills them in memory.
 * **Cross-Runtime Verification:** Native characterization tests, real-WebAssembly contracts, static-bundle checks, and Chromium browser tests protect the shared TUI behavior while keeping browser dependencies out of normal native builds.
+* **Planned Fully Client-Side WebTorrent:** The browser roadmap includes a WebTorrent-backed torrent manager for real browser-native downloading, seeding, sequential piece delivery, and media streaming without an application server; the current demo remains fully simulated.
 
 ### ⚡ Async Networking Core
 Superseedr is built on the **Tokio** runtime, leveraging asynchronous I/O for maximum concurrency.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Superseedr is a modern Rust BitTorrent client featuring a high-performance termi
 
 ## Live Interactive Demo
 
-**[Launch Superseedr in your browser](https://jagalite.github.io/superseedr/)** to explore the production terminal interface with deterministic simulated torrent activity. The demo runs entirely client-side and does not perform real torrent, network, or disk operations.
+**[Live Interactive Demo](https://jagalite.github.io/superseedr/)**
+
+This demo runs entirely client-side and does not perform real torrent, network, or disk operations. Experience the full superseedr terminal UI in the browser!
 
 ![Feature Demo](https://raw.githubusercontent.com/Jagalite/superseedr-assets/main/superseedr_landing.webp)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Superseedr is a modern Rust BitTorrent client featuring a high-performance termi
 
 ## Live Interactive Demo
 
-**[Live Interactive Demo](https://jagalite.github.io/superseedr/)**
+**[Launch the browser demo →](https://jagalite.github.io/superseedr/)**
 
 This demo runs entirely client-side and does not perform real torrent, network, or disk operations. Experience the full superseedr terminal UI in the browser!
 

--- a/README.md
+++ b/README.md
@@ -387,12 +387,20 @@ operation.
 
 ## 🧠 Advanced: Architecture & Engineering
 
-Superseedr is built on a **Reactive Actor** architecture verified by model-based fuzzing, ensuring stability under chaos. It features a **Self-Tuning Resource Allocator** that adapts to your hardware in real-time and a hybrid **BitTorrent v2** engine, all powered by asynchronous **Tokio** streams for maximum throughput.
+Superseedr is built on a **Reactive Actor** architecture verified by model-based fuzzing, ensuring stability under chaos. It features a **Self-Tuning Resource Allocator** that adapts to your hardware in real-time, a hybrid **BitTorrent v2** engine, and a client-side WebAssembly demonstration of the production terminal UI.
 
 <details>
 <summary><strong>Click to expand technical internals</strong></summary>
 
 This section is designed for developers, contributors, and AI agents seeking to understand the internal design decisions that drive Superseedr's performance.
+
+### 🌐 Shared TUI Browser Runtime
+The **[Live Interactive Demo](https://jagalite.github.io/superseedr/)** runs the Superseedr terminal interface entirely in the browser without a server-side application runtime.
+* **Production Ratatui Rendering:** The WebAssembly client invokes the same Ratatui screen renderers, shared state models, event dispatcher, and reducers used by the native application instead of recreating the interface in HTML.
+* **Ghostty Web Output:** A browser Ratatui backend emits ANSI frames into Ghostty Web, preserving the terminal presentation, keyboard interaction, responsive resizing, themes, visualizations, and 60 FPS target.
+* **Deterministic Simulation:** Browser-owned mocks provide fictional torrents, peers, files, lifecycle events, DHT activity, telemetry, and disk conditions without performing real torrent, network, or disk operations.
+* **Shared Interaction Contracts:** Magnet paste, navigation, pause, resume, delete, configuration, file-browser, and management interactions pass through production reducers and command boundaries before the simulated service fulfills them in memory.
+* **Cross-Runtime Verification:** Native characterization tests, real-WebAssembly contracts, static-bundle checks, and Chromium browser tests protect the shared TUI behavior while keeping browser dependencies out of normal native builds.
 
 ### ⚡ Async Networking Core
 Superseedr is built on the **Tokio** runtime, leveraging asynchronous I/O for maximum concurrency.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Superseedr is a modern Rust BitTorrent client featuring a high-performance terminal UI, real-time swarm observability, secure VPN-aware Docker setups, and zero manual network configuration. It is fast, privacy-oriented, and built for both desktop users and homelab/server workflows.
 
-**[Live Interactive Demo →](https://web.superseedr.com/)** — Experience the full superseedr terminal UI in the browser! This demo runs entirely client-side and does not perform real torrent, network, or disk operations.
+**[Live Interactive Demo](https://web.superseedr.com/)** — Experience the full superseedr terminal UI in the browser! This demo runs entirely client-side and does not perform real torrent, network, or disk operations.
 
 ![Feature Demo](https://raw.githubusercontent.com/Jagalite/superseedr-assets/main/superseedr_landing.webp)
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 
 Superseedr is a modern Rust BitTorrent client featuring a high-performance terminal UI, real-time swarm observability, secure VPN-aware Docker setups, and zero manual network configuration. It is fast, privacy-oriented, and built for both desktop users and homelab/server workflows.
 
+## Live Interactive Demo
+
+**[Launch Superseedr in your browser](https://jagalite.github.io/superseedr/)** to explore the production terminal interface with deterministic simulated torrent activity. The demo runs entirely client-side and does not perform real torrent, network, or disk operations.
+
 ![Feature Demo](https://raw.githubusercontent.com/Jagalite/superseedr-assets/main/superseedr_landing.webp)
 
 ## 🚀 Features at a Glance
@@ -474,5 +478,3 @@ Superseedr implements the following BitTorrent Enhancement Proposals (BEPs):
 * **BEP 52:** The BitTorrent Protocol v2
 
 </details>
-
-

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Superseedr is a modern Rust BitTorrent client featuring a high-performance terminal UI, real-time swarm observability, secure VPN-aware Docker setups, and zero manual network configuration. It is fast, privacy-oriented, and built for both desktop users and homelab/server workflows.
 
-**[Live Interactive Demo](https://web.superseedr.com/)** Experience the full superseedr terminal UI in the browser! This demo runs entirely client-side and does not perform real torrent, network, or disk operations.
+**[Live Interactive Demo](https://web.superseedr.com/)** — Experience the full superseedr terminal UI in the browser! This demo runs entirely client-side and does not perform real torrent, network, or disk operations.
 
 ![Feature Demo](https://raw.githubusercontent.com/Jagalite/superseedr-assets/main/superseedr_landing.webp)
 


### PR DESCRIPTION
## Summary

- add a prominent Live Interactive Demo section near the beginning of the README
- link to the GitHub Pages browser demo
- clarify that the current demo is client-side and simulated

## Validation

- `git diff --check origin/main...HEAD`