### PR TITLE
feat(tui): frame live traffic bursts and chart peer history

### DIFF
--- a/docs/auto-graph-policy.md
+++ b/docs/auto-graph-policy.md
@@ -1,0 +1,108 @@
+# AUTO graph: live burst detection
+
+AUTO follows meaningful rises in combined download and upload throughput. It
+keeps related spikes together within a rolling ten-minute maximum. It no longer
+scores the shape of saved history to choose a range.
+
+## Detection and display policy
+
+`src/telemetry/auto_graph.rs` consumes live one-second samples and maintains a
+constant-size detector and optional burst period:
+
+1. Calibrate from the first three live samples. Steady traffic already present
+   at startup becomes the reference; it does not manufacture a new burst.
+2. Use a three-sample median to reject isolated high/zero samples, then an EWMA
+   with weight 0.35 to detect a sustained rise.
+3. The entry margin is the largest of 50% of the reference rate, four times the
+   smoothed absolute deviation, and 4 KiB/s. Both the median and EWMA must exceed
+   the reference plus this margin to start a burst.
+4. Continue the burst while the median exceeds the reference plus half the
+   entry margin. This lower continuation threshold prevents repeated entry and
+   exit near one boundary. Freeze the reference throughout the burst and its
+   cooldown, so a larger peak cannot erase smaller subsequent spikes.
+5. Outside a burst, learn the reference and clipped absolute deviation with
+   weight 0.02, only from samples below the continuation threshold. This avoids
+   absorbing a candidate rise into the reference before detection.
+6. Remember the burst's start and last active sample. Nearby spikes extend the
+   same period across quiet gaps of up to two minutes. Median-filter latency
+   adds roughly one second to the observed end of a burst.
+7. Frame the detected span with about 20% space for context: 1m up to 48 seconds,
+   5m up to 240 seconds, then 10m. The range only widens on active samples and
+   never shrinks within the same period. A longer burst stays at a rolling 10m.
+8. After the cooldown, return to 1m. Expiring history, restored data, or old peaks
+   cannot create a new burst because none of them are detector inputs.
+
+The existing display controller reevaluates every five seconds and widens at
+most one marker per twenty seconds. It can shrink directly to the live default
+on its next evaluation. Detector updates continue while a manual range is
+selected, so returning to AUTO can frame an already detected burst. Manual
+ranges through 1y remain available.
+
+Duplicate timestamps are ignored by the detector. Clock rollback or a sampling
+interruption longer than two minutes starts fresh calibration. Shorter sampling
+gaps retain the last three real observations. Signal and baseline smoothing use
+elapsed-time weights (`1 - (1 - alpha)^seconds`) so repeated delayed ticks still
+detect sustained rises. The median still needs real samples; missing seconds
+are not filled with copies of the next observation.
+The normal native and browser second-tick paths share this implementation.
+
+## Why EWMA
+
+[EWMA](https://www.itl.nist.gov/div898/handbook/pmc/section3/pmc324.htm) and
+[CUSUM](https://www.itl.nist.gov/div898/handbook/pmc/section3/pmc323.htm) are
+established tools for detecting shifts in a process. Here they are engineering
+building blocks, not a claim of textbook statistical guarantees for correlated
+network traffic. The median filter, adaptive reference, margins, grouping, and
+display rules above are explicit application policy.
+
+Reproduce the fixed-step detector comparison with:
+
+```sh
+python3 scripts/compare_auto_graph_detectors.py
+```
+
+Each detector sees the same 1,080 synthetic traces: ten random seeds, three rate
+scales (0.1, 5, and 50 MB/s), 0/10/20% uniform jitter, four burst patterns with
+1.6x–20x heights, and 30/90/150-second quiet gaps. Traces also contain isolated
+high and zero outliers. There are 2,430 labeled sixty-second bursts per detector.
+
+Both candidates share filtering, reference learning, grouping, and framing. The
+reference CUSUM uses `max(0, sum + normalized_rise - 0.5)` with decision threshold
+4; EWMA uses the entry rule above. This is a comparison of these two parameter
+settings, not an exhaustive search for their best possible tuning.
+
+| Metric | EWMA | CUSUM |
+| --- | ---: | ---: |
+| Detected labeled bursts | 2,430 / 2,430 | 2,430 / 2,430 |
+| Median detection delay | 1s | 1s |
+| 95th-percentile delay | 5s | 6s |
+| Maximum delay | 13s | 12s |
+| False active seconds outside transitions | 0 | 0 |
+| Total target-range changes | 3,324 | 3,330 |
+| Current-group burst sample coverage | 99.998% | 99.998% |
+
+Delay is measured from the start of each labeled burst to its first active
+detection, including continued activity in an existing group. False-activity
+counts exclude a three-second allowance after a labeled burst for filtering.
+Coverage is the fraction of the current group's burst samples from the last ten
+minutes contained in the target window, measured during labeled bursts. Total
+range changes include expected widening and cooldown resets. These target-window
+metrics exclude the display controller's five-second evaluation and twenty-second
+widening delay; Rust integration tests cover the actual display transitions.
+
+EWMA was selected for its slightly better typical delay and simpler detector
+state. These results cover the generated step/spike traces, not every possible
+traffic distribution, gradual ramp, or a captured live session.
+
+## Regression checks
+
+```sh
+cargo test --locked --offline --lib telemetry::
+cargo test --locked --offline --lib reducer_graph_actions_include_auto_before_fixed_windows
+```
+
+The Rust tests exercise actual production state and tick paths, including late
+history restore, upload-only spikes, manual ranges, cooldown, startup, clock
+changes, and sampling gaps. Property tests vary rates, heights, gap lengths,
+timing, and noise and require preserved burst grouping, a ten-minute ceiling,
+monotonic framing within a period, and a stable return to 1m afterward.

--- a/scripts/compare_auto_graph_detectors.py
+++ b/scripts/compare_auto_graph_detectors.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 The superseedr Contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Reproduce the AUTO detector selection experiment using only the standard library.
+
+This is a fixed-step reference experiment, not the production implementation.
+Both candidates share median filtering, baseline learning, burst grouping, and
+framing; only the entry detector differs. Production timestamp handling, UI
+switching delays, and history restoration are covered by the Rust tests.
+See docs/auto-graph-policy.md for assumptions and metric definitions.
+"""
+
+import random
+import statistics
+
+
+class Activity:
+    def __init__(self, kind):
+        self.kind = kind
+        self.recent = []
+        self.base = self.fast = self.deviation = self.cusum = 0.0
+        self.start = self.last_active = None
+        self.mode = 60
+
+    def observe(self, t, raw):
+        warming_up = len(self.recent) < 3
+        self.recent = (self.recent + [raw])[-3:]
+        value = statistics.median(self.recent)
+        if warming_up:
+            self.base = self.fast = value
+            return False
+        self.fast += 0.35 * (value - self.fast)
+        margin = max(self.base * 0.5, self.deviation * 4, 4096)
+        self.cusum = max(0, self.cusum + (value - self.base) / margin - 0.5)
+        detected = (self.fast > self.base + margin if self.kind == 'EWMA'
+                    else self.cusum >= 4)
+        if self.start is None and detected and value > self.base + margin:
+            self.start = t
+        active = self.start is not None and value > self.base + margin * 0.5
+        if active:
+            self.last_active = t
+            span = t - self.start + 1
+            self.mode = max(self.mode, 60 if span <= 48 else 300 if span <= 240 else 600)
+        elif self.start is not None and t - self.last_active > 120:
+            self.start = self.last_active = None
+            self.mode = 60
+            self.fast = value
+            self.cusum = 0
+        if self.start is None and value <= self.base + margin * 0.5:
+            error = value - self.base
+            self.base += 0.02 * error
+            self.deviation += 0.02 * (min(abs(error), margin) - self.deviation)
+        return active
+
+
+def run(kind, seed, scale, jitter, amplitudes, gaps):
+    rng = random.Random(seed)
+    intervals = []
+    start = 600
+    for amp, gap in zip(amplitudes, gaps):
+        intervals.append((start, start + 60, amp))
+        start += 60 + gap
+    detector = Activity(kind)
+    delays = [None] * len(intervals)
+    false = flips = 0
+    previous_mode = 60
+    covered = total = 0
+    active_samples = []
+    for t in range(start + 800):
+        interval = next((i for i, (a, b, _) in enumerate(intervals) if a <= t < b), None)
+        amp = intervals[interval][2] if interval is not None else 1
+        value = scale * amp * (1 + rng.uniform(-jitter, jitter))
+        # Single-sample upward and downward outliers outside the burst periods.
+        if t == 150:
+            value = scale * 100
+        if t == 300:
+            value = 0
+        active = detector.observe(t, value)
+        if interval is not None:
+            if t == intervals[interval][0] and (interval == 0 or intervals[interval][0] - intervals[interval-1][1] >= 120):
+                active_samples.clear()
+            active_samples.append(t)
+            if active and delays[interval] is None:
+                delays[interval] = t - intervals[interval][0]
+            visible = [s for s in active_samples if s > t - 600]
+            total += len(visible)
+            covered += sum(s > t - detector.mode for s in visible)
+        elif active and all(t >= b + 3 or t < a for a, b, _ in intervals):
+            false += 1
+        if detector.mode != previous_mode:
+            flips += 1
+            previous_mode = detector.mode
+    return delays, false, flips, covered, total
+
+
+def main():
+    for kind in ['EWMA', 'CUSUM']:
+        delays = []
+        missed = false = flips = covered = total = traces = 0
+        for seed in range(10):
+            for scale in [100_000, 5_000_000, 50_000_000]:
+                for jitter in [0, 0.1, 0.2]:
+                    for amplitudes in [[2], [20], [20, 4, 8, 2], [1.6, 2, 1.6]]:
+                        for gap in [30, 90, 150]:
+                            result, f, sw, cov, count = run(kind, seed, scale, jitter,
+                                                            amplitudes, [gap] * len(amplitudes))
+                            delays.extend(d for d in result if d is not None)
+                            missed += sum(d is None for d in result)
+                            false += f
+                            flips += sw
+                            covered += cov
+                            total += count
+                            traces += 1
+        delays.sort()
+        print(dict(detector=kind, traces=traces, detected=len(delays), missed=missed,
+                   median_delay=statistics.median(delays), p95_delay=delays[int(len(delays)*.95)],
+                   max_delay=max(delays), false_active_seconds=false,
+                   range_changes=flips, burst_sample_coverage=covered/total), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -512,6 +512,7 @@ impl Default for AutoGraphWindowState {
 pub enum ChartPanelView {
     #[default]
     Network,
+    Peers,
     Cpu,
     Ram,
     Disk,
@@ -524,6 +525,7 @@ impl ChartPanelView {
     pub fn to_string(self) -> &'static str {
         match self {
             Self::Network => "NET",
+            Self::Peers => "PEERS",
             Self::Cpu => "CPU",
             Self::Ram => "RAM",
             Self::Disk => "DISK",
@@ -535,7 +537,8 @@ impl ChartPanelView {
 
     pub fn next(self) -> Self {
         match self {
-            Self::Network => Self::Cpu,
+            Self::Network => Self::Peers,
+            Self::Peers => Self::Cpu,
             Self::Cpu => Self::Ram,
             Self::Ram => Self::Disk,
             Self::Disk => Self::Tuning,
@@ -548,7 +551,8 @@ impl ChartPanelView {
     pub fn prev(self) -> Self {
         match self {
             Self::Network => Self::Network,
-            Self::Cpu => Self::Network,
+            Self::Peers => Self::Network,
+            Self::Cpu => Self::Peers,
             Self::Ram => Self::Cpu,
             Self::Disk => Self::Ram,
             Self::Tuning => Self::Disk,
@@ -2333,6 +2337,7 @@ pub struct AppState {
     pub chart_panel_view: ChartPanelView,
     pub graph_mode: GraphDisplayMode,
     pub auto_graph_window: AutoGraphWindowState,
+    pub(crate) auto_graph_activity: crate::telemetry::auto_graph::AutoGraphActivity,
     pub minute_avg_dl_history: Vec<u64>,
     pub minute_avg_ul_history: Vec<u64>,
     pub network_history_state: NetworkHistoryPersistedState,

--- a/src/persistence/activity_history.rs
+++ b/src/persistence/activity_history.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::io::{self, Cursor, Read};
 
-pub const ACTIVITY_HISTORY_SCHEMA_VERSION: u32 = 1;
+pub const ACTIVITY_HISTORY_SCHEMA_VERSION: u32 = 2;
+// Connected peer counts use thousandths to preserve fractional rollup averages.
+pub const PEER_COUNT_SCALE: u64 = 1_000;
 pub(super) const ACTIVITY_HISTORY_FILE_NAME: &str = "activity_history.bin";
 const ACTIVITY_HISTORY_MAGIC: &[u8; 8] = b"SSAHBIN1";
 const MAX_ACTIVITY_HISTORY_TORRENTS: usize = 100_000;
@@ -62,6 +64,7 @@ pub struct ActivityHistoryPersistedState {
     pub ram: ActivityHistorySeries,
     pub disk: ActivityHistorySeries,
     pub tuning: ActivityHistorySeries,
+    pub peers: ActivityHistorySeries,
     pub torrents: HashMap<String, ActivityHistorySeries>,
 }
 
@@ -74,6 +77,7 @@ impl Default for ActivityHistoryPersistedState {
             ram: ActivityHistorySeries::default(),
             disk: ActivityHistorySeries::default(),
             tuning: ActivityHistorySeries::default(),
+            peers: ActivityHistorySeries::default(),
             torrents: HashMap::new(),
         }
     }
@@ -199,6 +203,7 @@ pub struct ActivityHistoryRollupState {
     pub ram: ActivityHistorySeriesRollupState,
     pub disk: ActivityHistorySeriesRollupState,
     pub tuning: ActivityHistorySeriesRollupState,
+    pub peers: ActivityHistorySeriesRollupState,
     pub torrents: HashMap<String, ActivityHistorySeriesRollupState>,
 }
 
@@ -219,6 +224,7 @@ impl ActivityHistoryRollupState {
             ram: ActivityHistorySeriesRollupState::from_snapshot(&state.ram.rollups),
             disk: ActivityHistorySeriesRollupState::from_snapshot(&state.disk.rollups),
             tuning: ActivityHistorySeriesRollupState::from_snapshot(&state.tuning.rollups),
+            peers: ActivityHistorySeriesRollupState::from_snapshot(&state.peers.rollups),
             torrents,
         }
     }
@@ -228,6 +234,7 @@ impl ActivityHistoryRollupState {
         state.ram.rollups = self.ram.to_snapshot();
         state.disk.rollups = self.disk.to_snapshot();
         state.tuning.rollups = self.tuning.to_snapshot();
+        state.peers.rollups = self.peers.to_snapshot();
         for (info_hash, rollups) in &self.torrents {
             if let Some(series) = state.torrents.get_mut(info_hash) {
                 series.rollups = rollups.to_snapshot();
@@ -262,6 +269,7 @@ pub fn enforce_retention_caps(state: &mut ActivityHistoryPersistedState) {
     cap_series(&mut state.ram);
     cap_series(&mut state.disk);
     cap_series(&mut state.tuning);
+    cap_series(&mut state.peers);
     for series in state.torrents.values_mut() {
         cap_series(series);
     }
@@ -317,6 +325,7 @@ fn sparse_state_for_persistence(
         ram: sparse_series_for_persistence(&state.ram),
         disk: sparse_series_for_persistence(&state.disk),
         tuning: sparse_series_for_persistence(&state.tuning),
+        peers: sparse_series_for_persistence(&state.peers),
         torrents: HashMap::new(),
     };
 
@@ -479,7 +488,7 @@ pub(super) fn encode_activity_history_state(state: &ActivityHistoryPersistedStat
 
     let mut buf = Vec::new();
     buf.extend_from_slice(ACTIVITY_HISTORY_MAGIC);
-    encode_u32(&mut buf, state.schema_version);
+    encode_u32(&mut buf, ACTIVITY_HISTORY_SCHEMA_VERSION);
     encode_u64(&mut buf, state.updated_at_unix);
     encode_series(&mut buf, &state.cpu);
     encode_series(&mut buf, &state.ram);
@@ -490,6 +499,7 @@ pub(super) fn encode_activity_history_state(state: &ActivityHistoryPersistedStat
         encode_string(&mut buf, info_hash);
         encode_series(&mut buf, series);
     }
+    encode_series(&mut buf, &state.peers);
     buf
 }
 
@@ -507,7 +517,7 @@ pub(super) fn decode_activity_history_state(
     }
 
     let schema_version = decode_u32(&mut cursor)?;
-    if schema_version != ACTIVITY_HISTORY_SCHEMA_VERSION {
+    if schema_version != 1 && schema_version != ACTIVITY_HISTORY_SCHEMA_VERSION {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("unsupported activity history schema version {schema_version}"),
@@ -533,6 +543,12 @@ pub(super) fn decode_activity_history_state(
         torrents.insert(info_hash, series);
     }
 
+    let peers = if schema_version >= 2 {
+        decode_series(&mut cursor)?
+    } else {
+        ActivityHistorySeries::default()
+    };
+
     if cursor.position() != bytes.len() as u64 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -541,12 +557,13 @@ pub(super) fn decode_activity_history_state(
     }
 
     Ok(ActivityHistoryPersistedState {
-        schema_version,
+        schema_version: ACTIVITY_HISTORY_SCHEMA_VERSION,
         updated_at_unix,
         cpu,
         ram,
         disk,
         tuning,
+        peers,
         torrents,
     })
 }
@@ -585,6 +602,15 @@ mod tests {
             primary: 250,
             secondary: 0,
         });
+        let mut peer_rollups = ActivityHistorySeriesRollupState::default();
+        for second in 1..=61 {
+            peer_rollups.ingest_second_sample(
+                &mut state.peers,
+                second,
+                if second <= 30 { PEER_COUNT_SCALE } else { 0 },
+                0,
+            );
+        }
         state.torrents.insert(
             "abcd".to_string(),
             ActivityHistorySeries {
@@ -606,6 +632,44 @@ mod tests {
         assert_eq!(loaded.updated_at_unix, state.updated_at_unix);
         assert_eq!(loaded.cpu.tiers.second_1s, state.cpu.tiers.second_1s);
         assert_eq!(loaded.torrents.get("abcd"), state.torrents.get("abcd"));
+        assert_eq!(loaded.peers, sparse_series_for_persistence(&state.peers));
+        assert_eq!(
+            loaded.peers.tiers.minute_1m[0].primary,
+            PEER_COUNT_SCALE / 2
+        );
+    }
+
+    #[test]
+    fn version_one_history_loads_without_losing_existing_series() {
+        let mut series = ActivityHistorySeries::default();
+        series.tiers.second_1s.push(ActivityHistoryPoint {
+            ts_unix: 100,
+            primary: 250,
+            secondary: 20,
+        });
+        // The original layout ended after the torrent map, with no peer series.
+        let mut bytes = ACTIVITY_HISTORY_MAGIC.to_vec();
+        encode_u32(&mut bytes, 1);
+        encode_u64(&mut bytes, 100);
+        for _ in 0..4 {
+            encode_series(&mut bytes, &series);
+        }
+        encode_u32(&mut bytes, 1);
+        encode_string(&mut bytes, "abcd");
+        encode_series(&mut bytes, &series);
+
+        let loaded = decode_activity_history_state(&bytes).unwrap();
+        assert_eq!(loaded.schema_version, ACTIVITY_HISTORY_SCHEMA_VERSION);
+        assert_eq!(loaded.cpu, series);
+        assert_eq!(loaded.ram, series);
+        assert_eq!(loaded.disk, series);
+        assert_eq!(loaded.tuning, series);
+        assert_eq!(loaded.torrents["abcd"], series);
+        assert_eq!(loaded.peers, ActivityHistorySeries::default());
+        assert_eq!(
+            decode_activity_history_state(&encode_activity_history_state(&loaded)).unwrap(),
+            loaded
+        );
     }
 
     #[test]

--- a/src/telemetry/activity_history_telemetry.rs
+++ b/src/telemetry/activity_history_telemetry.rs
@@ -5,7 +5,7 @@ use crate::app::AppState;
 use crate::persistence::activity_history::{
     enforce_retention_caps, retain_only_torrent_series_for_keys, ActivityHistoryPersistedState,
     ActivityHistoryPoint, ActivityHistorySeries, ActivityHistorySeriesRollupState,
-    ActivityHistoryTiers,
+    ActivityHistoryTiers, PEER_COUNT_SCALE,
 };
 use crate::persistence::network_history::{
     HOUR_1H_CAP, MINUTE_15M_CAP, MINUTE_1M_CAP, SECOND_1S_CAP,
@@ -47,7 +47,18 @@ impl ActivityHistoryTelemetry {
         let tuning_current = app_state.current_tuning_score;
         let tuning_best = app_state.last_tuning_score;
 
-        let mut changed = false;
+        let connected_peers = app_state.torrents.values().fold(0_u64, |total, torrent| {
+            total.saturating_add(torrent.latest_state.number_of_successfully_connected_peers as u64)
+        });
+        let mut changed = app_state
+            .activity_history_rollups
+            .peers
+            .ingest_second_sample(
+                &mut app_state.activity_history_state.peers,
+                now_unix,
+                connected_peers.saturating_mul(PEER_COUNT_SCALE),
+                0,
+            );
         changed |= app_state.activity_history_rollups.cpu.ingest_second_sample(
             &mut app_state.activity_history_state.cpu,
             now_unix,
@@ -171,6 +182,7 @@ fn merge_state_for_late_restore(
     replay_live_seconds_into_loaded(&live_state.ram, &mut merged.ram);
     replay_live_seconds_into_loaded(&live_state.disk, &mut merged.disk);
     replay_live_seconds_into_loaded(&live_state.tuning, &mut merged.tuning);
+    replay_live_seconds_into_loaded(&live_state.peers, &mut merged.peers);
 
     let mut all_torrents: HashSet<String> = merged.torrents.keys().cloned().collect();
     all_torrents.extend(live_state.torrents.keys().cloned());
@@ -236,6 +248,7 @@ fn densify_state_for_restore(
         ram: densify_series_for_restore(&state.ram, now_unix),
         disk: densify_series_for_restore(&state.disk, now_unix),
         tuning: densify_series_for_restore(&state.tuning, now_unix),
+        peers: densify_series_for_restore(&state.peers, now_unix),
         torrents: state
             .torrents
             .iter()
@@ -262,6 +275,60 @@ mod tests {
         ActivityHistoryPersistedState, ActivityHistoryPoint, ActivityHistoryRollupSnapshot,
         ActivityHistorySeries, ActivityHistoryTiers, PersistedRollupAccumulator,
     };
+
+    #[test]
+    fn peers_count_all_torrents_and_record_disconnects() {
+        let mut state = AppState::default();
+        for (id, peers) in [(1, 3), (2, 2)] {
+            let mut torrent = TorrentDisplayState::default();
+            torrent.latest_state.number_of_successfully_connected_peers = peers;
+            state.torrents.insert(vec![id; 20], torrent);
+        }
+        // A filtered torrent list must not change the global chart count.
+        state.torrent_list_order = vec![vec![1; 20]];
+        ActivityHistoryTelemetry::on_second_tick_at(&mut state, 100);
+        assert_eq!(
+            state.activity_history_state.peers.tiers.second_1s[0].primary,
+            5_000
+        );
+        state.torrents.clear();
+        ActivityHistoryTelemetry::on_second_tick_at(&mut state, 101);
+        assert_eq!(
+            state.activity_history_state.peers.tiers.second_1s[1].primary,
+            0
+        );
+        assert!(state.activity_history_dirty);
+    }
+
+    #[test]
+    fn peer_restore_replays_live_counts_and_fills_quiet_gaps() {
+        let mut state = AppState::default();
+        state.activity_history_rollups.peers.ingest_second_sample(
+            &mut state.activity_history_state.peers,
+            102,
+            3_000,
+            0,
+        );
+        let mut loaded = ActivityHistoryPersistedState::default();
+        loaded.peers.tiers.second_1s.push(ActivityHistoryPoint {
+            ts_unix: 100,
+            primary: 2_000,
+            secondary: 0,
+        });
+        ActivityHistoryTelemetry::apply_loaded_state_at(&mut state, loaded, 103);
+        let points = &state.activity_history_state.peers.tiers.second_1s;
+        assert_eq!(
+            points
+                .iter()
+                .map(|p| (p.ts_unix, p.primary))
+                .collect::<Vec<_>>(),
+            vec![(100, 2_000), (101, 0), (102, 3_000), (103, 0)]
+        );
+        assert_eq!(
+            state.activity_history_rollups.peers.to_snapshot(),
+            state.activity_history_state.peers.rollups
+        );
+    }
 
     fn partial_accumulator(
         count: u32,

--- a/src/telemetry/auto_graph.rs
+++ b/src/telemetry/auto_graph.rs
@@ -1,0 +1,404 @@
+// SPDX-FileCopyrightText: 2026 The superseedr Contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::app::GraphDisplayMode;
+
+const SIGNAL_ALPHA: f64 = 0.35;
+const BASELINE_ALPHA: f64 = 0.02;
+const MINIMUM_RISE_BPS: f64 = 4_096.0;
+const BURST_COOLDOWN_SECS: u64 = 120;
+
+fn elapsed_alpha(alpha: f64, elapsed_secs: u64) -> f64 {
+    if elapsed_secs == 1 {
+        alpha
+    } else {
+        1.0 - (1.0 - alpha).powf(elapsed_secs as f64)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct BurstPeriod {
+    started_unix: u64,
+    last_active_unix: u64,
+    mode: GraphDisplayMode,
+}
+
+/// Live-only burst detection and framing. Persisted history is deliberately not
+/// an input: expiring a history bucket cannot start, extend, or erase a burst.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub(crate) struct AutoGraphActivity {
+    last_sample_unix: Option<u64>,
+    recent_rates: [f64; 3],
+    samples_seen: u8,
+    baseline_bps: f64,
+    smoothed_bps: f64,
+    deviation_bps: f64,
+    burst: Option<BurstPeriod>,
+}
+
+impl AutoGraphActivity {
+    pub(crate) fn mode(&self) -> GraphDisplayMode {
+        self.burst
+            .map(|burst| burst.mode)
+            .unwrap_or(GraphDisplayMode::OneMinute)
+    }
+
+    pub(crate) fn observe(&mut self, now_unix: u64, rate_bps: u64) {
+        let rate = rate_bps as f64;
+        let mut elapsed_secs = 1;
+        if let Some(previous) = self.last_sample_unix {
+            if now_unix == previous {
+                return;
+            }
+            if now_unix < previous || now_unix - previous > BURST_COOLDOWN_SECS {
+                // A clock rollback or a long sampling interruption needs a new
+                // baseline, rather than invented activity across missing time.
+                *self = Self::default();
+            } else {
+                // Keep real observations when ticks are delayed. Resetting on
+                // every missed second prevents a slower stream detecting rises.
+                elapsed_secs = now_unix - previous;
+            }
+        }
+        self.last_sample_unix = Some(now_unix);
+        self.recent_rates.rotate_left(1);
+        self.recent_rates[2] = rate;
+        let warming_up = self.samples_seen < 3;
+        self.samples_seen = (self.samples_seen + 1).min(3);
+
+        if self.samples_seen < 3 {
+            self.baseline_bps = if self.samples_seen == 1 {
+                rate
+            } else {
+                (self.recent_rates[1] + rate) / 2.0
+            };
+            self.smoothed_bps = self.baseline_bps;
+            return;
+        }
+
+        // A single zero or high sample must not redefine the signal or baseline.
+        let mut sorted = self.recent_rates;
+        sorted.sort_by(f64::total_cmp);
+        let filtered = sorted[1];
+        if warming_up {
+            self.baseline_bps = filtered;
+            self.smoothed_bps = filtered;
+            return;
+        }
+        self.smoothed_bps +=
+            elapsed_alpha(SIGNAL_ALPHA, elapsed_secs) * (filtered - self.smoothed_bps);
+        let margin = (self.baseline_bps * 0.5)
+            .max(self.deviation_bps * 4.0)
+            .max(MINIMUM_RISE_BPS);
+        let enter_threshold = self.baseline_bps + margin;
+        let continue_threshold = self.baseline_bps + margin * 0.5;
+
+        if self.burst.is_none() && self.smoothed_bps > enter_threshold && filtered > enter_threshold
+        {
+            self.burst = Some(BurstPeriod {
+                started_unix: now_unix,
+                last_active_unix: now_unix,
+                mode: GraphDisplayMode::OneMinute,
+            });
+        }
+
+        if let Some(burst) = self.burst.as_mut() {
+            if filtered > continue_threshold {
+                burst.last_active_unix = now_unix;
+                let span = now_unix.saturating_sub(burst.started_unix);
+                // Leave about 20% for context, with a rolling 10m ceiling for
+                // long bursts. Quiet time alone never widens the chart.
+                let target = if span < 48 {
+                    GraphDisplayMode::OneMinute
+                } else if span < 240 {
+                    GraphDisplayMode::FiveMinutes
+                } else {
+                    GraphDisplayMode::TenMinutes
+                };
+                if target.as_seconds() > burst.mode.as_seconds() {
+                    burst.mode = target;
+                }
+            } else if now_unix.saturating_sub(burst.last_active_unix) > BURST_COOLDOWN_SECS {
+                self.burst = None;
+                self.smoothed_bps = filtered;
+            }
+        }
+
+        // Freeze the reference during a burst, its cooldown, and a candidate
+        // rise. Otherwise learning can absorb a moderate spike before detection,
+        // or let a large spike hide the smaller spikes that follow it.
+        if self.burst.is_none() && filtered <= continue_threshold {
+            let error = filtered - self.baseline_bps;
+            let alpha = elapsed_alpha(BASELINE_ALPHA, elapsed_secs);
+            self.baseline_bps += alpha * error;
+            self.deviation_bps += alpha * (error.abs().min(margin) - self.deviation_bps);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    const BASELINE: u64 = 5_000_000;
+
+    fn run(end: u64, rate: impl Fn(u64) -> u64) -> Vec<GraphDisplayMode> {
+        let mut activity = AutoGraphActivity::default();
+        (0..=end)
+            .map(|second| {
+                activity.observe(second, rate(second));
+                activity.mode()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn smoothing_weights_follow_elapsed_time() {
+        for alpha in [SIGNAL_ALPHA, BASELINE_ALPHA] {
+            let mut repeated = 0.0;
+            for _ in 0..3 {
+                repeated += alpha * (100.0 - repeated);
+            }
+            assert!((elapsed_alpha(alpha, 3) * 100.0 - repeated).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn delayed_samples_frame_grouped_spikes_and_reset_by_wall_time() {
+        for cadence in [&[1][..], &[2], &[3], &[1, 3, 2, 5]] {
+            let mut activity = AutoGraphActivity::default();
+            let mut t = 0;
+            let mut index = 0;
+            while t <= 1_200 {
+                let active = (600..720).contains(&t) || (780..900).contains(&t);
+                activity.observe(t, if active { 100_000_000 } else { BASELINE });
+                if (680..720).contains(&t) {
+                    assert_eq!(
+                        activity.mode(),
+                        GraphDisplayMode::FiveMinutes,
+                        "{cadence:?} at {t}"
+                    );
+                }
+                if (870..1_010).contains(&t) {
+                    assert_eq!(
+                        activity.mode(),
+                        GraphDisplayMode::TenMinutes,
+                        "{cadence:?} at {t}"
+                    );
+                }
+                if t >= 1_040 {
+                    assert!(activity.burst.is_none(), "{cadence:?} at {t}");
+                }
+                t += cadence[index % cadence.len()];
+                index += 1;
+            }
+        }
+    }
+
+    #[test]
+    fn delayed_samples_still_reject_isolated_outliers() {
+        for step in [2, 3] {
+            for outlier in [0, u64::MAX] {
+                let mut activity = AutoGraphActivity::default();
+                for sample in 0..600 {
+                    activity.observe(
+                        sample * step,
+                        if sample == 300 { outlier } else { BASELINE },
+                    );
+                    assert!(activity.burst.is_none());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn frames_a_two_minute_rise_and_stays_reset_after_it_ends() {
+        let modes = run(2_000, |t| {
+            if (600..720).contains(&t) {
+                100_000_000
+            } else {
+                BASELINE
+            }
+        });
+        assert!(modes[..600]
+            .iter()
+            .all(|m| *m == GraphDisplayMode::OneMinute));
+        assert_eq!(modes[719], GraphDisplayMode::FiveMinutes);
+        assert_eq!(modes[800], GraphDisplayMode::FiveMinutes);
+        assert!(modes[850..]
+            .iter()
+            .all(|m| *m == GraphDisplayMode::OneMinute));
+    }
+
+    #[test]
+    fn groups_different_height_spikes_across_two_minute_quiet_gaps() {
+        let modes = run(1_300, |t| match t {
+            600..630 => 100_000_000,
+            750..780 => 20_000_000,
+            900..930 => 40_000_000,
+            1050..1080 => 10_000_000,
+            _ => BASELINE,
+        });
+        assert_eq!(modes[779], GraphDisplayMode::FiveMinutes);
+        assert_eq!(modes[929], GraphDisplayMode::TenMinutes);
+        assert!(modes[929..1_200]
+            .iter()
+            .all(|m| *m == GraphDisplayMode::TenMinutes));
+        assert_eq!(modes[1_210], GraphDisplayMode::OneMinute);
+    }
+
+    #[test]
+    fn long_quiet_gaps_start_a_new_period() {
+        let modes = run(1_400, |t| match t {
+            600..900 | 1100..1120 => 100_000_000,
+            _ => BASELINE,
+        });
+        assert_eq!(modes[899], GraphDisplayMode::TenMinutes);
+        assert_eq!(modes[1_030], GraphDisplayMode::OneMinute);
+        assert!(modes[1_030..]
+            .iter()
+            .all(|m| *m == GraphDisplayMode::OneMinute));
+    }
+
+    #[test]
+    fn quiet_time_does_not_widen_a_short_burst() {
+        let modes = run(900, |t| {
+            if (600..620).contains(&t) {
+                100_000_000
+            } else {
+                BASELINE
+            }
+        });
+        assert!(modes.iter().all(|m| *m == GraphDisplayMode::OneMinute));
+    }
+
+    #[test]
+    fn a_permanent_rise_holds_ten_minutes_without_relearning_the_burst() {
+        let modes = run(10_000, |t| if t >= 600 { 100_000_000 } else { BASELINE });
+        assert!(modes[850..]
+            .iter()
+            .all(|m| *m == GraphDisplayMode::TenMinutes));
+    }
+
+    #[test]
+    fn ignores_isolated_zero_and_high_samples() {
+        let clean = run(1_000, |t| if t >= 600 { 15_000_000 } else { BASELINE });
+        for outlier in [0, u64::MAX] {
+            let noisy = run(1_000, |t| match t {
+                300 => outlier,
+                600.. => 15_000_000,
+                _ => BASELINE,
+            });
+            assert_eq!(clean, noisy);
+        }
+    }
+
+    #[test]
+    fn startup_uses_a_complete_median_before_detecting_changes() {
+        for position in 0..3 {
+            for outlier in [0, u64::MAX] {
+                let modes = run(600, |t| if t == position { outlier } else { BASELINE });
+                assert!(modes
+                    .iter()
+                    .all(|mode| *mode == GraphDisplayMode::OneMinute));
+            }
+        }
+    }
+
+    #[test]
+    fn a_larger_later_peak_does_not_erase_the_period_start() {
+        let mut activity = AutoGraphActivity::default();
+        for t in 0..800 {
+            activity.observe(t, if t >= 600 { 20_000_000 } else { BASELINE });
+        }
+        let started = activity.burst.unwrap().started_unix;
+        for t in 800..1_000 {
+            activity.observe(t, 100_000_000);
+            assert_eq!(activity.burst.unwrap().started_unix, started);
+        }
+        assert_eq!(activity.mode(), GraphDisplayMode::TenMinutes);
+    }
+
+    #[test]
+    fn clock_changes_and_sampling_gaps_do_not_reuse_stale_activity() {
+        let mut activity = AutoGraphActivity::default();
+        for t in 1_000..1_900 {
+            activity.observe(t, if t >= 1_600 { 100_000_000 } else { BASELINE });
+        }
+        assert_eq!(activity.mode(), GraphDisplayMode::TenMinutes);
+        let previous = activity;
+        activity.observe(1_899, 0);
+        assert_eq!(activity, previous);
+        activity.observe(2_100, BASELINE);
+        assert_eq!(activity.mode(), GraphDisplayMode::OneMinute);
+        activity = previous;
+        activity.observe(500, BASELINE);
+        assert_eq!(activity.mode(), GraphDisplayMode::OneMinute);
+    }
+
+    #[test]
+    fn a_sampling_gap_does_not_multiply_one_outlier_into_a_burst() {
+        let mut activity = AutoGraphActivity::default();
+        for t in 0..600 {
+            activity.observe(t, BASELINE);
+        }
+        activity.observe(605, u64::MAX);
+        for t in 606..900 {
+            activity.observe(t, BASELINE);
+            assert!(activity.burst.is_none());
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(96))]
+
+        #[test]
+        fn burst_grouping_is_stable_across_rates_gaps_and_small_noise(
+            baseline in 100_000_u64..100_000_000,
+            height in 2_u64..30,
+            gap in 10_u64..121,
+            shift in 0_u64..20,
+            seed in any::<u32>(),
+        ) {
+            let mut activity = AutoGraphActivity::default();
+            let start = 600 + shift;
+            let end = start + 4 * (60 + gap);
+            let mut random = seed;
+            let mut detected = [false; 4];
+            let mut first_start = None;
+            let mut previous_mode = GraphDisplayMode::OneMinute;
+            for t in 0..end + 800 {
+                random = random.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                let noise = 90 + u64::from(random % 21);
+                let age = t.saturating_sub(start);
+                let spike = t >= start && age / (60 + gap) < 4 && age % (60 + gap) < 60;
+                let multiplier = if spike {
+                    // Smaller spikes must remain visible after the first peak.
+                    if age / (60 + gap) == 0 { height } else { 2 }
+                } else { 1 };
+                activity.observe(t, baseline * multiplier * noise / 100);
+                prop_assert!(activity.mode().as_seconds() <= 600);
+                if spike && age % (60 + gap) >= 15 {
+                    prop_assert!(activity.burst.is_some());
+                    let burst = activity.burst.unwrap();
+                    prop_assert!(t.saturating_sub(burst.last_active_unix) <= 2);
+                    detected[(age / (60 + gap)) as usize] = true;
+                    if let Some(first) = first_start {
+                        prop_assert_eq!(burst.started_unix, first);
+                    } else {
+                        first_start = Some(burst.started_unix);
+                    }
+                }
+                if t >= start + 15 && t < end - gap {
+                    prop_assert!(activity.mode().as_seconds() >= previous_mode.as_seconds());
+                }
+                if t >= end + 130 {
+                    prop_assert_eq!(activity.mode(), GraphDisplayMode::OneMinute);
+                }
+                previous_mode = activity.mode();
+            }
+            prop_assert!(detected.iter().all(|d| *d));
+        }
+    }
+}

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 pub mod activity_history_telemetry;
+pub(crate) mod auto_graph;
 pub mod manager_telemetry;
 pub mod network_history_telemetry;
 pub(crate) mod restore_densify;

--- a/src/telemetry/network_history_telemetry.rs
+++ b/src/telemetry/network_history_telemetry.rs
@@ -15,19 +15,6 @@ pub struct NetworkHistoryTelemetry;
 
 const AUTO_GRAPH_EVALUATION_INTERVAL_SECS: u64 = 5;
 const AUTO_GRAPH_MINIMUM_DWELL_SECS: u64 = 20;
-const AUTO_GRAPH_FIXED_MODES: [GraphDisplayMode; 11] = [
-    GraphDisplayMode::OneMinute,
-    GraphDisplayMode::FiveMinutes,
-    GraphDisplayMode::TenMinutes,
-    GraphDisplayMode::ThirtyMinutes,
-    GraphDisplayMode::OneHour,
-    GraphDisplayMode::ThreeHours,
-    GraphDisplayMode::TwelveHours,
-    GraphDisplayMode::TwentyFourHours,
-    GraphDisplayMode::SevenDays,
-    GraphDisplayMode::ThirtyDays,
-    GraphDisplayMode::OneYear,
-];
 
 impl NetworkHistoryTelemetry {
     pub fn on_second_tick(app_state: &mut AppState) {
@@ -51,6 +38,9 @@ impl NetworkHistoryTelemetry {
         ) {
             app_state.network_history_dirty = true;
         }
+        app_state
+            .auto_graph_activity
+            .observe(now_unix, download_bps.saturating_add(upload_bps));
         update_auto_graph_window(app_state, now_unix);
     }
 
@@ -117,174 +107,30 @@ impl NetworkHistoryTelemetry {
     }
 }
 
-fn graph_mode_points(
-    state: &NetworkHistoryPersistedState,
-    mode: GraphDisplayMode,
-) -> (&[NetworkHistoryPoint], u64) {
-    match mode {
-        GraphDisplayMode::Auto
-        | GraphDisplayMode::OneMinute
-        | GraphDisplayMode::FiveMinutes
-        | GraphDisplayMode::TenMinutes
-        | GraphDisplayMode::ThirtyMinutes
-        | GraphDisplayMode::OneHour => (&state.tiers.second_1s, 1),
-        GraphDisplayMode::ThreeHours
-        | GraphDisplayMode::TwelveHours
-        | GraphDisplayMode::TwentyFourHours => (&state.tiers.minute_1m, 60),
-        GraphDisplayMode::SevenDays | GraphDisplayMode::ThirtyDays => {
-            (&state.tiers.minute_15m, 15 * 60)
-        }
-        GraphDisplayMode::OneYear => (&state.tiers.hour_1h, 60 * 60),
-    }
-}
-
-fn graph_mode_rank(mode: GraphDisplayMode) -> usize {
-    AUTO_GRAPH_FIXED_MODES
-        .iter()
-        .position(|candidate| *candidate == mode)
-        .unwrap_or(0)
-}
-
-fn auto_graph_required_history_secs(mode: GraphDisplayMode) -> u64 {
-    match mode {
-        GraphDisplayMode::Auto | GraphDisplayMode::OneMinute => 0,
-        GraphDisplayMode::FiveMinutes => GraphDisplayMode::OneMinute.as_seconds() as u64,
-        GraphDisplayMode::TenMinutes => GraphDisplayMode::FiveMinutes.as_seconds() as u64,
-        GraphDisplayMode::ThirtyMinutes => GraphDisplayMode::TenMinutes.as_seconds() as u64,
-        GraphDisplayMode::OneHour => GraphDisplayMode::ThirtyMinutes.as_seconds() as u64,
-        GraphDisplayMode::ThreeHours => GraphDisplayMode::OneHour.as_seconds() as u64,
-        GraphDisplayMode::TwelveHours => GraphDisplayMode::ThreeHours.as_seconds() as u64,
-        GraphDisplayMode::TwentyFourHours => GraphDisplayMode::TwelveHours.as_seconds() as u64,
-        GraphDisplayMode::SevenDays => GraphDisplayMode::TwentyFourHours.as_seconds() as u64,
-        GraphDisplayMode::ThirtyDays => GraphDisplayMode::SevenDays.as_seconds() as u64,
-        GraphDisplayMode::OneYear => GraphDisplayMode::ThirtyDays.as_seconds() as u64,
-    }
-}
-
-fn step_graph_mode_toward(current: GraphDisplayMode, target: GraphDisplayMode) -> GraphDisplayMode {
-    let current_rank = graph_mode_rank(current);
-    let target_rank = graph_mode_rank(target);
-    if target_rank > current_rank {
-        AUTO_GRAPH_FIXED_MODES[current_rank + 1]
-    } else if target_rank < current_rank {
-        AUTO_GRAPH_FIXED_MODES[current_rank - 1]
-    } else {
-        current
-    }
-}
-
-fn auto_graph_candidate_score(
-    state: &NetworkHistoryPersistedState,
-    mode: GraphDisplayMode,
-    now_unix: u64,
-) -> Option<f64> {
-    let window_secs = mode.as_seconds() as u64;
-    let window_start = now_unix.saturating_sub(window_secs);
-    let (tier, step_secs) = graph_mode_points(state, mode);
-    let oldest_ts = tier.first()?.ts_unix;
-    let available_span = now_unix.saturating_sub(oldest_ts).saturating_add(step_secs);
-    if available_span < auto_graph_required_history_secs(mode) {
-        return None;
-    }
-
-    let points = tier
-        .iter()
-        .filter(|point| point.ts_unix >= window_start && point.ts_unix <= now_unix)
-        .collect::<Vec<_>>();
-    if points.is_empty() {
-        return (mode == GraphDisplayMode::OneMinute).then_some(0.0);
-    }
-
-    let peak = points
-        .iter()
-        .map(|point| point.download_bps.saturating_add(point.upload_bps))
-        .max()
-        .unwrap_or_default();
-    if peak == 0 {
-        return (mode == GraphDisplayMode::OneMinute).then_some(0.0);
-    }
-    let activity_threshold = (peak / 50).max(1_024);
-    let active = points
-        .iter()
-        .filter_map(|point| {
-            let rate = point.download_bps.saturating_add(point.upload_bps);
-            (rate >= activity_threshold).then_some((point.ts_unix, rate))
-        })
-        .collect::<Vec<_>>();
-    let (first_active, last_active) = (active.first()?, active.last()?);
-    let first_position = first_active.0.saturating_sub(window_start) as f64 / window_secs as f64;
-    let last_position = last_active.0.saturating_sub(window_start) as f64 / window_secs as f64;
-    let activity_span = (last_position - first_position).clamp(0.0, 1.0);
-    let story_fit = (1.0 - (activity_span - 0.65).abs() / 0.65).clamp(0.0, 1.0);
-    let lead_in_fit = (1.0 - (first_position - 0.15).abs() / 0.35).clamp(0.0, 1.0);
-    let minimum = active.iter().map(|(_, rate)| *rate).min().unwrap_or(peak);
-    let dynamic_range = peak.saturating_sub(minimum) as f64 / peak as f64;
-    let transition_count = points
-        .windows(2)
-        .filter(|pair| {
-            let left =
-                pair[0].download_bps.saturating_add(pair[0].upload_bps) >= activity_threshold;
-            let right =
-                pair[1].download_bps.saturating_add(pair[1].upload_bps) >= activity_threshold;
-            left != right
-        })
-        .count();
-    let transition_score = (transition_count as f64 / 4.0).min(1.0);
-    let recent_score = if now_unix.saturating_sub(last_active.0) <= step_secs * 2 {
-        1.0
-    } else {
-        0.0
-    };
-    let clips_start = first_active.0 <= window_start.saturating_add(window_secs / 20);
-
-    Some(
-        0.35 * story_fit
-            + 0.25 * lead_in_fit
-            + 0.20 * dynamic_range
-            + 0.10 * transition_score
-            + 0.10 * recent_score
-            - if clips_start { 0.25 } else { 0.0 },
-    )
-}
-
-fn recommended_auto_graph_mode(app_state: &AppState, now_unix: u64) -> GraphDisplayMode {
-    AUTO_GRAPH_FIXED_MODES
-        .iter()
-        .copied()
-        .filter_map(|mode| {
-            auto_graph_candidate_score(&app_state.network_history_state, mode, now_unix)
-                .map(|score| (mode, score))
-        })
-        .max_by(|left, right| {
-            left.1
-                .total_cmp(&right.1)
-                .then_with(|| graph_mode_rank(left.0).cmp(&graph_mode_rank(right.0)))
-        })
-        .map(|(mode, _)| mode)
-        .unwrap_or(GraphDisplayMode::OneMinute)
-}
-
 fn update_auto_graph_window(app_state: &mut AppState, now_unix: u64) {
     if app_state.graph_mode != GraphDisplayMode::Auto
         || (app_state.auto_graph_window.last_evaluation_unix != 0
+            && now_unix >= app_state.auto_graph_window.last_evaluation_unix
             && now_unix.saturating_sub(app_state.auto_graph_window.last_evaluation_unix)
                 < AUTO_GRAPH_EVALUATION_INTERVAL_SECS)
     {
         return;
     }
     app_state.auto_graph_window.last_evaluation_unix = now_unix;
-    let target = recommended_auto_graph_mode(app_state, now_unix);
+    let target = app_state.auto_graph_activity.mode();
     let current = app_state.auto_graph_window.effective_mode;
     if target == current {
         return;
     }
 
-    let zooming_in = graph_mode_rank(target) < graph_mode_rank(current);
+    let zooming_in = target.as_seconds() < current.as_seconds();
     let dwell_complete = app_state.auto_graph_window.last_change_unix == 0
+        || now_unix < app_state.auto_graph_window.last_change_unix
         || now_unix.saturating_sub(app_state.auto_graph_window.last_change_unix)
             >= AUTO_GRAPH_MINIMUM_DWELL_SECS;
     if zooming_in || dwell_complete {
-        app_state.auto_graph_window.effective_mode = step_graph_mode_toward(current, target);
+        app_state.auto_graph_window.effective_mode =
+            if zooming_in { target } else { current.next() };
         app_state.auto_graph_window.last_change_unix = now_unix;
         app_state.ui.needs_redraw = true;
     }
@@ -378,7 +224,7 @@ fn densify_state_for_restore(
 mod tests {
     use super::{
         densify_state_for_restore, densify_tier_points, merge_state_for_late_restore,
-        recommended_auto_graph_mode, update_auto_graph_window, NetworkHistoryTelemetry,
+        NetworkHistoryTelemetry,
     };
     use crate::app::{AppState, GraphDisplayMode};
     use crate::persistence::network_history::{
@@ -410,78 +256,149 @@ mod tests {
         }
     }
 
-    #[test]
-    fn auto_graph_starts_at_one_minute_without_enough_history() {
-        let mut app_state = AppState {
-            graph_mode: GraphDisplayMode::Auto,
-            ..Default::default()
-        };
-        app_state.network_history_state.tiers.second_1s = (1..=30)
-            .map(|second| point(second, 10_000, 1_000))
-            .collect();
-
-        assert_eq!(
-            recommended_auto_graph_mode(&app_state, 30),
-            GraphDisplayMode::OneMinute
-        );
+    fn live_tick(state: &mut AppState, now: u64, download: u64, upload: u64) {
+        state.avg_download_history.clear();
+        state.avg_download_history.push(download);
+        state.avg_upload_history.clear();
+        state.avg_upload_history.push(upload);
+        NetworkHistoryTelemetry::on_second_tick_at(state, now);
     }
 
     #[test]
-    fn auto_graph_widens_to_frame_a_sustained_transfer() {
-        let mut app_state = AppState {
-            graph_mode: GraphDisplayMode::Auto,
+    fn auto_graph_frames_sustained_rises_with_delayed_ticks() {
+        for step in [1, 2, 3] {
+            let mut state = AppState::default();
+            for t in (1..=1_200).step_by(step) {
+                let rate = if (601..901).contains(&t) {
+                    100_000_000
+                } else {
+                    5_000_000
+                };
+                live_tick(&mut state, t, rate, 0);
+                if (880..1_010).contains(&t) {
+                    assert_eq!(
+                        state.auto_graph_window.effective_mode,
+                        GraphDisplayMode::TenMinutes,
+                        "{step}s ticks at {t}"
+                    );
+                }
+                if t >= 1_040 {
+                    assert_eq!(
+                        state.auto_graph_window.effective_mode,
+                        GraphDisplayMode::OneMinute,
+                        "{step}s ticks at {t}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn auto_graph_frames_live_download_and_upload_spikes_and_then_resets() {
+        for upload in [false, true] {
+            let mut state = AppState::default();
+            for t in 1..=1_800 {
+                let rate = if (601..=720).contains(&t) {
+                    100_000_000
+                } else {
+                    5_000_000
+                };
+                let (dl, ul) = if upload { (0, rate) } else { (rate, 0) };
+                live_tick(&mut state, t, dl, ul);
+                assert!(state.auto_graph_window.effective_mode.as_seconds() <= 600);
+                if t == 720 || t == 800 {
+                    assert_eq!(
+                        state.auto_graph_window.effective_mode,
+                        GraphDisplayMode::FiveMinutes
+                    );
+                }
+                if t >= 850 {
+                    assert_eq!(
+                        state.auto_graph_window.effective_mode,
+                        GraphDisplayMode::OneMinute
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn late_restore_and_unrelated_history_do_not_change_live_auto_decisions() {
+        let mut clean = AppState::default();
+        let mut restored = AppState::default();
+        let epoch = 60 * 86_400;
+        for elapsed in 1..=1_800 {
+            let now = epoch + elapsed;
+            let rate = if (601..=900).contains(&elapsed) {
+                100_000_000
+            } else {
+                5_000_000
+            };
+            if elapsed == 750 {
+                let before = restored.auto_graph_activity;
+                let mut loaded = NetworkHistoryPersistedState::default();
+                loaded.tiers.second_1s = vec![point(epoch - 3_600, 100_000_000, 0)];
+                loaded.tiers.minute_1m = vec![point(epoch - 86_400, 100_000_000, 0)];
+                loaded.tiers.minute_15m = vec![point(epoch - 14 * 86_400, 100_000_000, 0)];
+                NetworkHistoryTelemetry::apply_loaded_state_at(&mut restored, loaded, now);
+                assert_eq!(restored.auto_graph_activity, before);
+            }
+            live_tick(&mut clean, now, rate, 0);
+            live_tick(&mut restored, now, rate, 0);
+            assert_eq!(clean.auto_graph_activity, restored.auto_graph_activity);
+            assert_eq!(clean.auto_graph_window, restored.auto_graph_window);
+        }
+    }
+
+    #[test]
+    fn manual_ranges_keep_tracking_activity_for_return_to_auto() {
+        let mut state = AppState {
+            graph_mode: GraphDisplayMode::SevenDays,
             ..Default::default()
         };
-        app_state.network_history_state.tiers.second_1s = (941..=1_000)
-            .map(|second| point(second, 10_000, 0))
-            .collect();
-
+        let previous_window = state.auto_graph_window;
+        for t in 1..=720 {
+            live_tick(
+                &mut state,
+                t,
+                if t > 600 { 100_000_000 } else { 5_000_000 },
+                0,
+            );
+            assert_eq!(state.graph_mode, GraphDisplayMode::SevenDays);
+            assert_eq!(state.auto_graph_window, previous_window);
+        }
         assert_eq!(
-            recommended_auto_graph_mode(&app_state, 1_000),
+            state.auto_graph_activity.mode(),
+            GraphDisplayMode::FiveMinutes
+        );
+        state.graph_mode = GraphDisplayMode::Auto;
+        state.auto_graph_window = Default::default();
+        live_tick(&mut state, 721, 100_000_000, 0);
+        assert_eq!(
+            state.auto_graph_window.effective_mode,
             GraphDisplayMode::FiveMinutes
         );
     }
 
     #[test]
-    fn auto_graph_zooms_in_for_a_new_activity_burst() {
-        let mut app_state = AppState {
-            graph_mode: GraphDisplayMode::Auto,
-            ..Default::default()
-        };
-        app_state.network_history_state.tiers.second_1s = (1..=600)
-            .map(|second| point(second, u64::from(second >= 581) * 25_000, 0))
-            .collect();
-
+    fn clock_rollback_does_not_block_auto_evaluation() {
+        let mut state = AppState::default();
+        for t in 1_000..=1_900 {
+            live_tick(
+                &mut state,
+                t,
+                if t > 1_600 { 100_000_000 } else { 5_000_000 },
+                0,
+            );
+        }
         assert_eq!(
-            recommended_auto_graph_mode(&app_state, 600),
-            GraphDisplayMode::OneMinute
-        );
-    }
-
-    #[test]
-    fn auto_graph_widens_one_step_per_dwell_period() {
-        let mut app_state = AppState {
-            graph_mode: GraphDisplayMode::Auto,
-            ..Default::default()
-        };
-        app_state.network_history_state.tiers.second_1s = (1..=600)
-            .map(|second| point(second, u64::from(second >= 121) * 10_000, 0))
-            .collect();
-
-        update_auto_graph_window(&mut app_state, 600);
-        assert_eq!(
-            app_state.auto_graph_window.effective_mode,
-            GraphDisplayMode::FiveMinutes
-        );
-        update_auto_graph_window(&mut app_state, 605);
-        assert_eq!(
-            app_state.auto_graph_window.effective_mode,
-            GraphDisplayMode::FiveMinutes
-        );
-        update_auto_graph_window(&mut app_state, 620);
-        assert_eq!(
-            app_state.auto_graph_window.effective_mode,
+            state.auto_graph_window.effective_mode,
             GraphDisplayMode::TenMinutes
+        );
+        live_tick(&mut state, 500, 5_000_000, 0);
+        assert_eq!(
+            state.auto_graph_window.effective_mode,
+            GraphDisplayMode::OneMinute
         );
     }
 

--- a/src/tui/screens/normal.rs
+++ b/src/tui/screens/normal.rs
@@ -3141,6 +3141,35 @@ pub fn draw_network_chart(
                 Some(ratatui::widgets::GraphType::Scatter),
             ));
         }
+        ChartPanelView::Peers => {
+            let points = activity_points_for_tier(&app_state.activity_history_state.peers, tier);
+            let (counts, _) =
+                build_time_aligned_pair_window(points, step_secs, points_to_show, now_unix);
+            let scale = crate::persistence::activity_history::PEER_COUNT_SCALE;
+            let peak = counts.iter().copied().max().unwrap_or(0).div_ceil(scale);
+            // Use integer tick labels even for zero or one connected peer.
+            let upper = calculate_nice_upper_bound(peak.max(2)).div_ceil(2) * 2;
+            y_axis_upper = upper as f64;
+            y_axis_labels = vec![
+                Span::raw("0"),
+                Span::raw((upper / 2).to_string()),
+                Span::raw(upper.to_string()),
+            ];
+            // Keep exact second-level counts; longer tiers already contain means.
+            dataset_data.push(
+                counts
+                    .iter()
+                    .enumerate()
+                    .map(|(i, count)| (i as f64, *count as f64 / scale as f64))
+                    .collect(),
+            );
+            dataset_specs.push((
+                "Connected peers".to_string(),
+                ctx.accent_sky(),
+                true,
+                Some(ratatui::widgets::GraphType::Line),
+            ));
+        }
         ChartPanelView::Cpu => {
             let points = activity_points_for_tier(&app_state.activity_history_state.cpu, tier);
             let (cpu_x10, _) =
@@ -3530,6 +3559,7 @@ pub fn draw_network_chart(
 
     let all_views = [
         ChartPanelView::Network,
+        ChartPanelView::Peers,
         ChartPanelView::Cpu,
         ChartPanelView::Ram,
         ChartPanelView::Disk,
@@ -9611,6 +9641,67 @@ mod tests {
     }
 
     #[test]
+    fn peer_chart_is_selected_immediately_after_network() {
+        let mut state = AppState::default();
+        reduce_ui_action(&mut state, UiAction::ChartViewNext);
+        assert_eq!(state.chart_panel_view, ChartPanelView::Peers);
+        assert_eq!(ChartPanelView::Peers.to_string(), "PEERS");
+        assert_eq!(ChartPanelView::Peers.next(), ChartPanelView::Cpu);
+        assert_eq!(ChartPanelView::Cpu.prev(), ChartPanelView::Peers);
+        reduce_ui_action(&mut state, UiAction::ChartViewPrev);
+        assert_eq!(state.chart_panel_view, ChartPanelView::Network);
+    }
+
+    #[test]
+    fn peer_chart_renders_counts_in_wide_and_compact_panels() {
+        let mut state = AppState {
+            chart_panel_view: ChartPanelView::Peers,
+            ..Default::default()
+        };
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        for (ts_unix, primary) in [(now - 10, 2_000), (now - 1, 3_000)] {
+            state
+                .activity_history_state
+                .peers
+                .tiers
+                .second_1s
+                .push(ActivityHistoryPoint {
+                    ts_unix,
+                    primary,
+                    secondary: 0,
+                });
+        }
+        for (width, height) in [(120, 18), (44, 8)] {
+            let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+            let ctx = ThemeContext::new(Theme::builtin(ThemeName::Andromeda), 0.0);
+            terminal
+                .draw(|frame| draw_network_chart(frame, &state, frame.area(), &ctx))
+                .unwrap();
+            let buffer = terminal.backend().buffer();
+            let text = (0..height)
+                .map(|y| {
+                    (0..width)
+                        .map(|x| buffer.cell((x, y)).unwrap().symbol())
+                        .collect::<String>()
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(text.contains("PEERS"), "{text}");
+            assert!(!text.contains("B/s"), "{text}");
+            assert!(
+                text.chars().any(|c| ('\u{2801}'..='\u{28ff}').contains(&c)),
+                "{text}"
+            );
+            if width == 120 {
+                assert!(text.contains("Connected peers"), "{text}");
+            }
+        }
+    }
+
+    #[test]
     fn disk_series_draw_order_favors_more_recent_read_activity() {
         assert!(disk_series_draw_read_last(&[0, 12, 8, 0], &[0, 0, 0, 0]));
         assert!(!disk_series_draw_read_last(&[0, 0, 0, 0], &[0, 4, 3, 0]));
@@ -9776,6 +9867,7 @@ mod tests {
     fn every_activity_chart_legend_uses_top_left_position() {
         for view in [
             ChartPanelView::Network,
+            ChartPanelView::Peers,
             ChartPanelView::Cpu,
             ChartPanelView::Ram,
             ChartPanelView::Disk,


### PR DESCRIPTION
AUTO now follows live throughput bursts with median filtering and an adaptive EWMA detector, grouping nearby spikes and selecting a 1–10 minute window. This replaces history-shape scoring so old or restored peaks cannot drive range changes; longer manual ranges remain available.

Adds a PEERS activity chart with connected-peer counts and fractional rollup averages. Activity history schema v2 stores the new series while preserving reads of v1 history. Includes detector policy documentation and a reproducible EWMA/CUSUM comparison.

Validation: 80 telemetry tests, 17 activity-history tests, and 189 chart-screen tests passed (overlapping selections). Formatting and diff checks passed, and the comparison script reproduced the documented metrics. Full-suite and browser/WASM execution were not run.
