### PR TITLE
Improve help readability and use uppercase dashboard shortcuts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ chrono = "0.4.44"
 serde_json = "1.0.149"
 regex = "1.12.2"
 url = "2.5.8"
-ratatui = { version = "=0.30.2", default-features = false, features = ["all-widgets", "layout-cache", "macros", "std", "underline-color"] }
+ratatui = { version = "=0.30.2", default-features = false, features = ["all-widgets", "layout-cache", "macros", "std", "underline-color", "unstable-rendered-line-info"] }
 bitflags = "2.13.0"
 web-time = { version = "1.1.0", features = ["serde"] }
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ superseedr
 | `m` | **Open full manual / help** |
 | `Q` | Quit |
 | `↑` `↓` `←` `→` | Navigate |
-| `c` | Configure Settings |
+| `C` | Configure Settings |
+| `R` | Open RSS |
+| `Z` | Toggle power-saving mode |
 
 > [!TIP]  
 > Add torrents by clicking magnet links in your browser or opening .torrent files.
@@ -164,7 +166,7 @@ Superseedr can detect Gluetun’s updated port and reload the listener **live**,
 docker compose up -d && docker compose attach superseedr
 ```
 > To detach from the TUI without stopping the container, use the Docker key sequence: `Ctrl+P` followed by `Ctrl+Q`.
-> **Optional:** press `[z]` first to enter power-saving mode.
+> **Optional:** press `[Z]` first to enter power-saving mode.
 
 ---
 

--- a/src/tui/README.md
+++ b/src/tui/README.md
@@ -45,8 +45,9 @@
 - `Normal`:
   - `/` enters search.
   - `v` enters visualization focus mode when an eligible panel is visible; `Tab`/`Shift+Tab` moves between Peer Stream and DHT when those panels are visible, `Left`/`Right` (or `<`/`>`) cycles their retained visualization renderers, `u` restores the classic renderer, and `v` or `Esc` exits.
-  - `z` -> `PowerSaving`.
-  - `c` -> `Config`.
+  - `Z` -> `PowerSaving`.
+  - `C` -> `Config`.
+  - `R` -> `Rss`.
   - `a` -> `FileBrowser` (add torrent flow).
   - `d`/`D` -> `DeleteConfirm`.
   - `M` -> `TorrentManagement`.
@@ -71,7 +72,7 @@
   - `h`/`l` or `←`/`→` moves between visible columns; `s` sorts by the focused column.
   - `Enter` toggles full peer details on compact layouts; `x` toggles privacy masking.
   - `Esc`/`q` returns to `Normal`.
-- `PowerSaving`: `z` -> `Normal`.
+- `PowerSaving`: `Z` -> `Normal`.
 - `Config`:
   - `Space` shifts boolean and choice settings immediately, opens value editing for the listen port and global rate limits, or opens a path browser; `Left`/`Right` (or `h`/`l`) moves backward/forward through choices; `r` opens reset confirmation for the focused setting.
   - In reset confirmation, `Y` restores the default and `Esc` cancels.
@@ -94,9 +95,10 @@ This contract formalizes top-level screen transitions. Any transition behavior c
 | `Welcome` | `Esc` press | `Normal` | Entry handoff |
 | `Normal` | `m` | `Help` | Manual/help route |
 | `Help` | `Esc`, `m`, or `q` | `Normal` | Close help when search is not active |
-| `Normal` | `z` | `PowerSaving` | Zen mode |
-| `PowerSaving` | `z` | `Normal` | Return from zen |
-| `Normal` | `c` | `Config` | Open settings |
+| `Normal` | `Z` | `PowerSaving` | Zen mode |
+| `PowerSaving` | `Z` | `Normal` | Return from zen |
+| `Normal` | `C` | `Config` | Open settings |
+| `Normal` | `R` | `Rss` | Open RSS |
 | `Config` | completed control change | `Config` | Apply toggles, choices, confirmed resets, and value edits immediately |
 | `Config` | `Esc` or `q` | `Normal` or `Config` | Close immediately; compact details first returns to the settings list |
 | `Normal` | `M` | `TorrentManagement` | Batch torrent management |
@@ -111,8 +113,8 @@ This contract formalizes top-level screen transitions. Any transition behavior c
 | `FileBrowser` | `Esc` | `Normal` or `Config` | Depends on browser sub-mode |
 
 ### Forbidden/No-op examples
-- `Help` + unrelated keys (e.g. `c`, `a`, `d`) must stay in `Help`.
-- `PowerSaving` + non-`z` keys must stay in `PowerSaving`.
+- `Help` + unrelated keys (e.g. `C`, `a`, `d`) must stay in `Help`.
+- `PowerSaving` + non-`Z` keys must stay in `PowerSaving`.
 - `Welcome` + non-`Esc` keys must stay in `Welcome`.
 
 ### Executable Transition Table (Tests)
@@ -132,12 +134,14 @@ Keep the current lightweight contract unless one or more of these happen:
 ## Help Overlay
 - Help now uses dedicated route mode: `AppMode::Help`.
 - Windows: `m` press toggles between `Normal` and `Help`.
-- Non-Windows: `m` press opens help from `Normal`; `m` release or `Esc` closes to `Normal`.
+- Non-Windows: `m` press opens help from `Normal`; `m`, `q`, or `Esc` press closes it when search is inactive.
 - Help content is sectioned (`General`, `Torrents`, `Graphs`, `Legends`, `Screens`, `Paths`, `Build`) and scrolls with `Up`/`Down` or `k`/`j`.
 - `Tab`/`Shift+Tab` or `h`/`l` moves between sections.
 - `/` opens a prompt-panel search across all help contents, including path and build rows; typed characters filter live, `Tab` toggles fuzzy/regex matching, `Enter` keeps results, and `Esc` clears search.
-- Help keeps the section tabs above the bordered panel and the command footer below it. Wider layouts use the classic full tab strip; narrower layouts tighten the spacing or show neighboring sections while preserving the grouped command index.
-- Help geometry is planned once and shared by rendering and scroll clamping so fixed chrome, search, and warning rows cannot make reachable content diverge from what is visible.
+- Section tabs stay above the Help panel at every size, with tighter spacing or neighboring sections on narrow terminals. Dashboard shortcuts come first in General.
+- Keys and descriptions wrap without truncation; narrow layouts stack the description below its shortcut. `Page Up`/`Page Down` scroll by a viewport, and `Home`/`End` jump to either end while browsing. A scrollbar indicates additional content.
+- Invalid regular expressions and empty results offer a recovery hint. Search results retain their section headings.
+- Help geometry is planned once and shared by rendering and scroll clamping, using the same text wrapping as rendering, so fixed chrome, search, and warning rows cannot make reachable content diverge from what is visible.
 
 ## Invariants
 - Reducers are deterministic and side-effect free; side effects execute via effect runners.

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -1494,14 +1494,14 @@ mod tests {
         assert!(matches!(app.app_state.mode, AppMode::Normal));
         now += PasteBurst::flush_delay() + Duration::from_millis(1);
 
-        press_and_flush(&mut app, 'c', now).await;
+        press_and_flush(&mut app, 'C', now).await;
         assert!(matches!(app.app_state.mode, AppMode::Config));
         GLOBAL_ESC_TIMESTAMP.store(0, Ordering::Relaxed);
         press_key(&mut app, KeyCode::Esc).await;
         assert!(matches!(app.app_state.mode, AppMode::Normal));
         now += PasteBurst::flush_delay() + Duration::from_millis(1);
 
-        press_and_flush(&mut app, 'r', now).await;
+        press_and_flush(&mut app, 'R', now).await;
         assert!(matches!(app.app_state.mode, AppMode::Rss));
         GLOBAL_ESC_TIMESTAMP.store(0, Ordering::Relaxed);
         press_key(&mut app, KeyCode::Esc).await;
@@ -1536,11 +1536,11 @@ mod tests {
         assert!(matches!(app.app_state.mode, AppMode::Normal));
         now += PasteBurst::flush_delay() + Duration::from_millis(1);
 
-        press_and_flush(&mut app, 'z', now).await;
+        press_and_flush(&mut app, 'Z', now).await;
         assert!(matches!(app.app_state.mode, AppMode::PowerSaving));
         press_and_flush(
             &mut app,
-            'z',
+            'Z',
             now + PasteBurst::flush_delay() + Duration::from_millis(1),
         )
         .await;

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -57,19 +57,13 @@ impl HelpSection {
 
     fn description(self) -> &'static str {
         match self {
-            Self::General => {
-                "Move through Superseedr, search the manual, and reach every global workspace."
-            }
-            Self::Torrents => {
-                "Add, pause, sort, and remove transfers with deliberate keyboard control."
-            }
-            Self::Graphs => "Tune live telemetry, time scale, refresh cadence, and presentation.",
-            Self::Legends => {
-                "Decode peer state, disk activity, DHT telemetry, and session progression."
-            }
-            Self::Screens => "Use the context-aware commands available in each focused workspace.",
-            Self::Paths => "Inspect the resolved locations for this host and configuration mode.",
-            Self::Build => "See the discovery capabilities compiled into this exact executable.",
+            Self::General => "Everyday shortcuts. Use these from the main dashboard.",
+            Self::Torrents => "Add transfers and control the selected torrent.",
+            Self::Graphs => "Adjust charts, visualizations, and appearance.",
+            Self::Legends => "Understand the colors and metrics on the dashboard.",
+            Self::Screens => "Shortcuts for management, settings, and other screens.",
+            Self::Paths => "Configuration, logs, and watched folders on this host.",
+            Self::Build => "Discovery features available in this executable.",
         }
     }
 }
@@ -242,6 +236,56 @@ fn build_help_items(settings: &Settings, app_state: &AppState) -> Vec<HelpItem> 
 
     action_item!(
         HelpSection::General,
+        "Dashboard shortcuts",
+        "C",
+        "Open Config",
+        ActionTone::Open
+    );
+    action_item!(
+        HelpSection::General,
+        "Dashboard shortcuts",
+        "R",
+        "Open RSS",
+        ActionTone::Open
+    );
+    action_item!(
+        HelpSection::General,
+        "Dashboard shortcuts",
+        "J",
+        "Open the event journal",
+        ActionTone::Open
+    );
+    action_item!(
+        HelpSection::General,
+        "Dashboard shortcuts",
+        "M",
+        "Open torrent management",
+        ActionTone::Open
+    );
+    action_item!(
+        HelpSection::General,
+        "Dashboard shortcuts",
+        "P",
+        "Open peer management",
+        ActionTone::Open
+    );
+    action_item!(
+        HelpSection::General,
+        "Dashboard shortcuts",
+        "Z",
+        "Toggle Zen / Power Saving mode",
+        ActionTone::Toggle
+    );
+
+    action_item!(
+        HelpSection::General,
+        "Dashboard shortcuts",
+        "Q (shift+q)",
+        "Quit the application",
+        ActionTone::Destructive
+    );
+    action_item!(
+        HelpSection::General,
         "Help Navigation",
         "Tab / Shift+Tab / h / l",
         "Move between help sections",
@@ -257,8 +301,15 @@ fn build_help_items(settings: &Settings, app_state: &AppState) -> Vec<HelpItem> 
     action_item!(
         HelpSection::General,
         "Help Navigation",
+        "PgUp / PgDn / Home / End",
+        "Scroll by a page or jump to the start or end; Home and End apply while browsing",
+        ActionTone::Navigate
+    );
+    action_item!(
+        HelpSection::General,
+        "Help Navigation",
         "Esc / m / q",
-        "Close the field manual and return to the dashboard",
+        "Close help and return to the dashboard",
         ActionTone::Cancel
     );
     action_item!(
@@ -289,56 +340,6 @@ fn build_help_items(settings: &Settings, app_state: &AppState) -> Vec<HelpItem> 
         "Clear the current query without leaving the search panel",
         ActionTone::Clear
     );
-    action_item!(
-        HelpSection::General,
-        "Global Routes",
-        "Q (shift+q)",
-        "Quit the application",
-        ActionTone::Destructive
-    );
-    action_item!(
-        HelpSection::General,
-        "Global Routes",
-        "c",
-        "Open Config",
-        ActionTone::Open
-    );
-    action_item!(
-        HelpSection::General,
-        "Global Routes",
-        "r",
-        "Open RSS",
-        ActionTone::Open
-    );
-    action_item!(
-        HelpSection::General,
-        "Global Routes",
-        "J",
-        "Open the event journal",
-        ActionTone::Open
-    );
-    action_item!(
-        HelpSection::General,
-        "Global Routes",
-        "M",
-        "Open torrent management",
-        ActionTone::Open
-    );
-    action_item!(
-        HelpSection::General,
-        "Global Routes",
-        "P",
-        "Open peer management",
-        ActionTone::Open
-    );
-    action_item!(
-        HelpSection::General,
-        "Global Routes",
-        "z",
-        "Toggle Zen / Power Saving mode",
-        ActionTone::Toggle
-    );
-
     action_item!(
         HelpSection::Torrents,
         "Adding Torrents",
@@ -937,6 +938,10 @@ pub enum HelpAction {
     SectionPrev,
     ScrollUp,
     ScrollDown,
+    PageUp,
+    PageDown,
+    First,
+    Last,
     SearchStart,
     SearchInsert(char),
     SearchBackspace,
@@ -964,6 +969,14 @@ fn map_key_to_help_action(key: KeyEvent, search_panel_active: bool) -> Option<He
 
     let has_ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
     let has_alt = key.modifiers.contains(KeyModifiers::ALT);
+
+    match key.code {
+        KeyCode::PageUp => return Some(HelpAction::PageUp),
+        KeyCode::PageDown => return Some(HelpAction::PageDown),
+        KeyCode::Home if !search_panel_active => return Some(HelpAction::First),
+        KeyCode::End if !search_panel_active => return Some(HelpAction::Last),
+        _ => {}
+    }
 
     if search_panel_active && matches!(key.code, KeyCode::Tab) {
         return Some(HelpAction::ToggleSearchMode);
@@ -1019,28 +1032,26 @@ pub fn reduce_help_action(
                 effects: Vec::new(),
             }
         }
-        HelpAction::ScrollUp => {
+        HelpAction::ScrollUp
+        | HelpAction::ScrollDown
+        | HelpAction::PageUp
+        | HelpAction::PageDown
+        | HelpAction::First
+        | HelpAction::Last => {
             let max_scroll = max_help_scroll_offset(settings, app_state);
-            app_state.ui.help.scroll_offset = app_state
-                .ui
-                .help
-                .scroll_offset
-                .min(max_scroll)
-                .saturating_sub(1);
-            HelpReduceResult {
-                consumed: true,
-                effects: Vec::new(),
-            }
-        }
-        HelpAction::ScrollDown => {
-            let max_scroll = max_help_scroll_offset(settings, app_state);
-            app_state.ui.help.scroll_offset = app_state
-                .ui
-                .help
-                .scroll_offset
-                .min(max_scroll)
-                .saturating_add(1)
-                .min(max_scroll);
+            let current = app_state.ui.help.scroll_offset.min(max_scroll);
+            let page = help_visible_count_for_state(app_state)
+                .saturating_sub(1)
+                .max(1);
+            app_state.ui.help.scroll_offset = match action {
+                HelpAction::ScrollUp => current.saturating_sub(1),
+                HelpAction::ScrollDown => current.saturating_add(1).min(max_scroll),
+                HelpAction::PageUp => current.saturating_sub(page),
+                HelpAction::PageDown => current.saturating_add(page).min(max_scroll),
+                HelpAction::First => 0,
+                HelpAction::Last => max_scroll,
+                _ => unreachable!(),
+            };
             HelpReduceResult {
                 consumed: true,
                 effects: Vec::new(),
@@ -1273,7 +1284,7 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
 
     let active_color = help_section_color(app_state.ui.help.active_section, ctx);
     let panel_title = Line::from(Span::styled(
-        " ◆ ",
+        " Help ",
         ctx.apply(Style::default().fg(active_color).bold()),
     ));
     let vertical_padding = u16::from(matches!(layout.density, HelpDensity::Spacious));
@@ -1344,7 +1355,6 @@ fn draw_help_hero(
     if matches!(density, HelpDensity::Compact) {
         f.render_widget(
             Paragraph::new(Line::from(vec![
-                Span::styled("◆ ", ctx.apply(Style::default().fg(color).bold())),
                 Span::styled(
                     title,
                     ctx.apply(Style::default().fg(ctx.theme.semantic.text).bold()),
@@ -1371,13 +1381,10 @@ fn draw_help_hero(
     let columns = Layout::horizontal([Constraint::Min(1), Constraint::Length(14)])
         .split(Rect::new(inner.x, inner.y, inner.width, 1));
     f.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("◆ ", ctx.apply(Style::default().fg(color).bold())),
-            Span::styled(
-                title,
-                ctx.apply(Style::default().fg(ctx.theme.semantic.text).bold()),
-            ),
-        ])),
+        Paragraph::new(Line::from(vec![Span::styled(
+            title,
+            ctx.apply(Style::default().fg(ctx.theme.semantic.text).bold()),
+        )])),
         columns[0],
     );
     f.render_widget(
@@ -1390,12 +1397,8 @@ fn draw_help_hero(
     if inner.height > 1 {
         let description = if search_view {
             match app_state.ui.help.search_mode {
-                SearchMode::Fuzzy => {
-                    "Fuzzy matching across every help section; Tab changes mode and Esc clears."
-                }
-                SearchMode::Regex => {
-                    "Regex matching across every help section; Tab changes mode and Esc clears."
-                }
+                SearchMode::Fuzzy => "Searching all sections · Tab changes mode · Esc clears",
+                SearchMode::Regex => "Searching all sections · Tab changes mode · Esc clears",
             }
         } else {
             section.description()
@@ -1579,50 +1582,116 @@ fn help_visible_count_for_state(app_state: &AppState) -> usize {
 fn max_help_scroll_offset(settings: &Settings, app_state: &AppState) -> usize {
     let items = help_items_for_view(settings, app_state);
     let search_view = app_state.ui.help.is_searching || !app_state.ui.help.search_query.is_empty();
-    let display_rows = help_display_rows(&items, search_view);
-    clamped_scroll_offset(
-        usize::MAX,
-        display_rows.len(),
-        help_visible_count_for_state(app_state),
-    )
+    let height = help_content_height(
+        &items,
+        search_view,
+        help_table_area_for_state(app_state).width.saturating_sub(1),
+    );
+    clamped_scroll_offset(usize::MAX, height, help_visible_count_for_state(app_state))
 }
 
-fn help_marker_key_cell(
+fn help_marker_key_line(
     marker: &'static str,
     marker_color: Color,
     label: &str,
     ctx: &ThemeContext,
-) -> Cell<'static> {
-    Cell::from(Line::from(vec![
+) -> Line<'static> {
+    Line::from(vec![
         Span::styled(marker, ctx.apply(Style::default().fg(marker_color).bold())),
         Span::styled(
             format!(" {label}"),
             ctx.apply(Style::default().fg(ctx.theme.semantic.text)),
         ),
-    ]))
+    ])
 }
 
-fn help_item_key_cell(item: &HelpItem, key_width: u16, ctx: &ThemeContext) -> Cell<'static> {
+fn help_key_label(item: &HelpItem) -> String {
+    let key = sanitize_text(&item.key);
     match item.key_style {
-        HelpKeyStyle::Plain => Cell::from(Span::styled(
-            truncate_with_ellipsis(&format!("[{}]", item.key), key_width as usize),
+        HelpKeyStyle::Plain => key,
+        HelpKeyStyle::DiskRead => format!("↑ {key}"),
+        HelpKeyStyle::DiskWrite => format!("↓ {key}"),
+        _ => format!("■ {key}"),
+    }
+}
+
+fn help_item_key_line(item: &HelpItem, ctx: &ThemeContext) -> Line<'static> {
+    match item.key_style {
+        HelpKeyStyle::Plain => Line::from(Span::styled(
+            help_key_label(item),
             help_key_style(ctx, item.action_tone).bold(),
         )),
         HelpKeyStyle::PeerDownloadOpportunity => {
-            help_marker_key_cell("■", ctx.accent_sapphire(), &item.key, ctx)
+            help_marker_key_line("■", ctx.accent_sapphire(), &item.key, ctx)
         }
         HelpKeyStyle::PeerDownloadBlocked => {
-            help_marker_key_cell("■", ctx.accent_maroon(), &item.key, ctx)
+            help_marker_key_line("■", ctx.accent_maroon(), &item.key, ctx)
         }
         HelpKeyStyle::PeerUploadOpportunity => {
-            help_marker_key_cell("■", ctx.accent_teal(), &item.key, ctx)
+            help_marker_key_line("■", ctx.accent_teal(), &item.key, ctx)
         }
         HelpKeyStyle::PeerUploadRestricted => {
-            help_marker_key_cell("■", ctx.accent_peach(), &item.key, ctx)
+            help_marker_key_line("■", ctx.accent_peach(), &item.key, ctx)
         }
-        HelpKeyStyle::DiskRead => help_marker_key_cell("↑", ctx.state_success(), &item.key, ctx),
-        HelpKeyStyle::DiskWrite => help_marker_key_cell("↓", ctx.accent_sky(), &item.key, ctx),
+        HelpKeyStyle::DiskRead => help_marker_key_line("↑", ctx.state_success(), &item.key, ctx),
+        HelpKeyStyle::DiskWrite => help_marker_key_line("↓", ctx.accent_sky(), &item.key, ctx),
     }
+}
+
+// Measurement and drawing both use Paragraph's wrapper, including Unicode widths.
+fn wrapped_height(text: &str, width: u16) -> usize {
+    Paragraph::new(text)
+        .wrap(Wrap { trim: false })
+        .line_count(width.max(1))
+        .max(1)
+}
+
+fn help_key_width(width: u16) -> Option<u16> {
+    (width >= 64).then_some(28)
+}
+
+fn help_row_height(row: &HelpDisplayRow<'_>, width: u16) -> usize {
+    match row {
+        HelpDisplayRow::Spacer => 1,
+        HelpDisplayRow::Heading { title, .. } => wrapped_height(title, width),
+        HelpDisplayRow::Item(item) => {
+            let key = help_key_label(item);
+            let action = sanitize_text(&item.action);
+            if let Some(key_width) = help_key_width(width) {
+                wrapped_height(&key, key_width)
+                    .max(wrapped_height(&action, width.saturating_sub(key_width + 2)))
+            } else {
+                wrapped_height(&key, width) + wrapped_height(&action, width.saturating_sub(2))
+            }
+        }
+    }
+}
+
+fn help_content_height(items: &[HelpItem], search_view: bool, width: u16) -> usize {
+    help_display_rows(items, search_view)
+        .iter()
+        .map(|row| help_row_height(row, width))
+        .sum()
+}
+
+// A paragraph can begin above the viewport: scroll inside it instead of dropping
+// its remaining lines. This keeps long descriptions and paths fully reachable.
+fn draw_help_paragraph(f: &mut Frame, area: Rect, start: usize, scroll: usize, line: Line<'_>) {
+    let height = Paragraph::new(line.clone())
+        .wrap(Wrap { trim: false })
+        .line_count(area.width);
+    let hidden = scroll.saturating_sub(start);
+    let y = start.saturating_sub(scroll);
+    if hidden >= height || y >= usize::from(area.height) || area.width == 0 {
+        return;
+    }
+    let visible = (height - hidden).min(usize::from(area.height) - y) as u16;
+    f.render_widget(
+        Paragraph::new(line)
+            .wrap(Wrap { trim: false })
+            .scroll((hidden as u16, 0)),
+        Rect::new(area.x, area.y + y as u16, area.width, visible),
+    );
 }
 
 fn draw_help_table(
@@ -1632,86 +1701,116 @@ fn draw_help_table(
     items: &[HelpItem],
     ctx: &ThemeContext,
 ) {
-    if area.height == 0 {
+    if area.is_empty() {
         return;
     }
-
+    let muted = ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0));
+    if items.is_empty() {
+        let invalid_regex = app_state.ui.help.search_mode == SearchMode::Regex
+            && regex::Regex::new(app_state.ui.help.search_query.trim()).is_err();
+        let message = if invalid_regex {
+            "Invalid regular expression. Edit the query or press Tab for fuzzy search."
+        } else {
+            "No matching commands. Try a shorter query, or press Esc to browse sections."
+        };
+        f.render_widget(
+            Paragraph::new(message)
+                .wrap(Wrap { trim: false })
+                .style(muted),
+            area,
+        );
+        return;
+    }
+    // Leave a dedicated gutter for the scroll indicator.
+    let content = Rect::new(area.x, area.y, area.width.saturating_sub(1), area.height);
     let search_view = app_state.ui.help.is_searching || !app_state.ui.help.search_query.is_empty();
-    let display_rows = help_display_rows(items, search_view);
-    let visible_count = help_table_capacity(area);
+    let rows = help_display_rows(items, search_view);
+    let total = help_content_height(items, search_view, content.width);
     let scroll = clamped_scroll_offset(
         app_state.ui.help.scroll_offset,
-        display_rows.len(),
-        visible_count,
+        total,
+        help_table_capacity(area),
     );
-    let visible_rows = display_rows
-        .iter()
-        .skip(scroll)
-        .take(visible_count)
-        .collect::<Vec<_>>();
-    let key_width = if area.width >= 58 {
-        28
-    } else if area.width >= 42 {
-        22
-    } else {
-        (area.width / 2).clamp(12, 20)
-    };
-    let column_spacing = u16::from(area.width >= 48);
-    let action_width = area
-        .width
-        .saturating_sub(key_width)
-        .saturating_sub(column_spacing)
-        .saturating_sub(2) as usize;
-
-    let rows = if visible_rows.is_empty() {
-        vec![Row::new(vec![
-            Cell::from(Span::styled(
-                "-",
-                ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0)),
-            )),
-            Cell::from(Span::styled(
-                if app_state.ui.help.search_query.is_empty() {
-                    "No help entries in this view"
-                } else {
-                    "No help entries match the search"
-                },
-                ctx.apply(Style::default().fg(ctx.state_warning())),
-            )),
-        ])]
-    } else {
-        visible_rows
-            .into_iter()
-            .map(|row| match row {
-                HelpDisplayRow::Spacer => Row::new(vec![Cell::from(""), Cell::from("")]),
-                HelpDisplayRow::Heading { section, title } => Row::new(vec![
-                    Cell::from(Span::styled(
-                        truncate_with_ellipsis(
-                            &format!("◆ {}", title.to_uppercase()),
-                            key_width as usize,
-                        ),
+    let mut start = 0;
+    for row in rows {
+        let height = help_row_height(&row, content.width);
+        match &row {
+            HelpDisplayRow::Spacer => {}
+            HelpDisplayRow::Heading { section, title } => {
+                draw_help_paragraph(
+                    f,
+                    content,
+                    start,
+                    scroll,
+                    Line::styled(
+                        title.clone(),
                         ctx.apply(
                             Style::default()
                                 .fg(help_section_color(*section, ctx))
                                 .bold(),
                         ),
-                    )),
-                    Cell::from(""),
-                ]),
-                HelpDisplayRow::Item(item) => Row::new(vec![
-                    help_item_key_cell(item, key_width, ctx),
-                    Cell::from(Span::styled(
-                        format!("  {}", truncate_with_ellipsis(&item.action, action_width)),
-                        ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1)),
-                    )),
-                ]),
-            })
-            .collect()
-    };
-
-    let table = Table::new(rows, [Constraint::Length(key_width), Constraint::Min(1)])
-        .column_spacing(column_spacing);
-
-    f.render_widget(table, area);
+                    ),
+                );
+            }
+            HelpDisplayRow::Item(item) => {
+                let key = help_item_key_line(item, ctx);
+                let action = Line::styled(
+                    sanitize_text(&item.action),
+                    ctx.apply(Style::default().fg(ctx.theme.semantic.text)),
+                );
+                if let Some(key_width) = help_key_width(content.width) {
+                    draw_help_paragraph(
+                        f,
+                        Rect::new(content.x, content.y, key_width, content.height),
+                        start,
+                        scroll,
+                        key,
+                    );
+                    draw_help_paragraph(
+                        f,
+                        Rect::new(
+                            content.x + key_width + 2,
+                            content.y,
+                            content.width - key_width - 2,
+                            content.height,
+                        ),
+                        start,
+                        scroll,
+                        action,
+                    );
+                } else {
+                    let key_height = wrapped_height(&help_key_label(item), content.width);
+                    draw_help_paragraph(f, content, start, scroll, key);
+                    draw_help_paragraph(
+                        f,
+                        Rect::new(
+                            content.x + 2,
+                            content.y,
+                            content.width.saturating_sub(2),
+                            content.height,
+                        ),
+                        start + key_height,
+                        scroll,
+                        action,
+                    );
+                }
+            }
+        }
+        start += height;
+    }
+    if total > usize::from(area.height) {
+        let mut state = ScrollbarState::new(total.saturating_sub(usize::from(area.height)) + 1)
+            .position(scroll);
+        f.render_stateful_widget(
+            Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                .begin_symbol(None)
+                .end_symbol(None)
+                .track_style(ctx.apply(Style::default().fg(ctx.theme.semantic.surface1)))
+                .thumb_style(muted),
+            area,
+            &mut state,
+        );
+    }
 }
 
 fn draw_help_controls(f: &mut Frame, area: Rect, app_state: &AppState, ctx: &ThemeContext) {
@@ -1725,9 +1824,8 @@ fn draw_help_controls(f: &mut Frame, area: Rect, app_state: &AppState, ctx: &The
     let compact = area.width < 68;
     let entries: &[(&str, &str, ActionTone)] = if search_panel_active && tight {
         &[
-            ("Tab", "", ActionTone::Mode),
-            ("Enter", "", ActionTone::Confirm),
-            ("Esc", "", ActionTone::Cancel),
+            ("Tab", "mode", ActionTone::Mode),
+            ("Esc", "clear", ActionTone::Cancel),
         ]
     } else if search_panel_active && compact {
         &[
@@ -1745,9 +1843,9 @@ fn draw_help_controls(f: &mut Frame, area: Rect, app_state: &AppState, ctx: &The
         ]
     } else if tight {
         &[
-            ("Esc", "", ActionTone::Cancel),
-            ("Tab", "", ActionTone::Mode),
-            ("/", "", ActionTone::Search),
+            ("Esc", "close", ActionTone::Cancel),
+            ("Tab", "next", ActionTone::Mode),
+            ("/", "find", ActionTone::Search),
         ]
     } else if compact {
         &[
@@ -1755,12 +1853,20 @@ fn draw_help_controls(f: &mut Frame, area: Rect, app_state: &AppState, ctx: &The
             ("Tab", "section", ActionTone::Mode),
             ("/", "search", ActionTone::Search),
         ]
-    } else {
+    } else if area.width < 94 {
         &[
-            ("Esc/m/q", "close", ActionTone::Cancel),
+            ("Esc", "close", ActionTone::Cancel),
             ("Tab", "section", ActionTone::Mode),
             ("/", "search", ActionTone::Search),
             ("↑/↓", "scroll", ActionTone::Navigate),
+        ]
+    } else {
+        &[
+            ("Esc", "close", ActionTone::Cancel),
+            ("Tab", "section", ActionTone::Mode),
+            ("/", "search", ActionTone::Search),
+            ("↑/↓", "scroll", ActionTone::Navigate),
+            ("PgUp/Dn", "page", ActionTone::Navigate),
         ]
     };
 
@@ -1773,7 +1879,7 @@ fn draw_help_controls(f: &mut Frame, area: Rect, app_state: &AppState, ctx: &The
             ));
         }
         spans.push(Span::styled(
-            format!("[{key}]"),
+            *key,
             crate::tui::action_style::footer_key_style(ctx, *tone),
         ));
         if !label.is_empty() {
@@ -1801,6 +1907,10 @@ mod tests {
     fn render_help_screen(width: u16, height: u16, mut app_state: AppState) -> String {
         app_state.mode = AppMode::Help;
         app_state.screen_area = Rect::new(0, 0, width, height);
+        render_help_state(width, height, &app_state)
+    }
+
+    fn render_help_state(width: u16, height: u16, app_state: &AppState) -> String {
         let settings = Settings::default();
         let dht_status = DhtStatus::default();
         let dht_wave_telemetry = DhtWaveTelemetry::default();
@@ -1811,7 +1921,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let screen = ScreenContext::new(
-                    &app_state,
+                    app_state,
                     &dht_status,
                     &dht_wave_telemetry,
                     &settings,
@@ -1835,7 +1945,7 @@ mod tests {
     }
 
     #[test]
-    fn help_layout_uses_top_tabs_and_external_footer() {
+    fn help_layout_keeps_navigation_and_footer_outside_content() {
         for area in [
             Rect::new(0, 0, 120, 36),
             Rect::new(0, 0, 80, 48),
@@ -1929,17 +2039,23 @@ mod tests {
     }
 
     #[test]
-    fn wide_help_render_keeps_classic_chrome_and_simplified_content() {
+    fn wide_help_render_shows_top_tabs_and_dashboard_shortcuts() {
         let rendered = render_help_screen(120, 36, AppState::default());
 
-        assert!(!rendered.contains("FIELD INDEX"));
-        assert!(!rendered.contains("FIELD NOTE"));
+        let tab_line = rendered
+            .lines()
+            .find(|line| line.contains("Torrents"))
+            .expect("top tabs");
+        for section in HELP_SECTIONS {
+            assert!(tab_line.contains(section.label()));
+        }
         for section in HELP_SECTIONS {
             assert!(rendered.contains(section.label()));
         }
-        assert!(rendered.contains("search the manual"));
-        assert!(rendered.contains("HELP NAVIGATION"));
-        assert!(!rendered.contains("ROWS 1-"));
+        assert!(rendered.contains("Everyday shortcuts"));
+        assert!(rendered.contains("Dashboard shortcuts"));
+        assert!(rendered.contains("Open Config"));
+        assert!(!rendered.contains("[C]"));
     }
 
     #[test]
@@ -1953,9 +2069,8 @@ mod tests {
                     section.label()
                 );
             }
-            assert!(!rendered.contains("FIELD INDEX"));
-            assert!(rendered.contains("HELP NAVIGATION"));
-            assert!(rendered.contains("[Tab] section"));
+            assert!(rendered.contains("Dashboard shortcuts"));
+            assert!(rendered.contains("Tab section"));
         }
     }
 
@@ -1980,8 +2095,13 @@ mod tests {
                 ..Default::default()
             };
             app_state.ui.help.is_searching = true;
-            let display_rows =
-                help_display_rows(&help_items_for_view(&settings, &app_state), true).len();
+            let display_rows = help_content_height(
+                &help_items_for_view(&settings, &app_state),
+                true,
+                help_table_area_for_state(&app_state)
+                    .width
+                    .saturating_sub(1),
+            );
             let expected_max =
                 display_rows.saturating_sub(help_visible_count_for_state(&app_state));
 
@@ -2010,6 +2130,116 @@ mod tests {
         tight_state.ui.help.search_query = "path".to_string();
         let tight_rendered = render_help_screen(40, 10, tight_state);
         assert!(tight_rendered.contains("Help Search"));
+    }
+
+    #[test]
+    fn help_can_render_below_its_minimum_useful_size() {
+        for (width, height) in [(1, 1), (8, 4), (24, 8), (40, 10)] {
+            let mut state = AppState::default();
+            render_help_state(width, height, &state);
+            state.ui.help.is_searching = true;
+            state.system_warning = Some("Service notice".to_string());
+            render_help_state(width, height, &state);
+        }
+    }
+
+    #[test]
+    fn top_tabs_keep_the_full_panel_width_at_every_size() {
+        for area in [
+            Rect::new(0, 0, 120, 36),
+            Rect::new(0, 0, 80, 36),
+            Rect::new(0, 0, 120, 18),
+        ] {
+            let layout = calculate_help_layout(area, false, None);
+            assert_eq!(layout.tabs.height, 1);
+            assert!(layout.tabs.bottom() <= layout.panel.y);
+            assert_eq!(layout.panel.x, layout.popup.x);
+            assert_eq!(layout.panel.width, layout.popup.width);
+        }
+    }
+
+    #[test]
+    fn paging_and_end_reach_wrapped_content_after_resize() {
+        let settings = Settings::default();
+        let mut state = AppState {
+            mode: AppMode::Help,
+            screen_area: Rect::new(0, 0, 80, 24),
+            ..Default::default()
+        };
+        state.ui.help.active_section = HelpSection::Screens;
+        handle_event_with_settings(
+            CrosstermEvent::Key(KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE)),
+            &mut state,
+            &settings,
+        );
+        assert_eq!(
+            state.ui.help.scroll_offset,
+            help_visible_count_for_state(&state) - 1
+        );
+        handle_event_with_settings(
+            CrosstermEvent::Key(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE)),
+            &mut state,
+            &settings,
+        );
+        assert_eq!(state.ui.help.scroll_offset, 0);
+        for (width, height) in [(40, 12), (80, 24), (120, 36)] {
+            state.screen_area = Rect::new(0, 0, width, height);
+            handle_event_with_settings(
+                CrosstermEvent::Key(KeyEvent::new(KeyCode::End, KeyModifiers::NONE)),
+                &mut state,
+                &settings,
+            );
+            assert_eq!(
+                state.ui.help.scroll_offset,
+                max_help_scroll_offset(&settings, &state)
+            );
+            let rendered = render_help_state(width, height, &state);
+            assert!(
+                rendered.contains("Confirm delete"),
+                "last action must be reachable:\n{rendered}"
+            );
+        }
+        handle_event_with_settings(
+            CrosstermEvent::Key(KeyEvent::new(KeyCode::Home, KeyModifiers::NONE)),
+            &mut state,
+            &settings,
+        );
+        assert_eq!(state.ui.help.scroll_offset, 0);
+    }
+
+    #[test]
+    fn long_path_is_readable_across_scrolled_pages() {
+        let settings = Settings::default();
+        let mut state = AppState {
+            mode: AppMode::Help,
+            screen_area: Rect::new(0, 0, 40, 12),
+            ..Default::default()
+        };
+        state.ui.help.active_section = HelpSection::Paths;
+        state.runtime_paths.settings_path = Some(std::path::PathBuf::from(
+            "/archive/研究/quiet-valley/observations/seasonal-records/configuration/unique-tail.toml"));
+        let mut all_visible = String::new();
+        for offset in 0..=max_help_scroll_offset(&settings, &state) {
+            state.ui.help.scroll_offset = offset;
+            all_visible.push_str(&render_help_state(40, 12, &state));
+        }
+        // TestBackend retains the blank continuation cell after each wide glyph.
+        assert!(all_visible.contains('研') && all_visible.contains('究'));
+        assert!(all_visible.contains("unique-tail.toml"));
+        assert!(!all_visible.contains('…'));
+    }
+
+    #[test]
+    fn search_errors_offer_a_recovery_action() {
+        let mut state = AppState::default();
+        state.ui.help.is_searching = true;
+        state.ui.help.search_mode = SearchMode::Regex;
+        state.ui.help.search_query = "[".to_string();
+        let rendered = render_help_state(80, 24, &state);
+        assert!(rendered.contains("Invalid regular expression"));
+        state.ui.help.search_query = "unmatched-reference-4821".to_string();
+        let rendered = render_help_screen(80, 24, state);
+        assert!(rendered.contains("No matching commands"));
     }
 
     #[test]
@@ -2050,7 +2280,7 @@ mod tests {
         };
 
         handle_event(
-            CrosstermEvent::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE)),
+            CrosstermEvent::Key(KeyEvent::new(KeyCode::Char('C'), KeyModifiers::NONE)),
             &mut app_state,
         );
 
@@ -2216,7 +2446,7 @@ mod tests {
         let items = build_help_items(&Settings::default(), &AppState::default());
 
         assert!(items.iter().any(|item| {
-            item.subsection == "Global Routes"
+            item.subsection == "Dashboard shortcuts"
                 && item.key == "P"
                 && item.action == "Open peer management"
         }));

--- a/src/tui/screens/normal.rs
+++ b/src/tui/screens/normal.rs
@@ -1006,7 +1006,7 @@ fn map_key_to_ui_action(key: KeyEvent) -> Option<UiAction> {
         KeyCode::Char('v') => Some(UiAction::ToggleVisualizationFocus),
         KeyCode::Char('/') => Some(UiAction::StartSearch),
         KeyCode::Char('x') => Some(UiAction::ToggleAnonymizeNames),
-        KeyCode::Char('z') => Some(UiAction::EnterPowerSaving),
+        KeyCode::Char('Z') => Some(UiAction::EnterPowerSaving),
         KeyCode::Char('Q') => Some(UiAction::RequestQuit),
         KeyCode::Char('g') => Some(UiAction::ChartViewNext),
         KeyCode::Char('G') => Some(UiAction::ChartViewPrev),
@@ -1016,8 +1016,8 @@ fn map_key_to_ui_action(key: KeyEvent) -> Option<UiAction> {
         KeyCode::Char('f') => Some(UiAction::OpenSelectedTorrentFiles),
         KeyCode::Char('d') => Some(UiAction::OpenDeleteConfirm { with_files: false }),
         KeyCode::Char('D') => Some(UiAction::OpenDeleteConfirm { with_files: true }),
-        KeyCode::Char('c') => Some(UiAction::OpenConfig),
-        KeyCode::Char('r') => Some(UiAction::OpenRss),
+        KeyCode::Char('C') => Some(UiAction::OpenConfig),
+        KeyCode::Char('R') => Some(UiAction::OpenRss),
         KeyCode::Char('J') => Some(UiAction::OpenJournal),
         KeyCode::Char('P') => Some(UiAction::OpenPeerManagement),
         KeyCode::Char('M') => Some(UiAction::OpenTorrentManagement),
@@ -2223,15 +2223,15 @@ pub fn draw_footer(
     push_if_fits("[v]", "isual", footer_key_style(ctx, ActionTone::Mode));
     push_if_fits("[<]theme[>]", "", footer_key_style(ctx, ActionTone::Theme));
     push_if_fits("[/]", "search", footer_key_style(ctx, ActionTone::Search));
-    push_if_fits("[c]", "onfig", footer_key_style(ctx, ActionTone::Open));
-    push_if_fits("[r]", "ss", footer_key_style(ctx, ActionTone::Open));
+    push_if_fits("[C]", "onfig", footer_key_style(ctx, ActionTone::Open));
+    push_if_fits("[R]", "ss", footer_key_style(ctx, ActionTone::Open));
     push_if_fits(
         "[d]",
         "elete",
         footer_key_style(ctx, ActionTone::Destructive),
     );
     push_if_fits("[x]", "anon", footer_key_style(ctx, ActionTone::Toggle));
-    push_if_fits("[z]", "power", footer_key_style(ctx, ActionTone::Toggle));
+    push_if_fits("[Z]", "power", footer_key_style(ctx, ActionTone::Toggle));
     push_if_fits("[T]", "time++", footer_key_style(ctx, ActionTone::Rate));
     push_if_fits("[[]", "slower", footer_key_style(ctx, ActionTone::Rate));
     push_if_fits("[]]", "faster", footer_key_style(ctx, ActionTone::Rate));
@@ -9250,6 +9250,35 @@ mod tests {
     }
 
     #[test]
+    fn workspace_shortcuts_use_uppercase_with_or_without_shift_reporting() {
+        for (key, action) in [
+            ('C', UiAction::OpenConfig),
+            ('R', UiAction::OpenRss),
+            ('Z', UiAction::EnterPowerSaving),
+        ] {
+            for modifiers in [KeyModifiers::NONE, KeyModifiers::SHIFT] {
+                assert_eq!(
+                    map_key_to_ui_action(KeyEvent::new(KeyCode::Char(key), modifiers)),
+                    Some(action.clone())
+                );
+            }
+            assert_eq!(
+                map_key_to_ui_action(KeyEvent::new(
+                    KeyCode::Char(key.to_ascii_lowercase()),
+                    KeyModifiers::NONE
+                )),
+                None
+            );
+            for modifiers in [KeyModifiers::CONTROL, KeyModifiers::ALT] {
+                assert_eq!(
+                    map_key_to_ui_action(KeyEvent::new(KeyCode::Char(key), modifiers)),
+                    None
+                );
+            }
+        }
+    }
+
+    #[test]
     fn visualization_focus_keymap_is_mode_local() {
         assert_eq!(
             map_visualization_focus_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
@@ -9308,7 +9337,7 @@ mod tests {
             None
         );
         assert_eq!(
-            map_key_to_ui_action(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL)),
+            map_key_to_ui_action(KeyEvent::new(KeyCode::Char('R'), KeyModifiers::CONTROL)),
             None
         );
     }

--- a/src/tui/screens/power.rs
+++ b/src/tui/screens/power.rs
@@ -32,7 +32,7 @@ pub struct PowerReduceResult {
 }
 
 fn map_key_to_power_action(key_code: KeyCode, key_kind: KeyEventKind) -> Option<PowerAction> {
-    if key_kind == KeyEventKind::Press && matches!(key_code, KeyCode::Char('z')) {
+    if key_kind == KeyEventKind::Press && matches!(key_code, KeyCode::Char('Z')) {
         return Some(PowerAction::Resume);
     }
     None
@@ -216,7 +216,7 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
             "Press ",
             ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0)),
         ),
-        Span::styled("[z]", footer_key_style(ctx, ActionTone::Toggle)),
+        Span::styled("[Z]", footer_key_style(ctx, ActionTone::Toggle)),
         Span::styled(
             " to resume",
             ctx.apply(Style::default().fg(ctx.theme.semantic.subtext0)),
@@ -234,14 +234,14 @@ mod tests {
     use crate::terminal_event::{KeyEvent, KeyModifiers};
 
     #[test]
-    fn power_z_returns_to_normal() {
+    fn power_uppercase_z_returns_to_normal() {
         let mut app_state = AppState {
             mode: AppMode::PowerSaving,
             ..Default::default()
         };
 
         handle_event(
-            CrosstermEvent::Key(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE)),
+            CrosstermEvent::Key(KeyEvent::new(KeyCode::Char('Z'), KeyModifiers::SHIFT)),
             &mut app_state,
         );
 
@@ -255,11 +255,12 @@ mod tests {
             ..Default::default()
         };
 
-        handle_event(
-            CrosstermEvent::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE)),
-            &mut app_state,
-        );
-
-        assert!(matches!(app_state.mode, AppMode::PowerSaving));
+        for key in ['z', 'C', 'R'] {
+            handle_event(
+                CrosstermEvent::Key(KeyEvent::new(KeyCode::Char(key), KeyModifiers::NONE)),
+                &mut app_state,
+            );
+            assert!(matches!(app_state.mode, AppMode::PowerSaving));
+        }
     }
 }

--- a/src/tui/screens/welcome.rs
+++ b/src/tui/screens/welcome.rs
@@ -191,7 +191,7 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
                 ctx.apply(Style::default().fg(ctx.theme.semantic.surface2))
                     .italic(),
             ),
-            Span::styled("[c]", footer_key_style(ctx, ActionTone::Open).italic()),
+            Span::styled("[C]", footer_key_style(ctx, ActionTone::Open).italic()),
         ]),
         Line::from(""),
         Line::from(vec![
@@ -220,7 +220,7 @@ pub fn draw(f: &mut Frame, screen: &ScreenContext<'_>) {
             " | ",
             ctx.apply(Style::default().fg(ctx.theme.semantic.surface2)),
         ),
-        Span::styled(" [c] ", footer_key_style(ctx, ActionTone::Open)),
+        Span::styled(" [C] ", footer_key_style(ctx, ActionTone::Open)),
         Span::styled(
             "Config",
             ctx.apply(Style::default().fg(ctx.theme.semantic.subtext1)),
@@ -503,7 +503,7 @@ mod tests {
         };
 
         handle_event(
-            CrosstermEvent::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE)),
+            CrosstermEvent::Key(KeyEvent::new(KeyCode::Char('C'), KeyModifiers::NONE)),
             &mut app_state,
         );
 

--- a/web/tests/browser.spec.ts
+++ b/web/tests/browser.spec.ts
@@ -383,12 +383,12 @@ test("browser input reaches production screen and deeper reducers", async ({ pag
   await openScreen(page, "Shift+P", "peer-management");
   await page.keyboard.press("Enter");
   await page.keyboard.press("q");
-  await openScreen(page, "z", "power-saving");
-  await page.keyboard.press("z");
-  await openScreen(page, "c", "config");
+  await openScreen(page, "Shift+Z", "power-saving");
+  await page.keyboard.press("Shift+Z");
+  await openScreen(page, "Shift+C", "config");
   await page.keyboard.press("p");
   await page.keyboard.press("q");
-  await openScreen(page, "r", "rss");
+  await openScreen(page, "Shift+R", "rss");
   await page.keyboard.press("/");
   await page.keyboard.type("Signal Garden");
   await page.keyboard.press("Enter");
@@ -421,7 +421,7 @@ test("committed composition text reaches the production input reducer", async ({
   await page.goto("/");
   const terminal = await expectReady(page);
   await terminal.click();
-  await openScreen(page, "r", "rss");
+  await openScreen(page, "Shift+R", "rss");
   await page.keyboard.press("Tab");
   await page.keyboard.press("a");
 
@@ -617,7 +617,7 @@ test("focused terminal reserves Ctrl+C for the browser", async ({ page }) => {
 
   expect(shortcut.defaultPrevented).toBe(false);
   await expect(terminal).toHaveAttribute("data-should-quit", "false");
-  await openScreen(page, "r", "rss");
+  await openScreen(page, "Shift+R", "rss");
   expect(errors).toEqual([]);
 });
 
@@ -663,7 +663,7 @@ test("browser host disables uppercase Q without changing lowercase screen naviga
   await expect(terminal).toHaveAttribute("data-web-quit-blocked-count", "1");
   await expect(terminal).toHaveAttribute("data-should-quit", "false");
   await page.keyboard.press("Escape");
-  await openScreen(page, "r", "rss");
+  await openScreen(page, "Shift+R", "rss");
   await page.keyboard.press("q");
   await expect(terminal).toHaveAttribute("data-current-screen", "normal");
   expect(errors).toEqual([]);
@@ -772,7 +772,7 @@ test("power-saving mode throttles the browser scheduler to one FPS", async ({ pa
   const terminal = await expectReady(page);
   await terminal.click();
 
-  await page.keyboard.press("z");
+  await page.keyboard.press("Shift+Z");
   await expect(terminal).toHaveAttribute("data-current-screen", "power-saving");
   await expect(terminal).toHaveAttribute("data-target-fps", "1");
   const ticksBefore = Number(await terminal.getAttribute("data-simulation-tick-count"));
@@ -807,7 +807,7 @@ test("RSS configuration sync and preview download effects remain interactive", a
   await page.goto("/");
   const terminal = await expectReady(page);
   await terminal.click();
-  await openScreen(page, "r", "rss");
+  await openScreen(page, "Shift+R", "rss");
 
   await expect(terminal).toHaveAttribute("data-rss-feed-count", "1");
   await expect(terminal).toHaveAttribute("data-rss-enabled-feed-count", "1");
@@ -929,7 +929,7 @@ test("configuration path selection opens the virtual browser and applies the set
   const terminal = await expectReady(page);
   await terminal.click();
   await expect(terminal).toHaveAttribute("data-default-download-folder", "");
-  await openScreen(page, "c", "config");
+  await openScreen(page, "Shift+C", "config");
   for (let index = 0; index < 2; index += 1) await page.keyboard.press("ArrowDown");
 
   await page.keyboard.press("Space");
@@ -956,7 +956,7 @@ test("configuration exposes the browser-owned network interface inventory", asyn
   const terminal = await expectReady(page);
   await terminal.click();
   await expect(terminal).toHaveAttribute("data-browser-network-interface-count", "1");
-  await openScreen(page, "c", "config");
+  await openScreen(page, "Shift+C", "config");
   await page.keyboard.press("ArrowDown");
   await page.keyboard.press("ArrowRight");
   await page.keyboard.press("ArrowDown");
@@ -971,7 +971,7 @@ test("configuration transfer limits constrain the simulated browser runtime", as
   await page.goto("/");
   const terminal = await expectReady(page);
   await terminal.click();
-  await openScreen(page, "c", "config");
+  await openScreen(page, "Shift+C", "config");
   for (let index = 0; index < 5; index += 1) await page.keyboard.press("ArrowDown");
 
   await page.keyboard.press("Space");

--- a/web/wasm/src/browser_demo.rs
+++ b/web/wasm/src/browser_demo.rs
@@ -978,7 +978,7 @@ mod tests {
         let screens = [
             ("welcome", "How to Get Started:"),
             ("normal", "Torrents: 15"),
-            ("help", "HELP NAVIGATION"),
+            ("help", "Dashboard shortcuts"),
             ("journal", "Simulated torrent completed"),
             ("peer-management", "192.0.2."),
             ("torrent-management", " Torrents "),

--- a/web/wasm/src/lib.rs
+++ b/web/wasm/src/lib.rs
@@ -1855,7 +1855,12 @@ mod wasm_contracts {
     async fn power_saving_forces_browser_render_and_manager_cadence_to_one_fps() {
         let mut harness = DemoHarness::for_scenario(120, 40, scenarios::ScenarioId::Downloading);
         assert!(harness.session.select_torrent_hex(FIXTURE_HASH_HEX));
-        key_and_flush(&mut harness.session, KeyCode::Char('z'), KeyModifiers::NONE).await;
+        key_and_flush(
+            &mut harness.session,
+            KeyCode::Char('Z'),
+            KeyModifiers::SHIFT,
+        )
+        .await;
         assert_eq!(harness.session.target_fps(), 1.0);
 
         let before = harness.session.selected_peer_rate_frame_updates();
@@ -2608,7 +2613,7 @@ mod wasm_contracts {
     #[wasm_bindgen_test(async)]
     async fn config_interaction_uses_the_production_reducer() {
         let mut session = rich_session();
-        key_and_flush(&mut session, KeyCode::Char('c'), KeyModifiers::NONE).await;
+        key_and_flush(&mut session, KeyCode::Char('C'), KeyModifiers::SHIFT).await;
         assert_eq!(session.screen(), BrowserScreen::Config);
 
         key_and_flush(&mut session, KeyCode::Char('x'), KeyModifiers::NONE).await;
@@ -2621,7 +2626,12 @@ mod wasm_contracts {
     #[wasm_bindgen_test(async)]
     async fn config_rate_limits_update_the_browser_runtime_and_transfer_caps() {
         let mut harness = DemoHarness::for_scenario(120, 40, scenarios::ScenarioId::Mixed);
-        key_and_flush(&mut harness.session, KeyCode::Char('c'), KeyModifiers::NONE).await;
+        key_and_flush(
+            &mut harness.session,
+            KeyCode::Char('C'),
+            KeyModifiers::SHIFT,
+        )
+        .await;
         for _ in 0..5 {
             key_and_flush(&mut harness.session, KeyCode::Down, KeyModifiers::NONE).await;
         }
@@ -2664,7 +2674,12 @@ mod wasm_contracts {
     async fn config_path_browser_transitions_and_applies_the_virtual_selection() {
         let mut harness = DemoHarness::new(120, 40);
         mocks::install_simulated_state(&mut harness.session);
-        key_and_flush(&mut harness.session, KeyCode::Char('c'), KeyModifiers::NONE).await;
+        key_and_flush(
+            &mut harness.session,
+            KeyCode::Char('C'),
+            KeyModifiers::SHIFT,
+        )
+        .await;
         for _ in 0..2 {
             key_and_flush(&mut harness.session, KeyCode::Down, KeyModifiers::NONE).await;
         }
@@ -2721,7 +2736,12 @@ mod wasm_contracts {
     async fn config_uses_and_refreshes_a_virtual_network_interface_inventory() {
         let mut harness = DemoHarness::new(120, 40);
         assert_eq!(harness.session.browser_network_interface_count(), 1);
-        key_and_flush(&mut harness.session, KeyCode::Char('c'), KeyModifiers::NONE).await;
+        key_and_flush(
+            &mut harness.session,
+            KeyCode::Char('C'),
+            KeyModifiers::SHIFT,
+        )
+        .await;
         key_and_flush(&mut harness.session, KeyCode::Down, KeyModifiers::NONE).await;
         key_and_flush(&mut harness.session, KeyCode::Right, KeyModifiers::NONE).await;
         key_and_flush(&mut harness.session, KeyCode::Down, KeyModifiers::NONE).await;
@@ -3411,7 +3431,12 @@ mod wasm_contracts {
         assert_eq!(harness.session.torrent_count(), initial_torrents);
         assert_eq!(harness.session.rss_downloaded_preview_count(), 0);
 
-        key_and_flush(&mut harness.session, KeyCode::Char('r'), KeyModifiers::NONE).await;
+        key_and_flush(
+            &mut harness.session,
+            KeyCode::Char('R'),
+            KeyModifiers::SHIFT,
+        )
+        .await;
         key_and_flush(&mut harness.session, KeyCode::Char('s'), KeyModifiers::NONE).await;
         assert!(matches!(
             harness.fulfill_pending().as_slice(),
@@ -3544,7 +3569,7 @@ mod wasm_contracts {
     #[wasm_bindgen_test(async)]
     async fn rss_search_and_navigation_use_the_production_reducer() {
         let mut session = rich_session();
-        key_and_flush(&mut session, KeyCode::Char('r'), KeyModifiers::NONE).await;
+        key_and_flush(&mut session, KeyCode::Char('R'), KeyModifiers::SHIFT).await;
         assert_eq!(session.screen(), BrowserScreen::Rss);
 
         key_and_flush(&mut session, KeyCode::Char('/'), KeyModifiers::NONE).await;


### PR DESCRIPTION
Help previously clipped long shortcuts and descriptions, making commands and runtime paths difficult to read. The menu now keeps section tabs across the top, puts dashboard shortcuts first, removes decorative brackets from key labels, and wraps content with scrolling that accounts for the rendered lines. Page Up/Down, Home/End, a scrollbar, and clearer search feedback make longer sections easier to navigate.

Dashboard shortcuts now use `C` for Config, `R` for RSS, and `Z` to enter or leave Zen mode. On-screen hints, documentation, and browser/Wasm contract inputs follow the new bindings; commands within other screens retain their existing keys.

Validation:
- Root and Wasm workspace formatting checks.
- Strict Clippy with all targets and all features.
- Native TUI test suite: 782 passed, one ignored, including shortcut routing, wrapped Unicode paths, paging, resizing, search recovery, and narrow layouts.
- Real-Wasm contracts: all 91 tests passed locally, including the updated help-rendering assertion.
- Bundled browser suite was not run locally; CI is rerunning it.

