### PR TITLE
fix(tui): keep the torrent list cursor on its row during sorting

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3010,10 +3010,6 @@ pub(crate) fn file_activity_wave_steps_per_second(speed_bps: u64) -> f64 {
 }
 
 pub(crate) fn sort_and_filter_torrent_list_state(app_state: &mut AppState) {
-    let selected_info_hash = app_state
-        .torrent_list_order
-        .get(app_state.ui.selected_torrent_index)
-        .cloned();
     let torrents_map = &app_state.torrents;
     let (sort_by, sort_direction) = app_state.torrent_sort;
     let search_query = &app_state.ui.search_query;
@@ -3107,15 +3103,7 @@ pub(crate) fn sort_and_filter_torrent_list_state(app_state: &mut AppState) {
     });
 
     app_state.torrent_list_order = torrent_list;
-    if let Some(selected_info_hash) = selected_info_hash {
-        if let Some(selected_index) = app_state
-            .torrent_list_order
-            .iter()
-            .position(|info_hash| info_hash == &selected_info_hash)
-        {
-            app_state.ui.selected_torrent_index = selected_index;
-        }
-    }
+    // Keep the cursor on its row as live metrics reorder torrents, including the top row.
     clamp_selected_indices_in_state(app_state);
 }
 

--- a/src/app/reducer.rs
+++ b/src/app/reducer.rs
@@ -121,35 +121,38 @@ mod tests {
     }
 
     #[test]
-    fn metrics_batch_sort_preserves_the_selected_torrent() {
-        let selected_hash = vec![0x31; 20];
-        let faster_hash = vec![0x32; 20];
-        let mut state = AppState {
-            torrent_sort: (TorrentSortColumn::Down, SortDirection::Descending),
-            torrent_list_order: vec![selected_hash.clone(), faster_hash.clone()],
-            ..AppState::default()
-        };
-        for (info_hash, torrent_name, download_speed_bps) in [
-            (selected_hash.clone(), "Fictional Quiet Kernel", 1_000),
-            (faster_hash.clone(), "Fictional Swift Kernel", 20_000),
-        ] {
-            reduce_app_action(
-                &mut state,
-                AppAction::ManagerMetrics(Box::new(TorrentMetrics {
-                    info_hash,
-                    torrent_name: torrent_name.to_string(),
-                    download_speed_bps,
-                    number_of_pieces_total: 10,
-                    number_of_pieces_completed: 5,
-                    ..TorrentMetrics::default()
-                })),
-            );
+    fn metrics_batch_sort_preserves_the_selected_row() {
+        for selected_index in [0, 1] {
+            let selected_hash = vec![0x31; 20];
+            let faster_hash = vec![0x32; 20];
+            let mut state = AppState {
+                torrent_sort: (TorrentSortColumn::Down, SortDirection::Descending),
+                torrent_list_order: vec![selected_hash.clone(), faster_hash.clone()],
+                ..AppState::default()
+            };
+            state.ui.selected_torrent_index = selected_index;
+            for (info_hash, torrent_name, download_speed_bps) in [
+                (selected_hash.clone(), "Fictional Quiet Kernel", 1_000),
+                (faster_hash.clone(), "Fictional Swift Kernel", 20_000),
+            ] {
+                reduce_app_action(
+                    &mut state,
+                    AppAction::ManagerMetrics(Box::new(TorrentMetrics {
+                        info_hash,
+                        torrent_name: torrent_name.to_string(),
+                        download_speed_bps,
+                        number_of_pieces_total: 10,
+                        number_of_pieces_completed: 5,
+                        ..TorrentMetrics::default()
+                    })),
+                );
+            }
+
+            finalize_manager_metrics_batch(&mut state, false);
+
+            assert_eq!(state.torrent_list_order, vec![faster_hash, selected_hash]);
+            assert_eq!(state.ui.selected_torrent_index, selected_index);
         }
-
-        finalize_manager_metrics_batch(&mut state, false);
-
-        assert_eq!(state.torrent_list_order, vec![faster_hash, selected_hash]);
-        assert_eq!(state.ui.selected_torrent_index, 1);
     }
 
     #[test]

--- a/web/tests/browser.spec.ts
+++ b/web/tests/browser.spec.ts
@@ -49,6 +49,26 @@ async function openScreen(page: Page, key: string, screen: string) {
   await expect(page.locator("#terminal")).toHaveAttribute("data-current-screen", screen);
 }
 
+async function keepSelectedTorrentInNameOrder(page: Page) {
+  const terminal = page.locator("#terminal");
+  const targetHash = await terminal.getAttribute("data-selected-torrent-hash");
+  expect(targetHash).toBeTruthy();
+  // These control tests start on the Name column. A fixed name order keeps
+  // pause/resume rate changes from replacing the torrent at the selected row.
+  await page.keyboard.press("s");
+  await expect(terminal).toHaveAttribute("data-torrent-sort-column", "name");
+  await expect(terminal).toHaveAttribute("data-torrent-sort-pinned", "true");
+  await page.keyboard.press("Home");
+  const torrentCount = Number(await terminal.getAttribute("data-torrent-count"));
+  for (let index = 0; index < torrentCount; index += 1) {
+    const selectedHash = await terminal.getAttribute("data-selected-torrent-hash");
+    if (selectedHash === targetHash) break;
+    await page.keyboard.press("ArrowDown");
+    await expect(terminal).not.toHaveAttribute("data-selected-torrent-hash", selectedHash ?? "");
+  }
+  await expect(terminal).toHaveAttribute("data-selected-torrent-hash", targetHash!);
+}
+
 test("every production screen renders through the bundled browser host", async ({ page }) => {
   const errors = collectErrors(page);
   for (const screen of PRODUCTION_SCREENS) {
@@ -302,6 +322,7 @@ test("scenario-created torrents retain shared pause resume and delete controls",
   await terminal.click();
   await expect(terminal).toHaveAttribute("data-torrent-count", "3");
 
+  await keepSelectedTorrentInNameOrder(page);
   await page.keyboard.press("p");
   await expect(terminal).toHaveAttribute("data-selected-torrent-paused", "true");
   await expect(terminal).toHaveAttribute("data-simulated-peers", "0");
@@ -1183,6 +1204,7 @@ test("paste pause resume and confirmed deletion preserve browser reducer state",
   const terminal = await expectReady(page);
   await terminal.click();
 
+  await keepSelectedTorrentInNameOrder(page);
   await page.keyboard.press("p");
   await expect(terminal).toHaveAttribute("data-selected-torrent-paused", "true");
   await page.keyboard.press("p");

--- a/web/wasm/src/browser_demo.rs
+++ b/web/wasm/src/browser_demo.rs
@@ -953,6 +953,29 @@ mod tests {
     use super::*;
     use wasm_bindgen_test::wasm_bindgen_test;
 
+    #[wasm_bindgen_test(async)]
+    async fn retained_browser_terminal_refresh_and_resize_are_self_contained() {
+        let mut demo = BrowserDemo::new(80, 24);
+
+        let initial = demo.render_frame();
+        assert!(initial.starts_with("\x1b[2J"));
+        assert!(!demo.render_frame().starts_with("\x1b[2J"));
+
+        demo.resize(96, 30).await;
+        assert_eq!(demo.columns(), 96);
+        assert_eq!(demo.rows(), 30);
+        assert!(demo.force_refresh().starts_with("\x1b[2J"));
+
+        let paused_hash = demo.selected_torrent_hash();
+        assert!(demo.dispatch_key("p".to_owned(), 0, 0).await);
+        demo.resize(96, 30).await;
+        // The selected row can now contain another torrent after sorting.
+        assert_eq!(
+            demo.session.torrent_control_state_hex(&paused_hash),
+            Some(BrowserTorrentControlState::Paused)
+        );
+    }
+
     #[wasm_bindgen_test]
     fn key_adapter_accepts_named_and_character_keys() {
         assert_eq!(key_code("Escape", KeyModifiers::NONE), Some(KeyCode::Esc));

--- a/web/wasm/src/lib.rs
+++ b/web/wasm/src/lib.rs
@@ -401,24 +401,6 @@ mod wasm_contracts {
             .collect()
     }
 
-    #[wasm_bindgen_test(async)]
-    async fn retained_browser_terminal_refresh_and_resize_are_self_contained() {
-        let mut demo = BrowserDemo::new(80, 24);
-
-        let initial = demo.render_frame();
-        assert!(initial.starts_with("\x1b[2J"));
-        assert!(!demo.render_frame().starts_with("\x1b[2J"));
-
-        demo.resize(96, 30).await;
-        assert_eq!(demo.columns(), 96);
-        assert_eq!(demo.rows(), 30);
-        assert!(demo.force_refresh().starts_with("\x1b[2J"));
-
-        assert!(demo.dispatch_key("p".to_owned(), 0, 0).await);
-        demo.resize(96, 30).await;
-        assert!(demo.selected_torrent_paused());
-    }
-
     #[wasm_bindgen_test]
     fn low_rate_visualizations_consume_the_full_elapsed_interval() {
         let mut single_interval = session();
@@ -2481,6 +2463,8 @@ mod wasm_contracts {
             0
         );
 
+        // Pausing changes the live sort order; resume the same torrent explicitly.
+        assert!(harness.session.select_torrent_hex(&hash));
         key_and_flush(&mut harness.session, KeyCode::Char('p'), KeyModifiers::NONE).await;
         harness.fulfill_pending();
         assert_eq!(
@@ -2585,6 +2569,8 @@ mod wasm_contracts {
         let lifetime_totals_before_delete = harness.session.lifetime_transfer_totals();
         assert!(session_totals_before_delete.0 > 0);
 
+        // Simulation updates can move the torrent away from the selected row.
+        assert!(harness.session.select_torrent_hex(MAGNET_HASH_HEX));
         key_and_flush(&mut harness.session, KeyCode::Char('d'), KeyModifiers::NONE).await;
         harness
             .session


### PR DESCRIPTION
Live torrent sorting moved the cursor away from the top row because it followed the previously selected torrent by hash. Restore the row-based selection behavior from `main`: when speeds reorder torrents, the selected row stays in place. Existing bounds clamping still handles shorter and empty lists.

Update the metrics-batch regression test to cover selection at both row 0 and row 1. The test reproduced the bug before the fix (expected row 0, got row 1), and the repaired sorting function matches `main` apart from its explanatory comment.

Align the browser control tests with row-based selection: capture the paused torrent by hash for resize checks, reselect targets before resume/delete, and use a stable name order for bundled pause/resume checks.

Validation:

- Full library suite: 2,209 passed, 2 ignored (`cargo test --locked --lib`, with application debug symbols and incremental compilation disabled).
- `cargo fmt --all --check` and `git diff --check`.
- Strict Clippy across all targets with all features and with no default features (`--locked -- -D warnings`, debug symbols and incremental compilation disabled).
- Real-WASM contracts: all 91 passed (`cargo test --manifest-path web/wasm/Cargo.toml --target wasm32-unknown-unknown --locked`, debug symbols and incremental compilation disabled).
- Strict WASM Clippy across all targets and WASM workspace formatting passed.
- `npm run build`: WASM release build, TypeScript, site bundle, and asset-size checks passed.
- Chromium: all 3 targeted scenario and dynamic torrent pause/resume/delete tests passed.

No packaged native-app smoke test was performed locally.
